### PR TITLE
Stop the migration deleting the stats it does not carry

### DIFF
--- a/frontend/scripts/migrate/seed-public-institutions.ts
+++ b/frontend/scripts/migrate/seed-public-institutions.ts
@@ -75,6 +75,31 @@ export function isPublicInstitution(name: string | undefined): boolean {
   );
 }
 
+/** What this migration changes about the node itself.
+ *
+ * Only these fields, written with `update`. Writing the revision snapshot over
+ * the node with `set` - which is what this did until it had wiped the
+ * institutions it was meant to mark - deletes everything a revision
+ * deliberately leaves out, `stats` among it. A node with no
+ * `stats.nodeGroupSize` disappears from `/api/search`, which orders by it, and
+ * Firestore returns no document that lacks the field it is ordered on: the
+ * WFOŚiGW, Departament and Urząd entries were unfindable for as long as that
+ * took to notice.
+ *
+ * `revisionRef` is passed only when the node was already published, so an
+ * unapproved draft stays one.
+ */
+export function nodeOwnershipUpdate(revisionRef?: {
+  id: string;
+}): Record<string, unknown> {
+  const update: Record<string, unknown> = {
+    isPublic: true,
+    isPublicSource: "manual",
+  };
+  if (revisionRef) update.revision_id = revisionRef;
+  return update;
+}
+
 /** Fields regenerated or managed outside a revision, mirroring
  * `server/utils/revisions.ts` — copying them in would freeze a stale snapshot. */
 const INTERNAL_FIELDS = new Set([
@@ -138,7 +163,8 @@ async function migrate() {
 
     // A revision, not a bare field write: the node's content and its current
     // revision have to keep saying the same thing, and this change should show
-    // up in the node's history like any other.
+    // up in the node's history like any other. The revision is the content
+    // snapshot, so it keeps leaving the internal fields out.
     const revisionRef = db.collection("revisions").doc();
     batch.set(revisionRef, {
       node_id: doc.id,
@@ -147,9 +173,13 @@ async function migrate() {
       update_user: "migration:seed-public-institutions",
       update_automatic: true,
     });
-    // Published only if the node already was; an unapproved draft stays one.
-    if (data.revision_id) revisionData.revision_id = revisionRef;
-    batch.set(doc.ref, revisionData);
+    // The node only gains an answer about its ownership - see
+    // `nodeOwnershipUpdate` for why this is not the snapshot written back.
+    batch.update(
+      doc.ref,
+      // Published only if the node already was; an unapproved draft stays one.
+      nodeOwnershipUpdate(data.revision_id ? revisionRef : undefined),
+    );
     pending += 2;
 
     if (pending >= 400) {

--- a/frontend/tests/scripts/seedPublicInstitutions.test.ts
+++ b/frontend/tests/scripts/seedPublicInstitutions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { isPublicInstitution } from "../../scripts/migrate/seed-public-institutions";
+import {
+  isPublicInstitution,
+  nodeOwnershipUpdate,
+} from "../../scripts/migrate/seed-public-institutions";
 
 describe("isPublicInstitution", () => {
   it("covers the bodies that have no KRS entry to scrape", () => {
@@ -42,5 +45,47 @@ describe("isPublicInstitution", () => {
     expect(
       isPublicInstitution("Fundacja Promocji Kultury Miasta Krakowa"),
     ).toBe(false);
+  });
+});
+
+describe("nodeOwnershipUpdate", () => {
+  it("touches nothing but the ownership answer", () => {
+    // This ran against production writing the revision snapshot over the node,
+    // which deleted every field a revision leaves out. Losing `stats` took 37
+    // institutions out of /api/search - it orders by `stats.nodeGroupSize`, and
+    // Firestore returns no document missing the field it orders on - so
+    // WFOŚiGW, Departament and Urząd entries could not be found at all.
+    expect(Object.keys(nodeOwnershipUpdate()).sort()).toEqual([
+      "isPublic",
+      "isPublicSource",
+    ]);
+    for (const field of [
+      "stats",
+      "revisions",
+      "votes",
+      "nameChunksLower",
+      "name",
+      "krsNumber",
+    ]) {
+      expect(nodeOwnershipUpdate({ id: "rev1" })).not.toHaveProperty(field);
+    }
+  });
+
+  it("records the answer as a human one", () => {
+    // What stops the next company ingest, which cannot see a spółka akcyjna's
+    // shareholders, from writing its own guess over this.
+    expect(nodeOwnershipUpdate()).toMatchObject({
+      isPublic: true,
+      isPublicSource: "manual",
+    });
+  });
+
+  it("republishes a node that was published, and only that one", () => {
+    // A node with no current revision is an unapproved draft, and marking its
+    // owner must not publish it.
+    expect(nodeOwnershipUpdate({ id: "rev1" }).revision_id).toEqual({
+      id: "rev1",
+    });
+    expect(nodeOwnershipUpdate()).not.toHaveProperty("revision_id");
   });
 });


### PR DESCRIPTION
It wrote the revision snapshot back over the node with `set`, and a revision deliberately carries no `stats`, `revisions`, `votes` or `nameChunksLower`. So marking an institution as publicly owned deleted all four from it.

`nameChunksLower` came back on its own - onNodeWritten regenerates chunks it finds missing - which is what made this hard to see: the nodes looked indexed. `stats` did not come back, and /api/search orders by `stats.nodeGroupSize`. Firestore returns no document that lacks the field a query orders on, so the 37 institutions this had already marked in production - every WFOŚiGW, the Departament and Urząd entries, the ośrodki pomocy społecznej - could not be found by name at all, while still being there to open by url.

Only the ownership answer is written now, with `update`.

Note `createRevisionTransaction` writes nodes the same way, so a company or person ingest drops the same fields until the next stats run.