### PR TITLE
Add a password reset link to the email login form

### DIFF
--- a/frontend/app/components/form/LoginForm.vue
+++ b/frontend/app/components/form/LoginForm.vue
@@ -39,12 +39,22 @@
       @click:append-inner="showPassword = !showPassword"
     />
 
+    <div v-if="isLogin" class="text-right mb-2">
+      <a href="javascript:void(0)" class="text-caption" @click="resetPassword">
+        Nie pamiętasz hasła?
+      </a>
+    </div>
+
     <v-btn type="submit" block color="primary" size="large" :loading="loading">
       {{ isLogin ? "Zaloguj się" : "Stwórz konto" }}
     </v-btn>
 
     <v-alert v-if="error" type="error" density="compact" class="mt-4">
       {{ error }}
+    </v-alert>
+
+    <v-alert v-if="info" type="success" density="compact" class="mt-4">
+      {{ info }}
     </v-alert>
   </v-form>
 </template>
@@ -70,13 +80,19 @@ const email = ref("");
 const password = ref("");
 const showPassword = ref(false);
 const error = ref<string | null>(null);
+const info = ref<string | null>(null);
 const loading = ref(false);
 
 const auth = useFirebaseAuth()!;
-const { login: authLogin, register: authRegister } = useAuthState();
+const {
+  login: authLogin,
+  register: authRegister,
+  resetPassword: authResetPassword,
+} = useAuthState();
 
 const login = async () => {
   error.value = null;
+  info.value = null;
   loading.value = true;
   try {
     await authLogin(email.value, password.value);
@@ -93,6 +109,7 @@ const login = async () => {
 
 const loginWithGoogle = async () => {
   error.value = null;
+  info.value = null;
   loading.value = true;
   try {
     const provider = new GoogleAuthProvider();
@@ -108,8 +125,32 @@ const loginWithGoogle = async () => {
   }
 };
 
+const resetPassword = async () => {
+  error.value = null;
+  info.value = null;
+
+  if (!email.value) {
+    error.value = "Podaj swój adres email, i wyślemy Ci link do zmiany hasła.";
+    return;
+  }
+
+  loading.value = true;
+  try {
+    await authResetPassword(email.value);
+    // Deliberately worded so it does not reveal whether the account exists.
+    info.value = `Jeśli konto dla ${email.value} istnieje, wysłaliśmy na nie link do ustawienia nowego hasła. Sprawdź swoją skrzynkę.`;
+  } catch (err: unknown) {
+    const errorObj = err as { code: string; message: string };
+    console.error("Password reset error:", errorObj.code, errorObj.message);
+    error.value = getErrorMessage(errorObj.code);
+  } finally {
+    loading.value = false;
+  }
+};
+
 const register = async () => {
   error.value = null;
+  info.value = null;
   loading.value = true;
   try {
     const userCredential = await authRegister(email.value, password.value);
@@ -147,6 +188,11 @@ const getErrorMessage = (errorCode: string) => {
       return "Ten email jest już w użyciu.";
     case "auth/weak-password":
       return "Hasło jest zbyt słabe. Powinno mieć co najmniej 6 znaków.";
+    case "auth/invalid-email":
+    case "auth/missing-email":
+      return "Podaj poprawny adres email.";
+    case "auth/too-many-requests":
+      return "Zbyt wiele prób. Spróbuj ponownie za chwilę.";
     default:
       return "Wystąpił nieoczekiwany błąd. Spróbuj ponownie.";
   }

--- a/frontend/app/composables/auth.test.ts
+++ b/frontend/app/composables/auth.test.ts
@@ -4,26 +4,32 @@ import { ref } from "vue";
 import { useAuthState } from "@/composables/auth";
 
 // Hoisted variables for mocks
-const { mockIdTokenFn, mockAuth, mockUseFetchSpy, mockUseDocumentSpy } =
-  vi.hoisted(() => {
-    const fn = vi.fn();
-    const tokenFn = vi.fn();
-    const docFn = vi.fn();
-    return {
-      mockUseFetchSpy: fn,
-      mockIdTokenFn: tokenFn,
-      mockUseDocumentSpy: docFn,
-      mockAuth: {
-        currentUser: {
-          uid: "test-uid",
-          getIdToken: tokenFn,
-          getIdTokenResult: vi
-            .fn()
-            .mockResolvedValue({ claims: { admin: false }, token: "token" }),
-        },
+const {
+  mockIdTokenFn,
+  mockAuth,
+  mockUseFetchSpy,
+  mockUseDocumentSpy,
+  mockSendPasswordResetEmail,
+} = vi.hoisted(() => {
+  const fn = vi.fn();
+  const tokenFn = vi.fn();
+  const docFn = vi.fn();
+  return {
+    mockUseFetchSpy: fn,
+    mockIdTokenFn: tokenFn,
+    mockUseDocumentSpy: docFn,
+    mockSendPasswordResetEmail: vi.fn(),
+    mockAuth: {
+      currentUser: {
+        uid: "test-uid",
+        getIdToken: tokenFn,
+        getIdTokenResult: vi
+          .fn()
+          .mockResolvedValue({ claims: { admin: false }, token: "token" }),
       },
-    };
-  });
+    },
+  };
+});
 
 // Mock firebase/auth used by the composable
 vi.mock("firebase/auth", async () => {
@@ -33,6 +39,7 @@ vi.mock("firebase/auth", async () => {
     signOut: vi.fn(),
     signInWithEmailAndPassword: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),
+    sendPasswordResetEmail: mockSendPasswordResetEmail,
     GoogleAuthProvider: vi.fn(),
     Auth: {},
   };
@@ -79,5 +86,15 @@ describe("useAuthState", () => {
     expect(state.logout).toBeTypeOf("function");
     expect(state.login).toBeTypeOf("function");
     expect(state.register).toBeTypeOf("function");
+    expect(state.resetPassword).toBeTypeOf("function");
+  });
+
+  it("resetPassword sends the reset email for the given address", async () => {
+    const state = useAuthState();
+    await state.resetPassword("someone@example.com");
+    expect(mockSendPasswordResetEmail).toHaveBeenCalledWith(
+      mockAuth,
+      "someone@example.com",
+    );
   });
 });

--- a/frontend/app/composables/auth.ts
+++ b/frontend/app/composables/auth.ts
@@ -2,6 +2,7 @@ import {
   signOut,
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
+  sendPasswordResetEmail,
 } from "firebase/auth";
 import { computedAsync } from "@vueuse/core";
 import {
@@ -59,6 +60,16 @@ export function useAuthState() {
     return await createUserWithEmailAndPassword(auth, email, pass);
   };
 
+  /** Sends the "set a new password" link to `email`.
+   *
+   * Firebase's email enumeration protection makes this succeed even for an
+   * address with no account, so the caller must not report back whether the
+   * address is known.
+   */
+  const resetPassword = async (email: string) => {
+    return await sendPasswordResetEmail(auth, email);
+  };
+
   return {
     user,
     isAdmin,
@@ -67,6 +78,7 @@ export function useAuthState() {
     logout,
     login,
     register,
+    resetPassword,
   };
 }
 


### PR DESCRIPTION
The login form offered no way out of a forgotten password: the only recovery was to register again with a different address.

useAuthState gains resetPassword(), and LoginForm shows a "Nie pamiętasz hasła?" link in login mode, so both the /login page and the login dialog pick it up. The success copy does not say whether the address has an account, matching sendPasswordResetEmail's behaviour under Firebase's email enumeration protection.