### PR TITLE
Ask each edge type whether it dates the relation it records

### DIFF
--- a/data/scrapers/src/analysis/scripts/edge_dates.py
+++ b/data/scrapers/src/analysis/scripts/edge_dates.py
@@ -1,0 +1,248 @@
+"""Analyse how well each edge type dates the relation it records.
+
+An edge in koryta carries a period - ``start_date`` and ``end_date`` - but only
+some kinds of relation have one. A spell of employment began on a day and may
+have ended on another; a ``connection`` between two people asserts no period at
+all, and the edit form only offers the two date fields on its ``employed``
+branch. So a missing ``start_date`` means opposite things depending on the type,
+and the only way to tell them apart is to look at how the whole type behaves:
+
+* a type where **every** edge has a start date has one in its schema;
+* a type where **none** does has no notion of a period, and the empty ones that
+  do occur are blanks written by a form rather than dates;
+* a type in between is the interesting case - the date belongs there and some
+  documents are missing it. That is a gap in the record, and it is what
+  ``test_a_dated_edge_says_when_it_began`` in ``tests/pipelines/test_invariants``
+  budgets.
+
+It matters because nothing raises when the date is absent.
+``calculateExperience`` in ``frontend/shared/stats.ts`` skips an interval with no
+start, so the person simply shows less experience than they have, and
+``EDGE_SEMANTICS`` keys an employment on the role *and* the start, so an undated
+spell cannot be told apart from any other spell at that company.
+
+Run from the ``src`` directory (same import root as the tests)::
+
+    python -m analysis.scripts.edge_dates
+    python -m analysis.scripts.edge_dates --history 6
+    python -m analysis.scripts.edge_dates --export 2026-07-28T14:25:08.897Z
+
+It reads one koryta.pl Firestore export - the most recent complete one unless
+``--export`` names another - through ``scrapers.koryta.snapshot``, the same
+reader the invariant tests use. ``--history`` reads several, evenly spaced across
+the bucket, which is what tells a fixed set of old undated edges apart from a
+writer that is still producing them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+# Allow running as a plain script (python analysis/scripts/edge_dates.py) by
+# making sure the ``src`` root is importable, like the test suite expects.
+_SRC_ROOT = Path(__file__).resolve().parents[2]
+if str(_SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SRC_ROOT))
+
+from conductor import setup_context  # noqa: E402
+from scrapers.koryta.snapshot import (  # noqa: E402
+    Snapshot,
+    export_dates,
+    load_snapshot,
+    read_collection,
+)
+from scrapers.stores import Context  # noqa: E402
+
+DATE_FIELDS = ("start_date", "end_date")
+
+#: A relation whose type dates it, but which is missing the date, is only worth
+#: singling out where the type dates most of its edges - below this the type
+#: simply has no period and every edge "missing" one is normal.
+PARTIAL_BAND = (0.0, 1.0)
+
+
+def is_set(value: Any) -> bool:
+    """Whether a stored date says anything.
+
+    ``None`` and ``""`` are both "no date": /api/edges/create writes ``null``
+    for a field the form left blank while the editor writes an empty string, and
+    every reader in the frontend tests the field for truthiness, so the two are
+    the same absence seen from two writers.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def coverage(edges: Iterable[dict]) -> dict[str, Counter]:
+    """Per edge type, how many documents set, omit or blank each date field."""
+    counts: dict[str, Counter] = defaultdict(Counter)
+    for edge in edges:
+        stats = counts[str(edge.get("type"))]
+        stats["total"] += 1
+        for field in DATE_FIELDS:
+            if is_set(edge.get(field)):
+                stats[f"{field}.set"] += 1
+            elif field in edge:
+                stats[f"{field}.blank"] += 1
+            else:
+                stats[f"{field}.absent"] += 1
+        if is_set(edge.get("end_date")) and not is_set(edge.get("start_date")):
+            stats["ends_without_starting"] += 1
+    return counts
+
+
+def report_coverage(counts: dict[str, Counter], export: str) -> list[str]:
+    """Print the per-type table and return the types that date only some edges."""
+    print("\n" + "=" * 78)
+    print(f"EDGE DATE COVERAGE  (export {export})")
+    print("=" * 78)
+    print(
+        f"\n  {'type':<18}{'edges':>8}{'start':>8}{'rate':>8}"
+        f"{'absent':>8}{'blank':>7}{'end':>8}{'end only':>10}"
+    )
+
+    partial: list[str] = []
+    for edge_type, stats in sorted(
+        counts.items(), key=lambda item: item[1]["total"], reverse=True
+    ):
+        total = stats["total"]
+        rate = stats["start_date.set"] / total if total else 0.0
+        flag = ""
+        if PARTIAL_BAND[0] < rate < PARTIAL_BAND[1]:
+            partial.append(edge_type)
+            flag = "  <-- dated, but not always"
+        print(
+            f"  {edge_type:<18}{total:>8}{stats['start_date.set']:>8}{rate:>8.1%}"
+            f"{stats['start_date.absent']:>8}{stats['start_date.blank']:>7}"
+            f"{stats['end_date.set']:>8}{stats['ends_without_starting']:>10}{flag}"
+        )
+
+    print(
+        "\n  A type at 100% has the period in its schema; one at 0% has no notion\n"
+        "  of a period and its blanks are a form's empty strings, not lost dates.\n"
+        "  'end only' counts edges that record an end but no beginning, which is\n"
+        "  an interval no reader can place and should be zero everywhere."
+    )
+    return partial
+
+
+def report_gaps(snapshot: Snapshot, edge_type: str) -> None:
+    """Describe the undated edges of a type that dates most of its edges.
+
+    Which writer left the date out is the whole question, and the edge says so
+    indirectly: ``revision_id`` means it went through the editor, where the date
+    field is optional and was left empty, while an edge with none was written by
+    an ingest.
+    """
+    nodes = snapshot.by_id("nodes")
+    undated = [
+        edge
+        for edge in snapshot.collection("edges")
+        if edge.get("type") == edge_type and not is_set(edge.get("start_date"))
+    ]
+    if not undated:
+        return
+
+    print(f"\n### {edge_type!r}: {len(undated)} edges with no start date")
+
+    def tally(label: str, values: Iterable[Any]) -> None:
+        counts = Counter(values)
+        rendered = ", ".join(f"{key}: {count}" for key, count in counts.most_common(6))
+        print(f"  {label:<22}{rendered}")
+
+    tally(
+        "written by",
+        (
+            "editor (revision)" if edge.get("revision_id") else "ingest"
+            for edge in undated
+        ),
+    )
+    tally("published", (str(edge.get("published")) for edge in undated))
+    tally("role recorded", ("yes" if edge.get("name") else "no" for edge in undated))
+    tally(
+        "source node type",
+        (nodes.get(edge["source"], {}).get("type") for edge in undated),
+    )
+    tally(
+        "target node type",
+        (nodes.get(edge["target"], {}).get("type") for edge in undated),
+    )
+    tally("role", (edge.get("name") for edge in undated if edge.get("name")))
+    print(f"  {'sample ids':<22}{', '.join(edge['id'] for edge in undated[:6])}")
+
+
+def report_history(ctx: Context, samples: int) -> None:
+    """The same count over exports spread across the bucket.
+
+    A backlog of undated edges left by a writer that has since been fixed stands
+    still while the collection around it grows; one that is still being written
+    climbs with it. The two look identical in a single export.
+    """
+    dates = export_dates(ctx)
+    if not dates:
+        return
+    step = max(1, len(dates) // max(1, samples - 1))
+    picked = sorted({*dates[::step], dates[-1]})
+
+    print("\n" + "=" * 78)
+    print(f"HISTORY  ({len(picked)} of {len(dates)} exports)")
+    print("=" * 78)
+
+    rows = []
+    for date in picked:
+        counts = coverage(read_collection(ctx, date, "edges"))
+        rows.append((date, counts))
+
+    types = sorted(
+        {edge_type for _, counts in rows for edge_type in counts},
+        key=lambda edge_type: -rows[-1][1][edge_type]["total"],
+    )
+    header = "".join(f"{edge_type[:11]:>13}" for edge_type in types)
+    print(f"\n  {'export':<22}{header}")
+    for date, counts in rows:
+        cells = "".join(
+            f"{counts[t]['total'] - counts[t]['start_date.set']:>6}"
+            f"/{counts[t]['total']:<6}"
+            for t in types
+        )
+        print(f"  {date[:19]:<22}{cells}")
+    print("\n  Cells are (edges with no start date)/(edges of that type).")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--export",
+        help="Export timestamp to read (default: the most recent complete one).",
+    )
+    parser.add_argument(
+        "--history",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Also read N earlier exports, evenly spaced, and show the trend.",
+    )
+    args = parser.parse_args()
+
+    ctx = setup_context(False)[0]
+    snapshot = load_snapshot(ctx, args.export)
+    edges = snapshot.collection("edges")
+    print(f"Loaded {len(edges)} edges from {snapshot.date}.")
+
+    counts = coverage(edges)
+    for edge_type in report_coverage(counts, snapshot.date):
+        report_gaps(snapshot, edge_type)
+
+    if args.history:
+        report_history(ctx, args.history)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/scrapers/src/tests/pipelines/test_invariants.py
+++ b/data/scrapers/src/tests/pipelines/test_invariants.py
@@ -71,6 +71,19 @@ EDGE_ENDPOINT_TYPES: dict[str, set[tuple[str, str]]] = {
 # nodes. Kept in step with EDGE_SEMANTICS in `frontend/server/utils/edges.ts`.
 STATE_EDGE_TYPES = {"owns", "mentions", "comment", "source"}
 
+# Edge types that record a period rather than a standing tie, and so have to say
+# when it began. Every other type asserts something with no beginning - an
+# article names a person, a region seats a company - and the edit form agrees:
+# it offers the two date fields only on its `employed` branch. `connection` is
+# the one that looks like an exception, because `EDGE_SEMANTICS` lists
+# `start_date` among the fields that tell two of them apart, but nothing can
+# write one and not one of the 89 stored carries a date.
+#
+# So on the other six types a `start_date` is always a blank rather than a date:
+# 6 `owns`, 8 `mentions`, 8 `connection` and 3 `mentioned_person` hold an empty
+# string, which is what a form leaves behind, and none holds a value.
+DATED_EDGE_TYPES = ("employed", "election")
+
 VOTE_CATEGORIES = {"interesting", "quality", "correct", "insufficient"}
 
 EXTRACTION_FACT_TYPES = {"employment", "party_membership", "personal_relation"}
@@ -84,6 +97,20 @@ def sample(items, limit: int = 10) -> list:
     if isinstance(items, (set, dict)):
         return sorted(items)[:limit]
     return list(items)[:limit]
+
+
+def has_date(document: dict, field: str) -> bool:
+    """Whether a stored date field says anything.
+
+    `None` and `""` are one absence seen from two writers: /api/edges/create
+    stores `null` for a date the form left blank while the editor stores an
+    empty string, and every reader in the frontend tests the field for
+    truthiness, so neither is a date.
+    """
+    value = document.get(field)
+    if isinstance(value, str):
+        return bool(value.strip())
+    return value is not None
 
 
 def stats_of(document: dict) -> dict:
@@ -276,8 +303,7 @@ def test_extraction_fact_types_are_known(extractions):
     )
 
     assert not unknown, (
-        f"Extractions carry fact types the frontend does not render: "
-        f"{dict(unknown)}"
+        f"Extractions carry fact types the frontend does not render: {dict(unknown)}"
     )
 
 
@@ -902,6 +928,72 @@ def test_employment_says_what_the_person_did(edges):
     assert len(roleless) <= KNOWN_ROLELESS, (
         f"{len(roleless)} employment edges say nothing about what the person "
         f"did, up from the {KNOWN_ROLELESS} known ones: {sample(roleless)}"
+    )
+
+
+@pytest.mark.parametrize("edge_type", DATED_EDGE_TYPES)
+def test_a_dated_edge_says_when_it_began(edges, edge_type):
+    """An edge that records a period has to say when the period started.
+
+    Nothing raises when it does not. `calculateExperience` skips an interval it
+    cannot place, so the person shows less experience than they have rather than
+    an error; `EDGE_SEMANTICS` keys an employment on the role *and* the start, so
+    an undated spell is indistinguishable from every other spell at that company
+    - which is also why `findEdges` narrows in memory, since a Firestore filter
+    on `start_date` matches no document that is missing it. Until the duration
+    chip learned to print "?", the history card rendered "undefined - obecnie".
+
+    The two types fail differently, which is why the budgets differ. A candidacy
+    without a date is a candidacy with no election: the ingest derives the field
+    from the election year (`${election.election_year}-01-01`), so it cannot
+    write one without it, and no export has ever held one. An employment can be
+    entered by hand, where the date field is optional.
+    """
+    # 195 employment edges on the 2026-08-03 export. Nearly all of them are old:
+    # 183 in December 2025, when 183 was *every* employment stored, and still 184
+    # in June 2026 after the KRS import had taken the collection past 11,000 -
+    # that importer always sets a start date. The 11 added since are hand edits,
+    # and 185 of the 195 carry a revision_id, so the editor is where they come
+    # from. The other 10 came from an ingest and are all unpublished.
+    #
+    # It is a budget rather than a ceiling: the article-extraction path has no
+    # date field at all - none of the 244 employment extractions carries one -
+    # so every fact promoted from a review lands here until it gains one.
+    UNDATED = {"employed": 195, "election": 0}
+
+    undated = [
+        edge["id"]
+        for edge in edges
+        if edge.get("type") == edge_type and not has_date(edge, "start_date")
+    ]
+    budget = UNDATED[edge_type]
+
+    assert len(undated) <= budget, (
+        f"{len(undated)} {edge_type} edges do not say when they began, so they "
+        f"count for no experience and cannot be told from another spell - up "
+        f"from the {budget} known ones. Sample IDs: {sample(undated)}"
+    )
+
+
+def test_an_edge_that_ends_has_a_beginning(edges):
+    """An `end_date` with no `start_date` is an interval nothing can place.
+
+    `calculateExperience` reads a missing end as "still going" and a missing
+    start as no interval at all, so an edge with only an end contributes nothing
+    while reading, on the page, as a job that finished. There are none, on any
+    export read so far and across all eight stored edge types, so this is stated
+    strictly rather than budgeted: the writers that fill in an end always know
+    the start, and one that does not would be a new defect.
+    """
+    dangling = [
+        (edge["id"], edge.get("type"), edge["end_date"])
+        for edge in edges
+        if has_date(edge, "end_date") and not has_date(edge, "start_date")
+    ]
+
+    assert not dangling, (
+        f"{len(dangling)} edges record an end but no beginning, as "
+        f"(edge, type, end_date): {sample(dangling)}"
     )
 
 


### PR DESCRIPTION
The undefined-range fix left the obvious question unanswered: a missing start_date is a defect on some edge types and normal on others, and nothing wrote down which. src/analysis/scripts/edge_dates.py answers it from an export - per type, how many edges carry a start, how many omit the field and how many hold a blank - and reads the answer off the shape of the whole type. A type at 100% has the period in its schema; one at 0% has no notion of one, and the few start_dates it does hold are empty strings a form left behind. Only a type in between is missing data.

On the 2026-08-03 export exactly one type sits in between. employed is at 98.5%: 195 of 12,640 edges never say when the job began. election is at 100%, and the other six at 0% - owns, mentions, connection, comment, source and mentioned_person hold 25 start_dates between them, every one of them blank.

--history reads several exports and is what makes the 195 readable. The count was 183 in December 2025, when 183 was every employment stored, and still 184 in June 2026 after the KRS import had taken the collection past 11,000 - that importer always sets a date. So this is a fixed set of hand-entered edges, not a writer still producing them: 185 of the 195 carry a revision_id, and the 10 that do not came from an ingest and are unpublished.

Two invariants follow. A dated edge type has to say when it began, with the 195 as employed's budget and nothing allowed for election - the ingest derives that date from the election year, so a candidacy without one is a candidacy with no election. And an edge that records an end has to record a beginning, which is strict: there are none, and one would be an interval calculateExperience drops while the page reads it as a job that finished.