### PR TITLE
Show the home page the progress numbers it was inventing

### DIFF
--- a/frontend/app/components/card/CallToAction.vue
+++ b/frontend/app/components/card/CallToAction.vue
@@ -8,7 +8,7 @@
           <v-card-text>
             Nasza baza cały czas rośnie. Dołącz do grona wolontariuszy,
             analizujących dane lub promujących projekt. Dzięki osobom jak Ty,
-            znaleźliśmy już {{ interesting }} osób.
+            znaleźliśmy już {{ reviewed }} osób.
           </v-card-text>
         </v-card>
       </v-col>
@@ -36,5 +36,5 @@
 import { mdiPencilPlus } from "@mdi/js";
 import { useStats } from "~/composables/stats/useStats";
 
-const { interesting } = useStats();
+const { reviewed } = useStats();
 </script>

--- a/frontend/app/components/chart/PeopleProgress.vue
+++ b/frontend/app/components/chart/PeopleProgress.vue
@@ -37,32 +37,36 @@ interface Segment {
   link: string;
 }
 
-const { approved, interesting, toCheck } = useStats();
+const { approved, reviewed, toCheck } = useStats();
 
-const segments: Segment[] = [
+const segments = computed<Segment[]>(() => [
   {
-    value: approved,
+    value: approved.value,
     color: "#4caf50",
     label: "Dodane",
     link: "/eksploruj/tabela",
   },
   {
-    value: interesting,
+    value: reviewed.value,
     color: "#2196f3",
     label: "Ciekawe",
     link: "/pomoc",
   },
   {
-    value: toCheck,
+    value: toCheck.value,
     color: "#f44336",
     label: "Do sprawdzenia",
     link: "/eksploruj/tabela?visibility=private",
   },
-];
+]);
 
-// Calculate the total value of all segments
+// Calculate the total value of all segments. Floored at 1 so the widths below
+// stay numbers for the frame before the counts arrive.
 const total = computed(() =>
-  segments.reduce((sum, segment) => sum + segment.value, 0),
+  Math.max(
+    segments.value.reduce((sum, segment) => sum + segment.value, 0),
+    1,
+  ),
 );
 </script>
 

--- a/frontend/app/components/explore/ProgressBar.vue
+++ b/frontend/app/components/explore/ProgressBar.vue
@@ -69,8 +69,8 @@
         </span>
         <v-spacer />
         <span class="text-caption text-medium-emphasis">
-          oczekujące zmiany: {{ stats.pendingRevisions }} · z głosami:
-          {{ stats.withVotes }} · z notatkami: {{ stats.withNotes }}
+          z głosami: {{ stats.withVotes }} · z notatkami:
+          {{ stats.withNotes }}
         </span>
       </div>
 

--- a/frontend/app/composables/stats/useStats.ts
+++ b/frontend/app/composables/stats/useStats.ts
@@ -1,7 +1,33 @@
+import type { ProgressStats } from "~~/server/api/stats/progress.get";
+
+/** Site-wide tagging progress: how many people are published, how many the
+ * community has looked at but not published, how many nobody has touched.
+ *
+ * The same figures /api/stats/progress gives the explore table, asked for
+ * without filters. Every caller shares one `useAsyncData` key, so a page that
+ * shows the number in three places still fetches it once, and the endpoint is
+ * cached server-side on top of that.
+ *
+ * Zero until the request lands. Under SSR that never shows - the fetch is
+ * awaited before the page renders - but a client-side navigation paints one
+ * frame with it, so callers dividing by these need to say what they want at
+ * zero.
+ */
 export const useStats = () => {
+  const { data } = useAsyncData("site-progress", () =>
+    $fetch<ProgressStats>("/api/stats/progress"),
+  );
+
+  const count = (key: keyof ProgressStats) =>
+    computed(() => data.value?.[key] ?? 0);
+
   return {
-    approved: 846,
-    interesting: 126,
-    toCheck: 2598,
+    total: count("total"),
+    /** Published. */
+    approved: count("approved"),
+    /** Looked at by somebody, not published yet. */
+    reviewed: count("reviewed"),
+    /** Nobody has looked yet. */
+    toCheck: count("toCheck"),
   };
 };

--- a/frontend/app/pages/pomoc.vue
+++ b/frontend/app/pages/pomoc.vue
@@ -181,12 +181,12 @@ useSeoMeta({
 
 const { toCheck } = useStats();
 
-const quickActions = [
+const quickActions = computed(() => [
   {
     title: "Przeglądaj nowe osoby",
     to: "/eksploruj/nowe",
     icon: mdiLayersSearchOutline,
-    desc: `Oceń osoby, które nie są jeszcze opublikowane na stronie. Do sprawdzenia zostało jeszcze ${toCheck}.`,
+    desc: `Oceń osoby, które nie są jeszcze opublikowane na stronie. Do sprawdzenia zostało jeszcze ${toCheck.value}.`,
   },
   {
     title: "Kategoryzuj fakty",
@@ -200,7 +200,7 @@ const quickActions = [
     icon: mdiGithub,
     desc: "Masz pomysł na usprawnienie lub znalazłeś błąd? Zgłoś go na GitHubie.",
   },
-];
+]);
 
 // TODO update the link before the end of January 2025
 const communityLinks = [

--- a/frontend/server/api/stats/progress.get.ts
+++ b/frontend/server/api/stats/progress.get.ts
@@ -20,18 +20,31 @@ export type ProgressStats = {
   total: number;
   /** Published (approved) people. */
   approved: number;
-  /** Not published yet, but already looked at: voted on, annotated or with a
-   * pending revision. */
+  /** Not published yet, but already looked at: voted on or annotated.
+   *
+   * Deliberately not "or has a revision waiting for approval". Every person
+   * the scrapers ingest arrives as an unapproved revision, so
+   * `revisions.has_unapproved` is set on all 5190 unpublished people and on
+   * none of the published ones - counting it would restate `toCheck` under a
+   * second name. Only 30 of those 5190 have a hand-written latest revision,
+   * and telling them apart costs a read of every one of the revisions. If
+   * that number is ever wanted, /api/admin/summary already computes it as
+   * `unapprovedManual`. */
   reviewed: number;
   /** Not published and untouched by the community. */
   toCheck: number;
-  /** People with a proposed change awaiting approval. */
-  pendingRevisions: number;
   /** People at least one human voted on. */
   withVotes: number;
   /** People with at least one note. */
   withNotes: number;
 };
+
+/** What the counters below read, on top of whatever the filters ask for. */
+const COUNTER_FIELDS = [
+  "stats.isApproved",
+  "stats.votes.humanVoted",
+  "stats.notesCount",
+];
 
 /** Aggregate tagging-progress counts for the people matching the current
  * table filters. Status filters (visibility, hideVoted) are deliberately not
@@ -52,12 +65,11 @@ export default defineCachedEventHandler(
       approved: 0,
       reviewed: 0,
       toCheck: 0,
-      pendingRevisions: 0,
       withVotes: 0,
       withNotes: 0,
     };
 
-    const { ops, empty } = await buildStructuralFilterOps(
+    const { ops, fields, empty } = await buildStructuralFilterOps(
       db,
       { ...query, type: "person" },
       "all",
@@ -67,10 +79,18 @@ export default defineCachedEventHandler(
     // Fetch all people once and filter in memory: the counts need several
     // overlapping predicates, and the in-memory ops never hit missing-index
     // or multiple-array-filter limits of Firestore queries.
+    //
+    // Projected down to the leaf fields actually read, because that scan is
+    // the whole cost of this endpoint - 6077 documents as of the July 2026
+    // export, on every cache miss, for every distinct combination of filters.
+    // Asking for the `stats` map whole pulled 4.18 MB; the counters alone are
+    // 0.55 MB, and a place filter, which needs the target-id arrays too, 2.0
+    // MB. Against the emulator over loopback that was ~600 ms down to ~350;
+    // the read count does not change, but the bytes do.
     const snapshot = await db
       .collection("nodes")
       .where("type", "==", "person")
-      .select("type", "parties", "stats", "revisions")
+      .select(...new Set([...COUNTER_FIELDS, ...fields]))
       .get();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -82,7 +102,6 @@ export default defineCachedEventHandler(
     const stats = { ...zero, total: nodes.length };
     for (const node of nodes) {
       const isApproved = node.stats?.isApproved === true;
-      // const hasPending = node.revisions?.has_unapproved === true;
       const hasVotes = node.stats?.votes?.humanVoted === true;
       const hasNotes = (node.stats?.notesCount ?? 0) > 0;
 
@@ -90,7 +109,6 @@ export default defineCachedEventHandler(
       else if (hasVotes || hasNotes) stats.reviewed++;
       else stats.toCheck++;
 
-      // if (hasPending) stats.pendingRevisions++;
       if (hasVotes) stats.withVotes++;
       if (hasNotes) stats.withNotes++;
     }

--- a/frontend/server/utils/nodeFilters.ts
+++ b/frontend/server/utils/nodeFilters.ts
@@ -11,6 +11,11 @@ import { isInWojewodztwo, isWojewodztwoTeryt } from "~~/shared/teryt";
 export type NodeFilterOp = {
   applyFs: (q: FirebaseFirestore.Query) => FirebaseFirestore.Query;
   applyMem: (nodes: any[]) => any[];
+  /** Document fields `applyMem` reads. Declared so that a caller which
+   * projects its Firestore query knows what to ask for - a field left out of
+   * the projection reads back as undefined and the filter silently drops
+   * everything. Callers that fetch whole documents can ignore it. */
+  fields?: string[];
 };
 
 export type StructuralQuery = {
@@ -88,14 +93,20 @@ function memOnly(applyMem: NodeFilterOp["applyMem"]): NodeFilterOp {
  *
  * Returns `empty: true` when a filter value resolves to nothing (e.g. an
  * unknown KRS number), meaning the result set is empty regardless of the
- * other filters.
+ * other filters. `fields` is the union of what the ops read, for callers that
+ * project their query - see `NodeFilterOp.fields`.
  */
 export async function buildStructuralFilterOps(
   db: FirebaseFirestore.Firestore,
   query: StructuralQuery,
   edgeScope: "all" | "approved",
-): Promise<{ ops: NodeFilterOp[]; empty: boolean }> {
+): Promise<{ ops: NodeFilterOp[]; fields: string[]; empty: boolean }> {
   const ops: NodeFilterOp[] = [];
+  const result = (empty: boolean) => ({
+    ops,
+    fields: [...new Set(ops.flatMap((op) => op.fields ?? []))],
+    empty,
+  });
   // Firestore allows only one array-contains/array-contains-any clause per
   // query, so once one op uses it, later array ops must run in memory.
   let arrayFilterUsed = false;
@@ -104,6 +115,7 @@ export async function buildStructuralFilterOps(
     ops.push({
       applyFs: (q) => q.where("type", "==", query.type),
       applyMem: (nodes) => nodes.filter((n) => n.type === query.type),
+      fields: ["type"],
     });
   }
 
@@ -130,6 +142,7 @@ export async function buildStructuralFilterOps(
             return true;
           return false;
         }),
+      fields: ["parties"],
     });
   }
 
@@ -185,7 +198,7 @@ export async function buildStructuralFilterOps(
   if (placeIdSets.length > 0) {
     const placeIds = intersectAll(placeIdSets);
     if (placeIds.length === 0) {
-      return { ops, empty: true };
+      return result(true);
     }
     ops.push(targetNodesOp(placeIds, query, edgeScope, arrayFilterUsed));
     arrayFilterUsed = true;
@@ -194,7 +207,7 @@ export async function buildStructuralFilterOps(
   if (query.teryt) {
     const regionIds = await resolveRegionIds(db, query.teryt);
     if (regionIds.length === 0) {
-      return { ops, empty: true };
+      return result(true);
     }
     ops.push(targetNodesOp(regionIds, query, edgeScope, arrayFilterUsed));
     // Nothing reads this today, but every op that consumes the array-filter
@@ -211,6 +224,7 @@ export async function buildStructuralFilterOps(
         nodes.filter(
           (n) => n.stats?.edges?.[edgeScope]?.currentlyEmployed === true,
         ),
+      fields: [field],
     });
   }
 
@@ -224,6 +238,7 @@ export async function buildStructuralFilterOps(
           const val = n.stats?.edges?.[edgeScope]?.latestEmploymentStart;
           return typeof val === "string" && val >= minDate;
         }),
+      fields: [field],
     });
   }
 
@@ -233,10 +248,11 @@ export async function buildStructuralFilterOps(
       applyFs: (q) => q.where("stats.votes.interesting", ">=", minVotes),
       applyMem: (nodes) =>
         nodes.filter((n) => (n.stats?.votes?.interesting ?? 0) >= minVotes),
+      fields: ["stats.votes.interesting"],
     });
   }
 
-  return { ops, empty: false };
+  return result(false);
 }
 
 /** Region node ids a `teryt` filter covers.
@@ -326,14 +342,15 @@ function targetNodesOp(
         placeIds.includes(id),
       ),
     );
+  const arrayField = edgeTargetsField(edgeScope, query.currentlyEmployed);
 
   // array-contains-any accepts at most 10 values
   if (arrayFilterUsed || placeIds.length > 10) {
-    return memOnly(applyMem);
+    return { ...memOnly(applyMem), fields: [arrayField] };
   }
-  const arrayField = edgeTargetsField(edgeScope, query.currentlyEmployed);
   return {
     applyFs: (q) => q.where(arrayField, "array-contains-any", placeIds),
     applyMem,
+    fields: [arrayField],
   };
 }

--- a/frontend/tests/e2e/home.spec.ts
+++ b/frontend/tests/e2e/home.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 // The Cypress suite these come from also cross-checked the "Łącznie N" figure
-// against /api/nodes. Both ends of that check are gone: the home page no longer
-// carries a totals card, and app/composables/stats/useStats.ts returns
-// constants rather than anything the api could disagree with.
+// against /api/nodes. The home page no longer carries a totals card, so that
+// check has nothing to hang off; the figures it did show now come from
+// /api/stats/progress via app/composables/stats/useStats.ts.
 test.describe("Home", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/", { waitUntil: "domcontentloaded" });


### PR DESCRIPTION
useStats returned three constants - 846/126/2598 - that had drifted from the data they described; /api/stats/progress already computes the same breakdown, so the composable now asks it. The real figures are 887 published, 337 looked at, 4853 untouched. Its `interesting` is renamed `reviewed` to match the endpoint and to stop it reading as `stats.votes.interesting`, which is a different thing entirely.

The commented-out pendingRevisions counter is deleted rather than restored. `revisions.has_unapproved` is set on all 5190 unpublished people and on none of the published ones, because every person the scrapers ingest arrives as an unapproved revision - so "oczekujące zmiany" would have been "do sprawdzenia" printed twice. Only 30 of the 5190 have a hand-written latest revision, and separating those costs a read per revision; /api/admin/summary already does it where that is worth paying for.

The endpoint reads every person on each cache miss, for each distinct combination of filters. That much is inherent - the counts need overlapping predicates the in-memory ops exist to serve - but asking for the `stats` map whole pulled 4.18 MB of it. Filter ops now declare which fields they read, so the query projects to the leaves that are actually used: 0.55 MB unfiltered, 2.0 MB when a place filter needs the target-id arrays. Verified against the July 2026 export: nine filter combinations, identical counts either way.