### PR TITLE
Fix mypy and tests in data/scrapers

### DIFF
--- a/data/scrapers/pyproject.toml
+++ b/data/scrapers/pyproject.toml
@@ -208,8 +208,11 @@ max-statements = 50
 max-branches = 15
 
 [tool.ruff.lint.per-file-ignores]
+"src/scripts/fix_jsonl.py" = ["PLR0402"]
+"src/scripts/text_gemini_on_ner.py" = ["PLR0402"]
 "src/scrapers/article/hardcoded/listawstydupo.py" = ["E501"]
 "src/scrapers/article/hardcoded/kazdymusigdziespracowac.py" = ["E501"]
+"src/stores/storage.py" = ["PLR0402"]
 
 [tool.pytest.ini_options]
 markers = ["parametrize_skip_if"]

--- a/data/scrapers/src/scrapers/article/crawler.py
+++ b/data/scrapers/src/scrapers/article/crawler.py
@@ -78,7 +78,6 @@ def crawl_website(ctx: Context, uid, current_url):
 
     try:
         print(f"Crawling: {current_url}")
-        print("haha test")
         started = datetime.now(warsaw_tz)
         response = requests.get(current_url, headers=HEADERS, timeout=10)
 

--- a/data/scrapers/src/scrapers/article/crawler.py
+++ b/data/scrapers/src/scrapers/article/crawler.py
@@ -78,6 +78,7 @@ def crawl_website(ctx: Context, uid, current_url):
 
     try:
         print(f"Crawling: {current_url}")
+        print("haha test")
         started = datetime.now(warsaw_tz)
         response = requests.get(current_url, headers=HEADERS, timeout=10)
 

--- a/data/scrapers/src/scrapers/koryta/differ.py
+++ b/data/scrapers/src/scrapers/koryta/differ.py
@@ -86,11 +86,11 @@ class KorytaDiffer(Pipeline):
             df_sorted = df.sort_values("date")
             df_valid = df_sorted[df_sorted["name"].notna()]
             # Update map
-            self.id_map.update(
-                pd.Series(
-                    df_valid["name"].values, index=df_valid["id"].astype(str)
-                ).to_dict(into=dict[str, str])
-            )
+            latest_names = {
+                str(row["id"]): str(row["name"])
+                for _, row in df_valid.iterrows()
+            }
+            self.id_map.update(latest_names)
 
         if not dates:
             print("  No export dates found.")

--- a/data/scrapers/src/scripts/fix_jsonl.py
+++ b/data/scrapers/src/scripts/fix_jsonl.py
@@ -1,6 +1,6 @@
 import json
 
-from google.cloud import storage
+import google.cloud.storage as storage
 
 
 def fix_name(name: str) -> str:

--- a/data/scrapers/src/scripts/text_gemini_on_ner.py
+++ b/data/scrapers/src/scripts/text_gemini_on_ner.py
@@ -6,8 +6,8 @@ It defines metrics like recall for data person_wikipedia_ner.jsonl.
 import os
 
 import IPython
+import google.genai as genai
 import pandas as pd
-from google import genai
 from joblib import Memory
 from tqdm import tqdm
 

--- a/data/scrapers/src/scripts/text_gemini_on_ner.py
+++ b/data/scrapers/src/scripts/text_gemini_on_ner.py
@@ -5,8 +5,8 @@ It defines metrics like recall for data person_wikipedia_ner.jsonl.
 
 import os
 
-import IPython
 import google.genai as genai
+import IPython
 import pandas as pd
 from joblib import Memory
 from tqdm import tqdm

--- a/data/scrapers/src/stores/storage.py
+++ b/data/scrapers/src/stores/storage.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Generator
 from zoneinfo import ZoneInfo
 
-from google.cloud import storage
+import google.cloud.storage as storage
 from tqdm import tqdm
 
 from entities.util import NormalizedParse


### PR DESCRIPTION
Obecnie failuje mypy w data/scrapers. Nie wiem kiedy to się stało, ale mypy gryzie się z ruff o importy. Ruff --fix ustawia import po swojemu, a później przeszkadza to mypy. Zostawiłem w stylu mypy i dodałem ignore dla ruff. 

Also jedna zmiana w data/scrapers/src/scrapers/koryta/differ.py, bo mypy coś krzyczał o typy. Na moje oko nie nie psuje, ale @SzymonPajzert plz spójrz jako double check.