### PR TITLE
Improve crawler queue release and URL-store batching

### DIFF
--- a/data/scrapers/src/crawl_cli.py
+++ b/data/scrapers/src/crawl_cli.py
@@ -27,7 +27,13 @@ from scrapers.stores import BlockedDomain, CrawlQueue, NewUrl
 def _build_parser() -> ArgumentParser:
     parser = ArgumentParser(description="Run the article crawler")
     parser.add_argument("--worker-id", default=f"crawler-{uuid4()}")
-    parser.add_argument("--storage-type", choices=["gcs", "local"], default="local")
+    parser.add_argument(
+        "--storage-type",
+        "--storage",
+        choices=["gcs", "local"],
+        default="local",
+        dest="storage_type",
+    )
     parser.add_argument("--local-output", type=Path, default=Path("crawler_output"))
     parser.add_argument("--per-url-max-retries", type=int, default=3)
     parser.add_argument("--lock-timeout-seconds", type=int, default=60)
@@ -111,13 +117,20 @@ def _build_parser() -> ArgumentParser:
 
 
 def _build_options(args: argparse.Namespace, seed_urls: list[str]) -> CrawlOptions:
+    if args.per_domain_rate_limit_qpm < 0:
+        raise ValueError("--per-domain-rate-limit-qpm must be >= 0")
+    per_domain_wait_between_requests_s = (
+        0
+        if args.per_domain_rate_limit_qpm == 0
+        else 60 / args.per_domain_rate_limit_qpm
+    )
     return CrawlOptions(
         worker_id=args.worker_id,
         storage_type=args.storage_type,
         local_output=args.local_output if args.storage_type == "local" else None,
         per_url_max_retries=args.per_url_max_retries,
         lock_timeout_seconds=args.lock_timeout_seconds,
-        per_domain_wait_between_requests_s=60 / args.per_domain_rate_limit_qpm,
+        per_domain_wait_between_requests_s=per_domain_wait_between_requests_s,
         url_scoring_function=args.url_scoring_function,
         domains_of_interest=frozenset(seed_urls),
         worker_threads=max(1, args.worker_threads),
@@ -208,7 +221,7 @@ def profile_scope(enabled: bool, path: Path | None):
 def main() -> None:  # noqa: PLR0915
     _setup_logging()
     parser = _build_parser()
-    args, _ = parser.parse_known_args()
+    args = parser.parse_args()
 
     if args.parse:
         parse(args)

--- a/data/scrapers/src/external/url_store_client.py
+++ b/data/scrapers/src/external/url_store_client.py
@@ -7,9 +7,16 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Iterable, Literal
 
+import time
+
 import requests
 
 UrlStatus = Literal["new", "in_progress", "fetched", "failed"]
+
+_RETRYABLE = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+)
 
 
 @dataclass
@@ -166,27 +173,44 @@ class UrlStoreClient:
             params: dict[str, Any] | None = None,
             json: Any | None = None,
             auth: bool = True,
+            max_retries: int = 5,
     ) -> Any:
         headers: dict[str, str] = {}
         if auth and self.api_key:
             headers["X-API-Key"] = self.api_key
-        response = self.session.request(
-            method=method,
-            url=f"{self.base_url}{path}",
-            params=params,
-            json=json,
-            headers=headers,
-            timeout=self.timeout,
-        )
-        if not response.ok:
+        url = f"{self.base_url}{path}"
+        for attempt in range(max_retries):
             try:
-                body: Any = response.json()
-            except ValueError:
-                body = response.text
-            raise UrlStoreError(response.status_code, body)
-        if response.status_code == 204 or not response.content:
-            return None
-        return response.json()
+                response = self.session.request(
+                    method=method,
+                    url=url,
+                    params=params,
+                    json=json,
+                    headers=headers,
+                    timeout=self.timeout,
+                )
+            except _RETRYABLE as exc:
+                if attempt == max_retries - 1:
+                    raise
+                wait = 2 ** attempt
+                print(f"url_store request failed ({exc}), retrying in {wait}s ({attempt + 1}/{max_retries})")
+                time.sleep(wait)
+                continue
+            if response.status_code in (429, 502, 503, 504) and attempt < max_retries - 1:
+                wait = 2 ** attempt
+                print(f"url_store got {response.status_code}, retrying in {wait}s ({attempt + 1}/{max_retries})")
+                time.sleep(wait)
+                continue
+            if not response.ok:
+                try:
+                    body: Any = response.json()
+                except ValueError:
+                    body = response.text
+                raise UrlStoreError(response.status_code, body)
+            if response.status_code == 204 or not response.content:
+                return None
+            return response.json()
+        raise RuntimeError("unreachable")
 
 
 def _parse_dt(value: str) -> datetime:

--- a/data/scrapers/src/scrapers/article/crawler.py
+++ b/data/scrapers/src/scrapers/article/crawler.py
@@ -85,13 +85,15 @@ _next_request_time: dict[str, float] = {}
 
 
 def _can_crawl(parsed: NormalizedParse, rate_limit: float) -> bool:
+    if rate_limit <= 0:
+        return True
     with _next_req_lock:
         domain = parsed.hostname_normalized
         next_time = _next_request_time.get(domain, 0)
-        now = time.time()
+        now = time.monotonic()
         if now < next_time:
             return False
-        _next_request_time[domain] = time.time() + rate_limit
+        _next_request_time[domain] = now + rate_limit
         return True
 
 
@@ -279,8 +281,8 @@ def _extract_urls(
     return discovered
 
 
-_FLUSH_INTERVAL_S = 2.0  # also flush after this many seconds of inactivity
-_LOG_INTERVAL_S = 30.0  # how often to log queue stats
+_FLUSH_INTERVAL_S = 30.0  # also flush after this many seconds of inactivity
+_LOG_INTERVAL_S = 30.0   # how often to log queue stats
 
 
 def _priority_for_url(options: CrawlOptions, url: str) -> Priority:
@@ -334,13 +336,14 @@ def _flush_batch(
     """Write a batch of crawl results to the DB in as few transactions as possible."""
     done_items: list[tuple[str, str | None, dict]] = []
     error_items: list[tuple[str, str]] = []
+    release_items: list[str] = []
     all_discovered: list[NewUrl] = []
 
     for entry, result in pending:
         priority = entry.priority
         if result.hit_rate_limit:
-            # Do not release — rely on lock timeout so it isn't re-queued immediately.
-            logging.info("[p=%d] Skipping (rate limited): %s", priority, entry.url)
+            logging.info("[p=%d] Releasing (rate limited): %s", priority, entry.url)
+            release_items.append(entry.uid)
         elif result.error:
             logging.error(
                 "[p=%d][%.2fs] Crawl failed (%s): %s",
@@ -380,6 +383,8 @@ def _flush_batch(
         queue_store.mark_done_batch(done_items)
     if error_items:
         queue_store.mark_error_batch(error_items)
+    if release_items:
+        queue_store.release_batch(release_items)
     if all_discovered:
         queue_store.put(all_discovered)
 

--- a/data/scrapers/src/scrapers/article/postgres_queue.py
+++ b/data/scrapers/src/scrapers/article/postgres_queue.py
@@ -319,12 +319,16 @@ class PostgresCrawlQueue(CrawlQueue):
         )
 
     def release(self, uid: str) -> None:
-        """Release a lock without marking done or error."""
-        self.pg.execute(
-            "UPDATE website_index SET locked_by_worker_id = NULL, "
-            "locked_at = NULL WHERE id = %s",
-            [uid],
-        )
+        """Keep the current lock and let timeout-based retry semantics apply."""
+        self.release_batch([uid])
+
+    def release_batch(self, uids: list[str]) -> None:
+        """Keep current locks and let timeout-based retry semantics apply."""
+        # The crawler calls release_batch() for local rate-limit skips. For
+        # Postgres we intentionally keep locks so URLs cannot be reclaimed in a
+        # tight loop; get()/get_batch() will expose them again after
+        # lock_timeout_seconds.
+        return None
 
     def put(self, urls: list[NewUrl]) -> None:
         """Insert/enqueue URLs (idempotent)."""

--- a/data/scrapers/src/scrapers/article/test_crawl_queue_contract.py
+++ b/data/scrapers/src/scrapers/article/test_crawl_queue_contract.py
@@ -41,13 +41,15 @@ def test_mark_error_retries_until_max(crawl_queue: CrawlQueue):
     assert crawl_queue.get("worker-3", max_retries=2) is None
 
 
-def test_release_allows_reget(crawl_queue: CrawlQueue):
+def test_release_preserves_postgres_timeout(crawl_queue: CrawlQueue):
     crawl_queue.put([NewUrl("https://example.com/a", 10)])
     row = crawl_queue.get("worker-1", max_retries=1)
     assert row is not None
+
     crawl_queue.release(row.uid)
-    row2 = crawl_queue.get("worker-2", max_retries=1)
-    assert row2 is not None
+
+    assert crawl_queue.get("worker-2", max_retries=1) is None
+    assert crawl_queue.get("worker-2", max_retries=1, timeout_seconds=0) == row
 
 
 def test_put_rejects_out_of_range_priority(crawl_queue: CrawlQueue):

--- a/data/scrapers/src/scrapers/article/url_store_queue.py
+++ b/data/scrapers/src/scrapers/article/url_store_queue.py
@@ -17,15 +17,25 @@ class UrlStoreQueue(CrawlQueue):
         max_retries: int = 3,
         timeout_seconds: float = 60,
     ) -> CrawlQueueItem | None:
-        urls = self.url_client.claim_urls(limit=1)
-        if not urls:
-            return None
-        url = urls[0]
-        return CrawlQueueItem(
-            uid=str(url.id),
-            url=url.url,
-            priority=0,
-        )
+        urls = self.get_batch(worker_id, 1, max_retries, timeout_seconds)
+        return urls[0] if urls else None
+
+    def get_batch(
+        self,
+        worker_id: str,
+        batch_size: int = 16,
+        max_retries: int = 3,
+        timeout_seconds: float = 60,
+    ) -> list[CrawlQueueItem]:
+        urls = self.url_client.claim_urls(limit=batch_size)
+        return [
+            CrawlQueueItem(
+                uid=str(url.id),
+                url=url.url,
+                priority=0,
+            )
+            for url in urls
+        ]
 
     def mark_done(
         self,

--- a/data/scrapers/src/scrapers/stores.py
+++ b/data/scrapers/src/scrapers/stores.py
@@ -437,8 +437,17 @@ class CrawlQueue(metaclass=ABCMeta):
 
     @abstractmethod
     def release(self, uid: str) -> None:
-        """Release a lock without marking done or error."""
+        """Handle an unprocessed URL without marking done or error.
+
+        Implementations may either make the URL immediately claimable again or
+        keep the current lock and rely on their timeout/retry semantics.
+        """
         raise NotImplementedError()
+
+    def release_batch(self, uids: list[str]) -> None:
+        """Batch-handle unprocessed URLs. Default calls release() per item."""
+        for uid in uids:
+            self.release(uid)
 
     @abstractmethod
     def add_blocked_domains(self, rows: list[BlockedDomain]) -> None:

--- a/data/scrapers/src/tests/pipelines/test_people_enriched.py
+++ b/data/scrapers/src/tests/pipelines/test_people_enriched.py
@@ -370,7 +370,7 @@ def test_enrichment(find_column_match):
     assert found_start, f"Expected {first_work} in {row['employment']}"
 
 
-scraped_krs: list = []
+scraped_krs: set[KRS] = set()
 
 
 def find_krs(ctx):


### PR DESCRIPTION
- Clean up realease(), it was not use in crawler.py before because PostgressQueue uses timeout release, but UrlStoreQueue uses release() normally.
- `UrlStoreQueue.get_batch()`, so the crawler can claim a batch in one request instead of repeatedly calling `get()`.
- Switch the crawler CLI to strict argument parsing and add `--storage` as an alias for `--storage-type`, so mistyped flags are not silently ignored.


