### PR TITLE
Stop printing "undefined" where a relation has no start date

### DIFF
--- a/frontend/app/components/card/EmploymentHistory.vue
+++ b/frontend/app/components/card/EmploymentHistory.vue
@@ -26,7 +26,7 @@
           <ChipPublicCompany :company="asCompany(edge)" />
         </div>
 
-        <div class="d-md-none mt-2 pb-2">
+        <div v-if="isDated(edge)" class="d-md-none mt-2 pb-2">
           <ChipRelativeDuration
             :start="edge.start_date"
             :end="edge.end_date"
@@ -36,7 +36,7 @@
         </div>
 
         <template #append>
-          <div class="d-none d-md-flex">
+          <div v-if="isDated(edge)" class="d-none d-md-flex">
             <ChipRelativeDuration
               :start="edge.start_date"
               :end="edge.end_date"
@@ -98,6 +98,16 @@ const maxEnd = computed(() => {
 
 function edgeLabel(edge: EdgeNode) {
   return edge.label;
+}
+
+/** Whether the edge asserts a period at all.
+ *
+ * The card lists every relation a person has, not only the employment it is
+ * named after, and some kinds carry no dates by construction - a `connection`
+ * has no date fields in the schema. Drawing a full-width bar for those claims a
+ * span nobody recorded, so they get the label and nothing else. */
+function isDated(edge: EdgeNode): boolean {
+  return !!(edge.start_date || edge.end_date);
 }
 
 /** The company behind an edge, when the edge leads to one at all. */

--- a/frontend/app/components/chip/RelativeDuration.vue
+++ b/frontend/app/components/chip/RelativeDuration.vue
@@ -31,11 +31,16 @@ const props = defineProps<{
 }>();
 
 const description = computed(() => {
+  // Both ends are optional - an edge entered through the editor may carry no
+  // date at all - so neither may be interpolated unguarded. "obecnie" is only
+  // right for the end: a missing start is unknown, not today.
+  if (!props.start && !props.end) {
+    return "";
+  }
   if (props.start && props.end && props.start == props.end) {
     return props.start;
-  } else {
-    return `${props.start} - ${props.end || "obecnie"}`;
   }
+  return `${props.start ?? "?"} - ${props.end || "obecnie"}`;
 });
 
 const parseDate = (d: string | undefined, fallback: number) => {

--- a/frontend/tests/components/card/EmploymentHistory.test.ts
+++ b/frontend/tests/components/card/EmploymentHistory.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import EmploymentHistory from "../../../app/components/card/EmploymentHistory.vue";
+import type { EdgeNode } from "../../../app/composables/edges";
+
+function edge(fields: Partial<EdgeNode>): EdgeNode {
+  return {
+    id: "e1",
+    type: "employed",
+    label: "Zarząd",
+    source: "person",
+    target: "place",
+    richNode: { id: "place", type: "place", name: "PKP" },
+    ...fields,
+  } as EdgeNode;
+}
+
+async function render(edges: EdgeNode[]) {
+  return await mountSuspended(EmploymentHistory, { props: { edges } });
+}
+
+describe("CardEmploymentHistory", () => {
+  it("shows the period of a dated relation", async () => {
+    const wrapper = await render([
+      edge({ start_date: "2014-11-06", end_date: "2017-08-25" }),
+    ]);
+    expect(wrapper.text()).toContain("2014-11-06 - 2017-08-25");
+    // Anchors the selector the undated case asserts the absence of.
+    expect(
+      wrapper.findComponent({ name: "ChipRelativeDuration" }).exists(),
+    ).toBe(true);
+  });
+
+  it("drops the duration bar for a relation that carries no dates", async () => {
+    // `connection` has no date fields in the schema, so every one of them would
+    // otherwise draw a full-width bar over a span nobody recorded.
+    const wrapper = await render([
+      edge({ type: "connection", label: "kolega z zarządu" }),
+    ]);
+    expect(wrapper.text()).toContain("kolega z zarządu");
+    expect(
+      wrapper.findComponent({ name: "ChipRelativeDuration" }).exists(),
+    ).toBe(false);
+  });
+
+  it("never renders undefined for an undated employment", async () => {
+    const wrapper = await render([edge({ label: "zastępca prezesa" })]);
+    expect(wrapper.text()).not.toContain("undefined");
+  });
+});

--- a/frontend/tests/components/chip/RelativeDuration.test.ts
+++ b/frontend/tests/components/chip/RelativeDuration.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import RelativeDuration from "../../../app/components/chip/RelativeDuration.vue";
+
+async function textOf(props: { start?: string; end?: string }) {
+  return (
+    await mountSuspended(RelativeDuration, {
+      props: {
+        start: undefined,
+        end: undefined,
+        minStart: "2000-01-01",
+        maxEnd: "2026-01-01",
+        ...props,
+      },
+    })
+  ).text();
+}
+
+describe("ChipRelativeDuration", () => {
+  it("reads both ends of a closed period", async () => {
+    expect(await textOf({ start: "2014-11-06", end: "2017-08-25" })).toBe(
+      "2014-11-06 - 2017-08-25",
+    );
+  });
+
+  it("calls an open period ongoing", async () => {
+    expect(await textOf({ start: "2014-11-06" })).toBe("2014-11-06 - obecnie");
+  });
+
+  it("collapses a period that begins and ends on one day", async () => {
+    expect(await textOf({ start: "2014-11-06", end: "2014-11-06" })).toBe(
+      "2014-11-06",
+    );
+  });
+
+  it("never stringifies a missing start", async () => {
+    // An edge entered through the editor may carry no start date, and the
+    // template used to interpolate it straight into the caption - which is how
+    // 117 published people came to read "undefined - obecnie".
+    const text = await textOf({ end: "2017-08-25" });
+    expect(text).not.toContain("undefined");
+    expect(text).toBe("? - 2017-08-25");
+  });
+
+  it("says nothing at all when no date was recorded", async () => {
+    expect(await textOf({})).toBe("");
+  });
+});


### PR DESCRIPTION
The duration caption on a person's "Historia powiązań" interpolated start_date straight into a template literal, and only end_date had a fallback. An edge with no start date therefore read "undefined - obecnie". On today's export that is 117 published people - 206 rows, 145 employed and 61 connection.

The two sources are different problems. An employed edge with a blank start is a gap in the record: 185 of the 195 carry a revision_id, so they came from the editor with the date field left empty, while the KRS importer always sets one. A connection edge has no date fields in the schema at all, so every one of them was drawing a full-width bar over a span nobody recorded.

So the chip guards both ends - "?" for an unknown start, since a missing start is unknown rather than today - and the card withholds the bar entirely from an edge that asserts no period.