### PR TITLE
Reload the page while waiting for a Cloud Function, do not stare at it

### DIFF
--- a/frontend/tests/e2e/company_notes.spec.ts
+++ b/frontend/tests/e2e/company_notes.spec.ts
@@ -11,7 +11,7 @@ const COMPANY_VIEW = `/eksploruj/tabela?krs=${COMPANY_KRS}`;
 
 test.describe("Company notes", () => {
   test("lets a logged in user add a source to a company", async ({ page }) => {
-    test.setTimeout(90000); // Logs in, saves a note and revisits the page
+    test.setTimeout(180_000); // Logs in, saves a note and waits out a Cloud Function
 
     await page.goto(`/login?redirect=${encodeURIComponent(COMPANY_VIEW)}`);
     await waitForLoginFormHydrated(page);
@@ -50,12 +50,19 @@ test.describe("Company notes", () => {
     ).toBeHidden({ timeout: 15000 });
     await expect(companyCard).toContainText(url);
 
-    // The note is attached to the company, so it is there on a fresh visit
-    // The dev server keeps live listeners open, so "load" never settles here
-    await page.goto(COMPANY_VIEW, { waitUntil: "domcontentloaded" });
-    await companyCard
-      .getByRole("button", { name: "Notatki" })
-      .click({ timeout: 30000 });
-    await expect(companyCard).toContainText(url, { timeout: 30000 });
+    // The note is attached to the company, so it is there on a fresh visit -
+    // once onNoteWritten has folded it into the company. That is a Cloud
+    // Function firing on a write with no event to wait for from here, so the
+    // whole revisit is what gets retried rather than the assertion alone: a
+    // page loaded too early shows the notes panel with no sources in it, and
+    // waiting on that one longer will not make the note appear.
+    // "load" never settles here, the app keeps live listeners open.
+    await expect(async () => {
+      await page.goto(COMPANY_VIEW, { waitUntil: "domcontentloaded" });
+      await companyCard
+        .getByRole("button", { name: "Notatki" })
+        .click({ timeout: 30000 });
+      await expect(companyCard).toContainText(url, { timeout: 5000 });
+    }).toPass({ timeout: 90_000 });
   });
 });

--- a/frontend/tests/e2e/revisions_edit.spec.ts
+++ b/frontend/tests/e2e/revisions_edit.spec.ts
@@ -3,7 +3,7 @@ import { waitForLoginFormHydrated } from "./helpers/login";
 
 test.describe("Suggest node edits", () => {
   test("User can suggest an edit and admin can see it", async ({ page }) => {
-    test.setTimeout(60000); // This test goes through a long flow
+    test.setTimeout(240_000); // Registers, proposes an edit, waits out a Cloud Function
     // 1. Go to login page
     await page.goto("/login");
 
@@ -94,7 +94,7 @@ test.describe("Suggest node edits", () => {
       });
       await expect(
         page.locator(`.comparison-table:has-text("${newContent}")`),
-      ).toBeVisible({ timeout: 3000 });
-    }).toPass({ timeout: 60_000 });
+      ).toBeVisible({ timeout: 5000 });
+    }).toPass({ timeout: 120_000 });
   });
 });


### PR DESCRIPTION
Both of these write something and read it back once onNoteWritten or onRevisionWritten has folded it into the entity, and both waited by asserting harder on a page that had already rendered. company_notes was the plain case: it revisited the company, opened the notes panel and then gave the card 30 seconds to grow a source it did not have. The panel was open the whole time - the failure snapshot shows the prompt and no sources - so no amount of extra timeout on that render was going to help; the page has to be loaded again.

Both now retry the revisit itself, and the budgets are sized for a machine slower than this one: the pair went 2 flaky in a full local run before, and CI has fewer cores than that.