### PR TITLE
Fix pandas 3.0 groupby compatibility

### DIFF
--- a/data/scrapers/src/analysis/extract.py
+++ b/data/scrapers/src/analysis/extract.py
@@ -3,7 +3,6 @@ from datetime import date
 from functools import cached_property
 
 import pandas as pd
-from memoized_property import memoized_property  # type:ignore
 
 from analysis.people import PeopleEnriched
 from analysis.utils import drop_duplicates, empty_list_if_nan

--- a/data/scrapers/src/analysis/graph.py
+++ b/data/scrapers/src/analysis/graph.py
@@ -24,14 +24,16 @@ def flatten_parties(df):
     print("Flattening parties...")
 
     def extract_parties(group):
+        name = group.name
         row = group.iloc[0]
-        name = row["person_id"]
         parties = list(set(e["party"].lower() for e in row["elections"] if e["party"]))
         return pd.DataFrame(
             {"person_id": [name] * len(parties), "subgroup_id": parties}
         )
 
-    flattened = df.groupby("person_id", group_keys=False).apply(extract_parties)
+    flattened = df.groupby("person_id", group_keys=False).apply(
+        extract_parties, include_groups=False
+    )
     flattened.reset_index(inplace=True)
 
     print("Done.")

--- a/data/scrapers/src/analysis/tests/test_extract_krs.py
+++ b/data/scrapers/src/analysis/tests/test_extract_krs.py
@@ -205,10 +205,11 @@ def test_extract_by_krs():
 
     # 3. Inject args
     class MockArgs:
-        krs = "0000000001"
+        krss = ["0000000001"]
         region = "14"
         approved = False
         recent = False
+        ignore_elections = False
 
     extract.args = MockArgs()
 

--- a/data/scrapers/src/scrapers/pkw/test/test_pkw_process.py
+++ b/data/scrapers/src/scrapers/pkw/test/test_pkw_process.py
@@ -103,8 +103,8 @@ def test_check_no_nulls(column, df):
         ("2023", "senat", "birth_year"),
         ("2024", "europarlament", "birth_year"),
     }
-    grouped = df.groupby(["election_year", "election_type"]).apply(
-        lambda x: x[column].notnull().all()
+    grouped = df.groupby(["election_year", "election_type"])[column].apply(
+        lambda x: x.notnull().all()
     )
     for (year, election), passing in grouped.items():
         if passing:

--- a/data/scrapers/src/tests/pipelines/test_person_pkw.py
+++ b/data/scrapers/src/tests/pipelines/test_person_pkw.py
@@ -62,8 +62,8 @@ def test_check_no_nulls(column, df):
         ("2023", "senat", "birth_year"),
         ("2024", "europarlament", "birth_year"),
     }
-    grouped = df.groupby(["election_year", "election_type"]).apply(
-        lambda x: x[column].notnull().all()
+    grouped = df.groupby(["election_year", "election_type"])[column].apply(
+        lambda x: x.notnull().all()
     )
     for (year, election), passing in grouped.items():
         if passing:


### PR DESCRIPTION
## Summary

- Replace `DataFrameGroupBy.apply(lambda x: x[col]...)` with `SeriesGroupBy[col].apply(lambda x: x...)` in `test_pkw_process.py` and `test_person_pkw.py` — avoids the pandas 3.0 breaking change where groupby keys are excluded from the group DataFrame
- Fix `graph.py::extract_parties` to use `group.name` for the group key and pass `include_groups=False` to `apply`
- Update `MockArgs` in `test_extract_krs.py` to use `krss` (list) + `ignore_elections = False`, matching args added in bafce2c7
- Remove unused `memoized_property` import from `extract.py`

These failures were not caused by PR #449 — they come from a `main` commit (`bafce2c7`) that changed the `--krs` arg to `krss` without updating the test mock, plus a pandas version mismatch between local (2.x) and CI (3.0.2).

## Test plan

- [x] `test_extract_krs.py::test_extract_by_krs` passes
- [x] `test_graph.py::test_flatten_parties` passes (no FutureWarning)
- [x] `test_pkw_process.py::test_check_no_nulls` passes (no FutureWarning)
- [x] `test_person_pkw.py::test_check_no_nulls` passes (no FutureWarning)
- [x] `mypy` clean
- [x] `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)