### PR TITLE
Let a pipeline declare the context clients it needs

### DIFF
--- a/data/scrapers/src/analysis/notebooks/runner.py
+++ b/data/scrapers/src/analysis/notebooks/runner.py
@@ -5,7 +5,7 @@ from koryta import Pipeline
 
 
 def run_pipeline(p_type: typing.Type):
-    ctx = setup_context(False)[0]
+    ctx = setup_context()[0]
     p: Pipeline = Pipeline.create(p_type)
     # TODO remove it, None is needed only for old format
     return None, p.read_or_process(ctx)

--- a/data/scrapers/src/analysis/scripts/edge_dates.py
+++ b/data/scrapers/src/analysis/scripts/edge_dates.py
@@ -231,7 +231,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    ctx = setup_context(False)[0]
+    ctx = setup_context()[0]
     snapshot = load_snapshot(ctx, args.export)
     edges = snapshot.collection("edges")
     print(f"Loaded {len(edges)} edges from {snapshot.date}.")

--- a/data/scrapers/src/analysis/scripts/field_presence.py
+++ b/data/scrapers/src/analysis/scripts/field_presence.py
@@ -215,7 +215,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    snapshot = load_snapshot(setup_context(False)[0], args.export)
+    snapshot = load_snapshot(setup_context()[0], args.export)
 
     for collection in args.collections:
         df = load_collection(snapshot, collection)

--- a/data/scrapers/src/analysis/update_rate/shared.py
+++ b/data/scrapers/src/analysis/update_rate/shared.py
@@ -23,7 +23,7 @@ METHODS_OF_INTEREST = [
 
 def make_context():
     """Create a read-only pipeline context."""
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 def load_already_scraped(ctx) -> pd.DataFrame:

--- a/data/scrapers/src/conductor.py
+++ b/data/scrapers/src/conductor.py
@@ -11,13 +11,17 @@ from tqdm import tqdm
 from scrapers.article.crawler import parse_hostname, uuid7
 from scrapers.stores import (
     IO,
+    LLM,
+    NLP,
     CloudStorage,
     Context,
+    ContextResource,
     CrawlQueue,
     DataRef,
     File,
     LocalFile,
     ProcessPolicy,
+    RejestrIO,
 )
 from scrapers.stores.file import (
     DownloadableFile,
@@ -222,25 +226,36 @@ class Conductor(IO):
 
 
 def setup_context(
-    use_rejestr_io: bool = False,
-    use_nlp: bool = False,
-    use_llm: bool = False,
+    requires: typing.Iterable[type[ContextResource]] = (),
     policy: ProcessPolicy | None = None,
     crawl_queue: CrawlQueue | None = None,
     batch_upload: bool = False,
 ) -> tuple[Context, EntityDumper]:
+    """Build the Context, with the clients `requires` names and no others.
+
+    Callers get `requires` from `required_resources` on the pipelines they are
+    about to run, so what a run sets up follows from what the pipelines declare
+    rather than from a list kept in step by hand.
+    """
+    required = set(requires)
+    if CrawlQueue in required and crawl_queue is None:
+        raise ValueError(
+            "A selected pipeline requires the crawl queue, which is backed by "
+            "postgres and only the crawler CLI opens -- pass crawl_queue= to "
+            "setup_context."
+        )
     if policy is None:
         policy = ProcessPolicy.with_default()
     dumper = EntityDumper()
-    llm = _build_llm() if use_llm else None
+    llm = _build_llm() if LLM in required else None
     conductor = Conductor(dumper, llm=llm, batch_upload=batch_upload)
     rejestr_io = None
-    if use_rejestr_io:
+    if RejestrIO in required:
         print("Initializing RejestrIO as a data source")
         rejestr_io = Rejestr()
 
     nlp = None
-    if use_nlp:
+    if NLP in required:
         # We're importing dynamically here
         # to avoid big dependency on spacy
         from stores.nlp import NLPImpl  # noqa: PLC0415
@@ -249,12 +264,13 @@ def setup_context(
 
     ctx = Context(
         io=conductor,
-        rejestr_io=rejestr_io,  # type: ignore
+        # Rejestr matches RejestrIO by shape, not by inheritance.
+        rejestr_io=rejestr_io,  # type: ignore[arg-type]
         con=duckdb.connect(),
         utils=UtilsImpl(),
         web=WebImpl(),
         crawl_queue=crawl_queue,
-        nlp=nlp,  # type: ignore
+        nlp=nlp,
         refresh_policy=policy,
         llm=llm,
     )

--- a/data/scrapers/src/crawl_cli.py
+++ b/data/scrapers/src/crawl_cli.py
@@ -307,7 +307,7 @@ def main() -> None:  # noqa: PLR0915
         if args.profile_path
         else None
     )
-    ctx, _ = setup_context(False, crawl_queue=queue, batch_upload=True)
+    ctx, _ = setup_context(crawl_queue=queue, batch_upload=True)
     try:
         with profile_scope(profile_enabled, profile_path):
             run_crawler(ctx, options)

--- a/data/scrapers/src/koryta.py
+++ b/data/scrapers/src/koryta.py
@@ -9,22 +9,13 @@ from conductor import setup_context
 from pipelines import PIPELINES
 from scrapers.article.pipelines import pipeline_utils as article_args
 from scrapers.stores import (
+    ContextResource,
     Pipeline,
     ProcessPolicy,
     iterate_pipeline_dict,
+    required_resources,
 )
 from scrapers.wiki import dump as wiki_dump_args
-
-# Pipelines that need the LLM client on the Context.
-ARTICLE_PIPELINES = {
-    "ArticleAnalyzed",
-    "ArticleDoneUrls",
-    "ArticleDomainSelectors",
-    "ArticleExtractedFacts",
-    "ArticleFactsVerified",
-    "ArticleKoryciarskiScores",
-    "ArticleParsed",
-}
 
 
 class Printer:
@@ -101,6 +92,35 @@ def get_args():
     return args
 
 
+def select_pipelines(args) -> set[str]:
+    pipeline_names = set(pt.__name__ for pt in PIPELINES)
+    exclude = set(args.exclude)
+    unknown = (exclude | set(args.pipeline)) - pipeline_names
+    if unknown:
+        raise ValueError(
+            f"Pipeline(s) not found: {' '.join(sorted(unknown))}. "
+            f"Available: {' '.join(sorted(pipeline_names))}"
+        )
+
+    if args.all:
+        if args.pipeline:
+            raise ValueError("--all runs everything, so it takes no pipeline names")
+        # ScrapeRejestrIO bills per query -- never part of a bulk run.
+        return pipeline_names - {"ScrapeRejestrIO"} - exclude
+    if args.pipeline:
+        return set(args.pipeline) - exclude
+    raise ValueError("No pipeline specified, use koryta PipelineName or --all")
+
+
+def selected_resources(selected: set[str]) -> set[type[ContextResource]]:
+    """The clients the selected pipelines declared, their sources' included."""
+    required: set[type[ContextResource]] = set()
+    for p_type in PIPELINES:
+        if p_type.__name__ in selected:
+            required |= required_resources(p_type)
+    return required
+
+
 def main():
     args = get_args()
     if args.no_backup:
@@ -116,31 +136,17 @@ def main():
 
     policy = ProcessPolicy.with_default(refresh, exclude_refresh=exclude_refresh)
 
-    pipeline_names = set(pt.__name__ for pt in PIPELINES)
-    exclude = set(args.exclude)
-    unknown = (exclude | set(args.pipeline)) - pipeline_names
-    if unknown:
-        raise ValueError(
-            f"Pipeline(s) not found: {' '.join(sorted(unknown))}. "
-            f"Available: {' '.join(sorted(pipeline_names))}"
-        )
-
-    if args.all:
-        if args.pipeline:
-            raise ValueError("--all runs everything, so it takes no pipeline names")
-        # ScrapeRejestrIO bills per query -- never part of a bulk run.
-        selected = pipeline_names - {"ScrapeRejestrIO"} - exclude
-    elif args.pipeline:
-        selected = set(args.pipeline) - exclude
-    else:
-        raise ValueError("No pipeline specified, use koryta PipelineName or --all")
-
-    ctx, dumper = setup_context(
-        False, use_llm=bool(selected & ARTICLE_PIPELINES), policy=policy
-    )
+    selected = select_pipelines(args)
+    required = selected_resources(selected)
+    ctx, dumper = setup_context(required, policy=policy)
 
     for p_name in sorted(selected):
         print(f"Will run pipeline: {p_name}")
+    if required:
+        print(
+            "Setting up context clients: "
+            + " ".join(sorted(r.__name__ for r in required))
+        )
 
     printer = Printer(args)
     try:

--- a/data/scrapers/src/scraper.py
+++ b/data/scrapers/src/scraper.py
@@ -12,7 +12,7 @@ from conductor import setup_context
 from scrapers.kmgp.people import PeopleKMGP
 from scrapers.krs.scrape import ScrapeRejestrIO
 from scrapers.krs.updates import KRSUpdates
-from scrapers.stores import Context, ProcessPolicy
+from scrapers.stores import Context, ProcessPolicy, RejestrIO
 
 
 def get_urls_to_scrape(ctx):
@@ -36,7 +36,7 @@ def main():
     )
 
     # Initialize the context, similar to krs/scrape.py pipeline execution but manually
-    ctx, _ = setup_context(use_rejestr_io=False)
+    ctx, _ = setup_context()
 
     urls_to_scrape = get_urls_to_scrape(ctx)
     if not urls_to_scrape:
@@ -121,10 +121,7 @@ def scrape_krs_free(sleep_time=0.2):
     No cost — all queries go to the free api-krs.ms.gov.pl API.
     """
     scrape_updates_by_dates(sleep_time)
-    ctx, _ = setup_context(
-        use_rejestr_io=False,
-        policy=ProcessPolicy(REFRESH_PIPELINES),
-    )
+    ctx, _ = setup_context(policy=ProcessPolicy(REFRESH_PIPELINES))
     pipeline = ScrapeRejestrIO()
     queries = list(pipeline.read_or_process_list(ctx))
 
@@ -168,10 +165,9 @@ def scrape_krs_paid(sleep_time=0.2):
     where the censored people list didn't change. Only pays for
     rejestr.io queries where there's an actual difference.
     """
-    ctx, _ = setup_context(
-        use_rejestr_io=True,
-        policy=ProcessPolicy(REFRESH_PIPELINES),
-    )
+    # The queries come off a pipeline, but the paid calls are made here, so
+    # this phase asks for the client itself rather than declaring it.
+    ctx, _ = setup_context([RejestrIO], policy=ProcessPolicy(REFRESH_PIPELINES))
     pipeline = ScrapeRejestrIO()
     queries = list(pipeline.read_or_process_list(ctx))
 
@@ -184,7 +180,7 @@ def scrape_krs_paid(sleep_time=0.2):
             if "rejestr.io" not in url:
                 continue
 
-            result = ctx.rejestr_io.get_rejestr_io(url)
+            result = RejestrIO.from_context(ctx).get_rejestr_io(url)
             if result is None:
                 print(f"Skipping {url}")
                 continue
@@ -201,7 +197,7 @@ def scrape_krs(sleep_time=0.2):
 
 
 def scrape_updates_by_dates(sleep_time=0.2):
-    ctx, _ = setup_context(use_rejestr_io=False, policy=ProcessPolicy({"KRSUpdates"}))
+    ctx, _ = setup_context(policy=ProcessPolicy({"KRSUpdates"}))
 
     start_date = datetime.strptime("2025-06-01", "%Y-%m-%d").date()
     today = datetime.now().date()

--- a/data/scrapers/src/scrapers/article/pipelines/domain_selectors_pipeline.py
+++ b/data/scrapers/src/scrapers/article/pipelines/domain_selectors_pipeline.py
@@ -19,7 +19,7 @@ from scrapers.article.pipelines.pipeline_utils import (
     llm_model,
     read_html_from_storage,
 )
-from scrapers.stores import Context, DoneUrl, LLMRequest, Pipeline
+from scrapers.stores import LLM, Context, DoneUrl, LLMRequest, Pipeline
 
 SELECTOR_PROMPT_VERSION = 1
 SELECTOR_MAX_TOKENS = 200
@@ -140,6 +140,7 @@ class ArticleDomainSelectors(Pipeline):
     backup_to_shared_cache = False  # keep article outputs local-only
 
     done_urls: ArticleDoneUrls
+    llm: LLM
 
     def process(self, ctx: Context):
 
@@ -186,8 +187,7 @@ async def _generate_selectors(
     *,
     model: str,
 ) -> list[dict[str, Any]]:
-    assert ctx.llm is not None
-    await ctx.llm.check_health()
+    await LLM.from_context(ctx).check_health()
     rows: list[dict[str, Any]] = []
     domain_concurrency = max(
         1,
@@ -285,7 +285,6 @@ async def _generate_selector_prompt_rows(
     *,
     model: str,
 ) -> list[dict[str, Any]]:
-    assert ctx.llm is not None
     pending: dict[int, str] = {}
     responses_by_domain: dict[str, list[str]] = {
         str(row["domain"]): [] for row in prompt_rows
@@ -301,7 +300,7 @@ async def _generate_selector_prompt_rows(
         mininterval=1.0,
         smoothing=0.05,
     ) as bar:
-        async with ctx.llm.response_pool() as pool:
+        async with LLM.from_context(ctx).response_pool() as pool:
             for row in prompt_rows:
                 domain = str(row["domain"])
                 for prompt in row.get("prompts") or []:

--- a/data/scrapers/src/scrapers/article/pipelines/facts_pipeline.py
+++ b/data/scrapers/src/scrapers/article/pipelines/facts_pipeline.py
@@ -28,7 +28,7 @@ from scrapers.article.pipelines.pipeline_utils import (
     article_facts_text_limit,
     llm_model,
 )
-from scrapers.stores import VERSIONED_DIR, Context, LLMRequest
+from scrapers.stores import LLM, VERSIONED_DIR, Context, LLMRequest
 
 PROMPT_VERSION = 15
 TEXT_LIMIT = 100000
@@ -223,6 +223,7 @@ class ArticleExtractedFacts(IncrementalJsonlPipeline[ArticleFacts]):
     interrupt_note = "will save partial facts"
 
     koryciarski_scores: ArticleKoryciarskiScores
+    llm: LLM
 
     @property
     def output_class(self):
@@ -361,8 +362,7 @@ async def _extract_records(
     model: str,
     min_score: int | None,
 ) -> None:
-    assert ctx.llm is not None
-    await ctx.llm.check_health()
+    await LLM.from_context(ctx).check_health()
     pending: dict[int, dict[str, Any]] = {}
     uncached = _filter_uncached_fact_records(
         _emit_cached_facts(ctx, records, existing, model),
@@ -377,7 +377,7 @@ async def _extract_records(
         mininterval=1.0,
         smoothing=0.05,
     ) as bar:
-        async with ctx.llm.response_pool() as pool:
+        async with LLM.from_context(ctx).response_pool() as pool:
             for record in uncached:
                 while pool.is_full():
                     request_id, response = await pool.get_response()
@@ -1033,9 +1033,7 @@ def _normalize_markdown_response(
 
 
 def _print_llm_usage(ctx: Context) -> None:
-    llm = ctx.llm
-    if llm is None:
-        return
+    llm = LLM.from_context(ctx)
     print(
         "LLM usage: "
         f"{int(getattr(llm, 'request_count', 0) or 0)} requests, "

--- a/data/scrapers/src/scrapers/article/pipelines/incremental.py
+++ b/data/scrapers/src/scrapers/article/pipelines/incremental.py
@@ -66,6 +66,7 @@ class IncrementalJsonlPipeline(Pipeline[T]):
             self._cached_result = pd.DataFrame()
             return self._cached_result
 
+        self.bind_requirements(ctx)
         self.preprocess_sources(ctx, ctx.refresh_policy)
         graceful = True
         try:

--- a/data/scrapers/src/scrapers/article/pipelines/koryciarski_scores_pipeline.py
+++ b/data/scrapers/src/scrapers/article/pipelines/koryciarski_scores_pipeline.py
@@ -11,7 +11,7 @@ from entities.article import KoryciarskiScore
 from scrapers.article.pipelines.incremental import IncrementalJsonlPipeline
 from scrapers.article.pipelines.parsed_pipeline import ArticleParsed
 from scrapers.article.pipelines.pipeline_utils import llm_model
-from scrapers.stores import VERSIONED_DIR, Context, LLMRequest
+from scrapers.stores import LLM, VERSIONED_DIR, Context, LLMRequest
 
 PROMPT_VERSION = 1
 TEXT_LIMIT = 100000
@@ -57,6 +57,7 @@ class ArticleKoryciarskiScores(IncrementalJsonlPipeline[KoryciarskiScore]):
     interrupt_note = "will save partial scores"
 
     article_parsed: ArticleParsed
+    llm: LLM
 
     @property
     def output_class(self):
@@ -142,8 +143,7 @@ async def _score_records(
     *,
     model: str,
 ) -> list[dict[str, Any]]:
-    assert ctx.llm is not None
-    await ctx.llm.check_health()
+    await LLM.from_context(ctx).check_health()
     pending: dict[int, dict[str, Any]] = {}
     uncached = _emit_cached_scores(ctx, records, existing, model)
 
@@ -155,7 +155,7 @@ async def _score_records(
         mininterval=1.0,
         smoothing=0.05,
     ) as bar:
-        async with ctx.llm.response_pool() as pool:
+        async with LLM.from_context(ctx).response_pool() as pool:
             for record in uncached:
                 while pool.is_full():
                     request_id, response = await pool.get_response()
@@ -386,9 +386,7 @@ def _normalize_scoring_result(parsed: dict[str, Any]) -> tuple[bool, int | None,
 
 
 def _print_llm_usage(ctx: Context) -> None:
-    llm = ctx.llm
-    if llm is None:
-        return
+    llm = LLM.from_context(ctx)
     requests = int(getattr(llm, "request_count", 0) or 0)
     prompt_tokens = int(getattr(llm, "prompt_tokens", 0) or 0)
     completion_tokens = int(getattr(llm, "completion_tokens", 0) or 0)

--- a/data/scrapers/src/scrapers/article/pipelines/verified_facts_pipeline.py
+++ b/data/scrapers/src/scrapers/article/pipelines/verified_facts_pipeline.py
@@ -26,7 +26,7 @@ from entities.article import ArticleFactsVerified as ArticleFactsVerifiedRecord
 from scrapers.article.pipelines.facts_pipeline import ArticleExtractedFacts
 from scrapers.article.pipelines.incremental import IncrementalJsonlPipeline
 from scrapers.article.pipelines.pipeline_utils import llm_model
-from scrapers.stores import VERSIONED_DIR, Context, LLMRequest
+from scrapers.stores import LLM, VERSIONED_DIR, Context, LLMRequest
 
 VERIFY_VERSION = 4
 MAX_TOKENS = 4000
@@ -208,6 +208,7 @@ class ArticleFactsVerified(IncrementalJsonlPipeline[ArticleFactsVerifiedRecord])
     interrupt_note = "will save partial verifications"
 
     extracted_facts: ArticleExtractedFacts
+    llm: LLM
 
     @property
     def output_class(self):
@@ -365,8 +366,7 @@ async def _verify_rows(
     *,
     model: str,
 ) -> None:
-    assert ctx.llm is not None
-    await ctx.llm.check_health()
+    await LLM.from_context(ctx).check_health()
 
     # Reuse cache and collect fact-level tasks for the rest.
     to_judge: list[dict[str, Any]] = []
@@ -406,7 +406,7 @@ async def _verify_rows(
     ]
 
     with tqdm(total=total_facts, desc="Verifying facts", unit="fact") as bar:
-        async with ctx.llm.response_pool() as pool:
+        async with LLM.from_context(ctx).response_pool() as pool:
             for state, idx in tasks:
                 while pool.is_full():
                     await _drain_one(ctx, pool, inflight, model, bar)
@@ -434,9 +434,7 @@ async def _drain_one(ctx, pool, inflight, model, bar) -> None:
 
 
 def _print_llm_usage(ctx: Context) -> None:
-    llm = ctx.llm
-    if llm is None:
-        return
+    llm = LLM.from_context(ctx)
     print(
         "Verify LLM usage: "
         f"{int(getattr(llm, 'request_count', 0) or 0)} requests, "

--- a/data/scrapers/src/scrapers/stores/__init__.py
+++ b/data/scrapers/src/scrapers/stores/__init__.py
@@ -145,8 +145,55 @@ class IO(metaclass=ABCMeta):
         raise NotImplementedError()
 
 
-class RejestrIO(metaclass=ABCMeta):
+class ContextResource(metaclass=ABCMeta):
+    """A client the Context only carries when some pipeline asked for it.
+
+    A pipeline declares what it needs the same way it declares its sources --
+    by annotating it on the class:
+
+        class ArticleDomainSelectors(Pipeline):
+            done_urls: ArticleDoneUrls   # a source
+            llm: LLM                     # a client on the Context
+
+    The runner reads those declarations (see `required_resources`, which walks
+    the sources too) and builds only the clients the selected pipelines can
+    actually reach. That is what keeps a wiki-only pass from needing an LLM
+    backend, or a parse-only pass from paying for rejestr.io.
+
+    Reach for the client through `LLM.from_context(ctx)` rather than `ctx.llm`:
+    it is typed non-optional, and it names the missing declaration when a
+    pipeline reaches for a client it never asked for.
+    """
+
+    # The Context field this resource is passed as.
+    context_attr: typing.ClassVar[str]
+
+    @classmethod
+    def from_context(cls, ctx: "Context") -> typing.Self:
+        """This client off `ctx`, or a MissingResourceError naming it."""
+        value = getattr(ctx, cls.context_attr, None)
+        if value is None:
+            raise MissingResourceError(cls)
+        return typing.cast(typing.Self, value)
+
+
+class MissingResourceError(RuntimeError):
+    """A pipeline reached for a client the Context was not built with."""
+
+    def __init__(self, resource: type[ContextResource]) -> None:
+        super().__init__(
+            f"{resource.__name__} is not set up on this Context. Annotate the "
+            f"pipeline that needs it with "
+            f"`{resource.context_attr}: {resource.__name__}`, so the runner "
+            f"builds the client before the run starts."
+        )
+        self.resource = resource
+
+
+class RejestrIO(ContextResource, metaclass=ABCMeta):
     """Abstract interface for interacting with the rejestr.io API."""
+
+    context_attr = "rejestr_io"
 
     @abstractmethod
     def get_rejestr_io(self, url: str) -> str | None:
@@ -187,8 +234,10 @@ class Web(metaclass=ABCMeta):
         raise NotImplementedError()
 
 
-class NLP(metaclass=ABCMeta):
+class NLP(ContextResource, metaclass=ABCMeta):
     """Abstract interface for NLP toolkit"""
+
+    context_attr = "nlp"
 
     @abstractmethod
     def extract_ner_entities(self, text: str) -> NEREntities:
@@ -255,8 +304,10 @@ class LLMResponsePool(metaclass=ABCMeta):
         raise NotImplementedError()
 
 
-class LLM(metaclass=ABCMeta):
+class LLM(ContextResource, metaclass=ABCMeta):
     """Abstract interface for OpenAI-compatible chat completion clients."""
+
+    context_attr = "llm"
 
     @abstractmethod
     def response_pool(self) -> LLMResponsePool:
@@ -300,8 +351,10 @@ class BlockedDomain:
     reason: str
 
 
-class CrawlQueue(metaclass=ABCMeta):
+class CrawlQueue(ContextResource, metaclass=ABCMeta):
     """Abstract interface for crawler URL queue."""
+
+    context_attr = "crawl_queue"
 
     @abstractmethod
     def put(self, urls: list[NewUrl]) -> None:
@@ -517,17 +570,58 @@ class Context:
     """Execution context for a scraper pipeline, providing access to I/O interfaces."""
 
     io: IO
-    rejestr_io: RejestrIO
+    # The ContextResource fields are None unless a pipeline declared them --
+    # reach for them through `from_context`, not directly.
+    rejestr_io: RejestrIO | None
     con: "DuckDBPyConnection"
     utils: Utils
     web: Web
-    nlp: NLP
+    nlp: NLP | None
     crawl_queue: CrawlQueue | None = None
     refresh_policy: ProcessPolicy = field(default_factory=ProcessPolicy.with_default)
     llm: LLM | None = None
 
 
 Output = typing.TypeVar("Output")
+
+
+def _annotated_classes(pipeline_type: type) -> typing.Iterable[tuple[str, type]]:
+    """(name, class) for every annotation on the pipeline that names a class.
+
+    Base classes included: `pipeline_type.__annotations__` would only see the
+    most derived class that has any, silently dropping the sources and clients
+    a base pipeline declared.
+    """
+    merged: dict[str, Any] = {}
+    for klass in reversed(pipeline_type.__mro__):
+        merged.update(klass.__dict__.get("__annotations__", {}))
+    for annotation, annotated in merged.items():
+        if isinstance(annotated, type):
+            yield annotation, annotated
+
+
+def required_resources(pipeline_type: type) -> set[type[ContextResource]]:
+    """The clients a run of this pipeline needs, its sources' included.
+
+    Transitive, because read_or_process runs a stale source before reading it:
+    ArticleAnalyzed never touches the LLM itself, but it cannot run without one
+    unless every pipeline under it is already up to date.
+    """
+    resources: set[type[ContextResource]] = set()
+    seen: set[type] = set()
+
+    def walk(p_type: type) -> None:
+        if p_type in seen:
+            return
+        seen.add(p_type)
+        for _, annotated in _annotated_classes(p_type):
+            if issubclass(annotated, ContextResource):
+                resources.add(annotated)
+            elif issubclass(annotated, Pipeline):
+                walk(annotated)
+
+    walk(pipeline_type)
+    return resources
 
 
 class Pipeline(typing.Generic[Output]):
@@ -779,6 +873,7 @@ Should I run it? (y/n) [n]",
         ctx: Context,
         policy: ProcessPolicy,
     ) -> pd.DataFrame:
+        self.bind_requirements(ctx)
         self.preprocess_sources(ctx, policy)
 
         dumper = ctx.io.dumper  # type:ignore # TODO fix it
@@ -815,11 +910,30 @@ Should I run it? (y/n) [n]",
         return df
 
     def list_sources(self):
-        for annotation, pipeline_type_dep in self.__annotations__.items():
-            if isinstance(pipeline_type_dep, type) and issubclass(
-                pipeline_type_dep, Pipeline
-            ):
-                yield annotation, pipeline_type_dep
+        for annotation, annotated in _annotated_classes(type(self)):
+            if issubclass(annotated, Pipeline):
+                yield annotation, annotated
+
+    def list_requirements(self) -> typing.Iterable[tuple[str, type[ContextResource]]]:
+        """The clients this pipeline declares, without its sources'.
+
+        `required_resources` is the one the runner wants -- this is only what
+        this class itself will reach for through `from_context`.
+        """
+        for annotation, annotated in _annotated_classes(type(self)):
+            if issubclass(annotated, ContextResource):
+                yield annotation, annotated
+
+    def bind_requirements(self, ctx: Context) -> None:
+        """Put the declared clients on the instance, as __init__ does sources.
+
+        Raises before any work is done when one is missing, which is worth
+        doing up front: these pipelines spend minutes loading their inputs
+        before the first request, and a run that dies then has thrown that
+        away.
+        """
+        for annotation, resource in self.list_requirements():
+            self.__dict__[annotation] = resource.from_context(ctx)
 
     def output_path(
         self, filename: str | None = None, format: Formats | None = None

--- a/data/scrapers/src/tests/pipelines/conftest.py
+++ b/data/scrapers/src/tests/pipelines/conftest.py
@@ -20,4 +20,4 @@ def snapshot() -> Snapshot:
     a failure against the data that produced it, or to tell a regression apart
     from a difference between two days.
     """
-    return load_snapshot(setup_context(False)[0], os.environ.get("KORYTA_EXPORT"))
+    return load_snapshot(setup_context()[0], os.environ.get("KORYTA_EXPORT"))

--- a/data/scrapers/src/tests/pipelines/test_companies.py
+++ b/data/scrapers/src/tests/pipelines/test_companies.py
@@ -7,7 +7,7 @@ from pipelines import Companies
 
 @pytest.fixture(scope="module")
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 @pytest.fixture(scope="module")

--- a/data/scrapers/src/tests/pipelines/test_krs_already_scraped.py
+++ b/data/scrapers/src/tests/pipelines/test_krs_already_scraped.py
@@ -6,7 +6,7 @@ from pipelines import KRSAlreadyScraped
 
 @pytest.fixture(scope="module")
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 @pytest.mark.skip(reason="TODO it fails for KRS that are already closed")

--- a/data/scrapers/src/tests/pipelines/test_people_enriched.py
+++ b/data/scrapers/src/tests/pipelines/test_people_enriched.py
@@ -26,7 +26,7 @@ def df_all(ctx):
 
 @pytest.fixture(scope="module")
 def ctx():
-    c, _ = setup_context(False)
+    c, _ = setup_context()
 
     original_list_files = c.io.list_files
 

--- a/data/scrapers/src/tests/pipelines/test_people_kmgp.py
+++ b/data/scrapers/src/tests/pipelines/test_people_kmgp.py
@@ -19,7 +19,7 @@ def output_df(ctx):
 
 @pytest.fixture(scope="module")
 def ctx():
-    c, _ = setup_context(False)
+    c, _ = setup_context()
     return c
 
 

--- a/data/scrapers/src/tests/pipelines/test_people_parties.py
+++ b/data/scrapers/src/tests/pipelines/test_people_parties.py
@@ -6,7 +6,7 @@ from conductor import setup_context
 
 @pytest.fixture
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 @pytest.fixture

--- a/data/scrapers/src/tests/pipelines/test_people_payloads.py
+++ b/data/scrapers/src/tests/pipelines/test_people_payloads.py
@@ -12,7 +12,7 @@ from pipelines import PeoplePayloads
 
 @pytest.fixture
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 @pytest.fixture

--- a/data/scrapers/src/tests/pipelines/test_person_pkw.py
+++ b/data/scrapers/src/tests/pipelines/test_person_pkw.py
@@ -7,7 +7,7 @@ from pipelines import PeoplePKW
 
 @pytest.fixture(scope="module")
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 @pytest.fixture(scope="module")

--- a/data/scrapers/src/tests/pipelines/test_scrape_rejestr_io.py
+++ b/data/scrapers/src/tests/pipelines/test_scrape_rejestr_io.py
@@ -7,7 +7,7 @@ from scrapers.krs.scrape import ScrapeRejestrIO
 
 @pytest.fixture(scope="module")
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 @pytest.fixture(scope="module")

--- a/data/scrapers/src/tests/pipelines/test_stats.py
+++ b/data/scrapers/src/tests/pipelines/test_stats.py
@@ -6,7 +6,7 @@ from conductor import setup_context
 
 @pytest.fixture
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 @pytest.fixture

--- a/data/scrapers/src/tests/test_data.py
+++ b/data/scrapers/src/tests/test_data.py
@@ -9,7 +9,7 @@ COMMON_ROW = 7
 
 @pytest.fixture
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 def test_public_companies_list(ctx):

--- a/data/scrapers/src/tests/test_extract.py
+++ b/data/scrapers/src/tests/test_extract.py
@@ -11,7 +11,7 @@ from pipelines import Extract
 
 @pytest.fixture
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 def extract(ctx, region):

--- a/data/scrapers/src/tests/test_extraction.py
+++ b/data/scrapers/src/tests/test_extraction.py
@@ -194,7 +194,7 @@ COMPANIES_EXPECTED = {
 
 @pytest.fixture
 def ctx():
-    return setup_context(False)[0]
+    return setup_context()[0]
 
 
 def list_test_files():

--- a/data/scrapers/src/tests/test_pipeline_requirements.py
+++ b/data/scrapers/src/tests/test_pipeline_requirements.py
@@ -1,0 +1,111 @@
+"""What a pipeline declares it needs, and what the runner builds from that."""
+
+import pytest
+
+from koryta import selected_resources
+from scrapers.article.pipelines import (
+    ArticleAnalyzed,
+    ArticleDomainSelectors,
+    ArticleDoneUrls,
+    ArticleParsed,
+)
+from scrapers.stores import (
+    LLM,
+    NLP,
+    LLMResponsePool,
+    MissingResourceError,
+    Pipeline,
+    required_resources,
+)
+from scrapers.tests.mocks import get_test_context
+
+
+class StubLLM(LLM):
+    def response_pool(self) -> LLMResponsePool:
+        raise NotImplementedError()
+
+    async def check_health(self) -> None:
+        return None
+
+
+class NeedsLLM(Pipeline):
+    filename = "needs_llm"
+    llm: LLM
+
+
+class ReadsNeedsLLM(Pipeline):
+    filename = "reads_needs_llm"
+    upstream: NeedsLLM
+
+
+class NeedsNothing(Pipeline):
+    filename = "needs_nothing"
+
+
+class DerivedFromNeedsLLM(NeedsLLM):
+    filename = "derived_from_needs_llm"
+
+
+def test_declared_resource_is_required():
+    assert required_resources(NeedsLLM) == {LLM}
+
+
+def test_no_declaration_needs_nothing():
+    assert required_resources(NeedsNothing) == set()
+
+
+def test_requirement_is_transitive_through_sources():
+    # ReadsNeedsLLM never touches the client itself, but read_or_process runs
+    # a stale source before reading it.
+    assert required_resources(ReadsNeedsLLM) == {LLM}
+
+
+def test_requirement_is_inherited():
+    assert required_resources(DerivedFromNeedsLLM) == {LLM}
+
+
+def test_bind_requirements_names_the_missing_client():
+    ctx = get_test_context()
+    with pytest.raises(MissingResourceError) as excinfo:
+        Pipeline.create(NeedsLLM).bind_requirements(ctx)
+    assert excinfo.value.resource is LLM
+    assert "llm: LLM" in str(excinfo.value)
+
+
+def test_bind_requirements_puts_the_client_on_the_pipeline():
+    ctx = get_test_context()
+    ctx.llm = StubLLM()
+    pipeline = Pipeline.create(NeedsLLM)
+    pipeline.bind_requirements(ctx)
+    assert pipeline.llm is ctx.llm
+
+
+def test_from_context_returns_the_client():
+    ctx = get_test_context()
+    llm = StubLLM()
+    ctx.llm = llm
+    assert LLM.from_context(ctx) is llm
+
+
+def test_from_context_raises_for_a_client_that_was_never_built():
+    with pytest.raises(MissingResourceError):
+        NLP.from_context(get_test_context())
+
+
+def test_done_urls_alone_needs_no_llm():
+    # It reads postgres and the URL store, so a run that only refreshes it has
+    # no reason to want an LLM backend up.
+    assert selected_resources({"ArticleDoneUrls"}) == set()
+    assert required_resources(ArticleDoneUrls) == set()
+
+
+def test_the_article_pipelines_that_prompt_need_the_llm():
+    assert required_resources(ArticleDomainSelectors) == {LLM}
+    # Neither of these prompts, both sit above one that does.
+    assert required_resources(ArticleParsed) == {LLM}
+    assert required_resources(ArticleAnalyzed) == {LLM}
+
+
+def test_selected_resources_unions_over_the_selection():
+    assert selected_resources({"ArticleAnalyzed", "ProcessWiki"}) == {LLM}
+    assert selected_resources({"ProcessWiki"}) == set()

--- a/data/scrapers/src/uploader.py
+++ b/data/scrapers/src/uploader.py
@@ -192,7 +192,7 @@ class CompanyUploader(Uploader):
         """
         if self._company_payloads is None:
             print("Loading company payloads from Companies pipeline")
-            df = Companies().read_or_process(setup_context(False)[0])
+            df = Companies().read_or_process(setup_context()[0])
             self._company_payloads = {c["krs"]: c for c in iterate_pipeline_dict(df)}
         return self._company_payloads
 


### PR DESCRIPTION
koryta.py kept ARTICLE_PIPELINES, a hand-written set of names that decided whether the run built an LLM client. It listed ArticleDoneUrls, which reads postgres and the URL store and never prompts, and it would have gone stale the first time a pipeline outside scrapers/article wanted a client.

A pipeline now declares a client the same way it declares a source, by annotating it:

    class ArticleDomainSelectors(Pipeline):
        done_urls: ArticleDoneUrls
        llm: LLM

required_resources walks those annotations through the sources, because read_or_process runs a stale source before reading it -- ArticleAnalyzed never prompts, but it cannot run without an LLM unless everything under it is up to date. setup_context takes that set in place of its use_llm/use_nlp/use_rejestr_io booleans and builds exactly those clients.

The clients reach their users through LLM.from_context(ctx), which is typed non-optional and, when the client is missing, names the annotation that would have built it. run_pipeline binds them onto the instance before any work starts, so a run that is missing one dies immediately rather than after the minutes these pipelines spend loading their inputs.