### PR TITLE
Let several models nominate who to investigate next, not just one

### DIFF
--- a/data/scrapers/src/analysis/scores/__init__.py
+++ b/data/scrapers/src/analysis/scores/__init__.py
@@ -1,0 +1,43 @@
+"""Models that nominate the next person to look at.
+
+Each model writes its verdict to the site as a vote under its own `userUid`,
+all of them containing "pipeline" so the frontend keeps them out of the human
+tally. They are not variants of one another: `PeopleScores` reads a person's
+employers, `PeopleScoresPageRank` reads the shape of the graph around them,
+`PeopleScoresCoappointment` reads who they keep turning up with,
+`PeopleScoresTurnover` reads what they did after an election, and
+`PeopleScoresCapture` reads the institution rather than the person. Any of them
+can nominate somebody the others miss, which is why the site takes the best
+score across models rather than the sum.
+
+See `base.PeopleScoreModel` for what they share.
+"""
+
+from analysis.scores.base import PeopleScoreModel, Population
+from analysis.scores.capture import PeopleScoresCapture
+from analysis.scores.coappointment import PeopleScoresCoappointment
+from analysis.scores.company import CompanyScores, PeopleScores
+from analysis.scores.pagerank import PeopleScoresPageRank
+from analysis.scores.turnover import PeopleScoresTurnover
+
+#: Every model, in the order a run should produce them: the shared sources are
+#: read once and cached, so the first is the slow one.
+PEOPLE_SCORE_MODELS: list[type[PeopleScoreModel]] = [
+    PeopleScores,
+    PeopleScoresPageRank,
+    PeopleScoresCoappointment,
+    PeopleScoresTurnover,
+    PeopleScoresCapture,
+]
+
+__all__ = [
+    "CompanyScores",
+    "PEOPLE_SCORE_MODELS",
+    "PeopleScoreModel",
+    "PeopleScores",
+    "PeopleScoresCapture",
+    "PeopleScoresCoappointment",
+    "PeopleScoresPageRank",
+    "PeopleScoresTurnover",
+    "Population",
+]

--- a/data/scrapers/src/analysis/scores/base.py
+++ b/data/scrapers/src/analysis/scores/base.py
@@ -304,9 +304,15 @@ class PeopleScoreModel(Pipeline):
             return {}
         totals: dict[str, float] = {}
         for _, row in votes.iterrows():
-            node_id = str(row.get("person_koryta_id") or "")
+            target = row.get("person_koryta_id")
             interesting = row.get("interesting")
-            if not node_id or interesting is None or pd.isna(interesting):
+            # NaN rather than a blank is what a vote with no node on it looks
+            # like once pandas has been through it, and NaN is truthy - see
+            # `KorytaVotes.process`, which is where those get dropped now.
+            if pd.isna(target) or interesting is None or pd.isna(interesting):
+                continue
+            node_id = str(target).strip()
+            if not node_id:
                 continue
             totals[node_id] = totals.get(node_id, 0.0) + float(interesting)
         return totals

--- a/data/scrapers/src/analysis/scores/base.py
+++ b/data/scrapers/src/analysis/scores/base.py
@@ -1,0 +1,329 @@
+"""What every model that rates a person has in common.
+
+A scoring model answers one question: of the people the pipeline knows about
+and the site has not looked at yet, which should somebody open next? Each model
+answers it from a different angle, and each writes its answer as a vote under
+its own `userUid` - `pipeline-pagerank`, `pipeline-together` and so on. The
+frontend treats any uid containing "pipeline" as non-human and takes the best
+of them, so a model that is wrong about somebody costs a wasted click rather
+than a corrupted aggregate.
+
+Two things are shared here rather than left to each model. `Population` unpacks
+the payloads once into the shapes the models actually want (who works where,
+who stood for what, who sits on which board), because four models re-deriving
+that from raw payload rows would be four chances to disagree about what a
+missing KRS means. And `banded_scores` puts every model on the same 1-5 scale
+by rank, not by value: raw model outputs are on wildly different scales - a
+PageRank mass is ~1e-5, a co-appointment count is an integer - and with the
+frontend taking the maximum across models, whichever model scaled itself most
+generously would otherwise win every tie.
+"""
+
+import dataclasses
+import typing
+
+import pandas as pd
+
+from analysis.payloads.person import PeoplePayloads
+from entities.composite import PersonScore
+from scrapers.koryta.download import KorytaPeople, KorytaVotes
+from scrapers.krs.list import CompaniesKRS
+from scrapers.stores import Context, Pipeline
+
+#: How strongly a published page counts as "we already decided this one is
+#: interesting". A page gets published after a human wrote it up, so it is
+#: firmer evidence than a single passing vote but weaker than a maximal one.
+IS_PUBLIC_SCORE = 3
+
+#: The percentile a raw score has to reach to earn each point of the 1-5 scale,
+#: highest band first. Deliberately not even fifths: the point of a score is to
+#: order a queue, and a queue where a fifth of everybody is a 5 orders nothing.
+SCORE_BANDS: tuple[tuple[float, int], ...] = (
+    (0.99, 5),
+    (0.95, 4),
+    (0.85, 3),
+    (0.60, 2),
+    (0.0, 1),
+)
+
+
+def iter_dicts(value: typing.Any) -> typing.Iterator[dict]:
+    """The dict entries of a payload list column, whatever pandas made of it.
+
+    The same column arrives as a list of dataclass-dicts when the payloads were
+    built in this process and as a list of plain dicts when they were read back
+    from jsonl, and as a float NaN when the person had none.
+    """
+    if value is None or isinstance(value, float):
+        return
+    if not hasattr(value, "__iter__") or isinstance(value, (str, bytes)):
+        return
+    for item in value:
+        if isinstance(item, dict):
+            yield item
+
+
+@dataclasses.dataclass
+class Employment:
+    krs: str
+    role: str | None
+    start: str | None
+    end: str | None
+
+
+@dataclasses.dataclass
+class Candidacy:
+    year: str | None
+    teryt: str | None
+    party: str | None
+    committee: str | None
+
+
+@dataclasses.dataclass
+class CompanyFacts:
+    name: str | None
+    teryt: str | None
+    is_public: bool
+
+
+@dataclasses.dataclass
+class Population:
+    """Everyone a model can see, and what the site already thinks of them.
+
+    Keyed by person name throughout, which is what `PeoplePayloads` and the
+    site's own nodes are joined on today. Names collide - the existing
+    `CompanyScores` carries a TODO saying so - and until the payloads carry the
+    koryta node id, a model inherits that.
+
+    The population is whatever the payload run covered. `Extract` filters by
+    region unless asked for everything, so a regional run gives a regional
+    graph: someone whose only tie to a known face runs through a company in the
+    next voivodeship is invisible to it. That is the same horizon the current
+    model has, not a new limitation.
+    """
+
+    #: Payload rows, one per person, in payload order.
+    people: pd.DataFrame
+    #: Person name -> koryta node id. Only people the site already has a node
+    #: for; a model cannot vote on anybody else.
+    node_ids: dict[str, str]
+    #: Person name -> posts held, in payload order.
+    employments: dict[str, list[Employment]]
+    #: Person name -> candidacies stood.
+    candidacies: dict[str, list[Candidacy]]
+    #: KRS -> everybody the payloads put in that company.
+    roster: dict[str, list[str]]
+    #: KRS -> what the KRS register says about the company.
+    companies: dict[str, CompanyFacts]
+    #: Person name -> how firmly the site has already judged them. Positive for
+    #: a published page or an upvote, negative for a downvote, absent for the
+    #: unexamined. This is the ground truth the models generalise from, so it
+    #: counts humans only - seeding a model on the pipeline's own past votes
+    #: would just teach it to repeat itself.
+    seed_weights: dict[str, float]
+    #: The people eligible for a score: known to the site, not published, and
+    #: not yet voted on by a human. Rating anybody else is telling somebody
+    #: something they already know.
+    shortlist: list[str]
+
+    def seeds(self, sign: int = 1) -> dict[str, float]:
+        """Confirmed people whose judgement went the given way, weight positive."""
+        return {
+            name: abs(weight)
+            for name, weight in self.seed_weights.items()
+            if weight * sign > 0
+        }
+
+    def has_candidacy(self, name: str) -> bool:
+        return bool(self.candidacies.get(name))
+
+
+def banded_scores(raw: typing.Mapping[str, float]) -> dict[str, int]:
+    """Put a model's raw output on the shared 1-5 scale.
+
+    By rank, so the shape of the raw distribution does not matter: PageRank
+    masses are a power law and co-appointment counts are small integers with
+    ties everywhere, and both need to come out as a usable shortlist. People
+    scoring zero or less are dropped rather than banded - a model saying
+    nothing about somebody is not a vote.
+    """
+    series = pd.Series(raw, dtype="float64")
+    positive = series[series > 0]
+    if positive.empty:
+        return {}
+
+    percentile = positive.rank(pct=True, method="average")
+
+    def band(value: float) -> int:
+        for floor, points in SCORE_BANDS:
+            if value >= floor:
+                return points
+        return 1
+
+    return {str(name): band(value) for name, value in percentile.items()}
+
+
+class PeopleScoreModel(Pipeline):
+    """A model that nominates people to look at next.
+
+    Subclasses set `filename` and `model_tag` and implement `raw_scores`. The
+    base handles who is eligible, the 1-5 banding and the output shape.
+    """
+
+    #: The `userUid` this model's votes are stored under. Anything containing
+    #: "pipeline" reads as non-human to the frontend; the tag after it is what
+    #: tells two models apart in `stats.votes.models`.
+    model_tag: str = "pipeline"
+
+    people_payloads: PeoplePayloads
+    people_koryta: KorytaPeople
+    people_votes: KorytaVotes
+    companies_krs: CompaniesKRS
+
+    def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
+        """This model's opinion, on whatever scale suits it, keyed by name.
+
+        Scores for people outside the shortlist are ignored, so a model is free
+        to compute over everybody - the graph models have to.
+        """
+        raise NotImplementedError
+
+    def process(self, ctx: Context):
+        population = self.population(ctx)
+        print(
+            f"{type(self).__name__}: {len(population.people)} people, "
+            f"{len(population.seeds())} positive seeds, "
+            f"{len(population.seeds(-1))} negative, "
+            f"{len(population.shortlist)} on the shortlist"
+        )
+
+        raw = self.raw_scores(ctx, population)
+        eligible = set(population.shortlist)
+        banded = banded_scores(
+            {name: score for name, score in raw.items() if name in eligible}
+        )
+
+        records = [
+            dataclasses.asdict(
+                PersonScore(
+                    node_id=population.node_ids[name],
+                    name=name,
+                    score=score,
+                    model=self.model_tag,
+                )
+            )
+            for name, score in banded.items()
+        ]
+        if not records:
+            print(f"{type(self).__name__} found nobody to score")
+            return pd.DataFrame(columns=["node_id", "name", "score", "model"])
+
+        df = pd.DataFrame.from_records(records)
+        df = df.sort_values(by="score", ascending=False).reset_index(drop=True)
+        print(f"{type(self).__name__} scored {len(df)} people")
+        print(df["score"].value_counts().sort_index(ascending=False))
+        return df.astype({"score": "int32"})
+
+    def population(self, ctx: Context) -> Population:
+        people = self.people_payloads.read_or_process(ctx)
+        koryta = self.people_koryta.read_or_process(ctx)
+        votes = self.people_votes.read_or_process(ctx)
+        companies = self.companies_krs.read_or_process(ctx)
+
+        node_ids = dict(zip(koryta["full_name"], koryta["id"]))
+        human_votes = self.human_votes(votes, koryta)
+
+        employments: dict[str, list[Employment]] = {}
+        candidacies: dict[str, list[Candidacy]] = {}
+        roster: dict[str, list[str]] = {}
+
+        for _, row in people.iterrows():
+            name = str(row.get("name"))
+            posts = [
+                Employment(
+                    krs=str(company["krs"]),
+                    role=company.get("role"),
+                    start=company.get("start"),
+                    end=company.get("end"),
+                )
+                for company in iter_dicts(row.get("companies"))
+                if company.get("krs")
+            ]
+            employments[name] = posts
+            for post in posts:
+                roster.setdefault(post.krs, []).append(name)
+
+            candidacies[name] = [
+                Candidacy(
+                    year=election.get("election_year"),
+                    teryt=election.get("teryt"),
+                    party=election.get("party"),
+                    committee=election.get("committee"),
+                )
+                for election in iter_dicts(row.get("elections"))
+            ]
+
+        seed_weights: dict[str, float] = {}
+        shortlist: list[str] = []
+        for _, entry in koryta.iterrows():
+            name = str(entry.get("full_name"))
+            is_public = entry.get("is_public", False)
+            if pd.isna(is_public):
+                is_public = False
+
+            vote = human_votes.get(str(entry.get("id")), 0.0)
+            if is_public:
+                seed_weights[name] = max(seed_weights.get(name, 0.0), IS_PUBLIC_SCORE)
+            elif vote:
+                seed_weights[name] = vote
+            elif name in employments:
+                shortlist.append(name)
+
+        return Population(
+            people=people,
+            node_ids=node_ids,
+            employments=employments,
+            candidacies=candidacies,
+            roster=roster,
+            companies=self.company_facts(companies),
+            seed_weights=seed_weights,
+            shortlist=shortlist,
+        )
+
+    @staticmethod
+    def human_votes(votes: pd.DataFrame, koryta: pd.DataFrame) -> dict[str, float]:
+        """Node id -> the sum of what people voted on it.
+
+        `KorytaPeople.votes_interesting` would be the obvious source and is the
+        wrong one: it is the site's own aggregate, which includes the
+        pipeline's vote. A model seeded on it would be seeded on its own output
+        and, worse, `shortlist` would drop everybody the pipeline had ever
+        scored, so no run after the first could revise a score.
+        """
+        if votes.empty or "person_koryta_id" not in votes:
+            return {}
+        totals: dict[str, float] = {}
+        for _, row in votes.iterrows():
+            node_id = str(row.get("person_koryta_id") or "")
+            interesting = row.get("interesting")
+            if not node_id or interesting is None or pd.isna(interesting):
+                continue
+            totals[node_id] = totals.get(node_id, 0.0) + float(interesting)
+        return totals
+
+    @staticmethod
+    def company_facts(companies: pd.DataFrame) -> dict[str, CompanyFacts]:
+        if companies.empty or "krs" not in companies:
+            return {}
+        facts = {}
+        for _, row in companies.iterrows():
+            krs = row.get("krs")
+            if not krs or pd.isna(krs):
+                continue
+            is_public = row.get("is_public", False)
+            facts[str(krs)] = CompanyFacts(
+                name=row.get("name"),
+                teryt=str(row["teryt_code"]) if row.get("teryt_code") else None,
+                is_public=bool(is_public) if not pd.isna(is_public) else False,
+            )
+        return facts

--- a/data/scrapers/src/analysis/scores/capture.py
+++ b/data/scrapers/src/analysis/scores/capture.py
@@ -1,0 +1,78 @@
+"""Who sits in an institution whose board is mostly political appointees.
+
+The other three models score a person on their own record: who they know, who
+they travel with, what they did after an election. That leaves out the case the
+site most wants to hear about - the newcomer with no record at all, appointed
+last year to a company where four of the other five board members are former
+candidates. Nothing about them is suspicious. Everything about where they are
+is.
+
+So this model scores the place and reads the score onto the person. For each
+company, what share of its board is either a former candidate or somebody the
+site has already confirmed; a person's score is the worst institution they sit
+in. The person is left out of their own institution's numerator and
+denominator, or an ex-candidate on a two-person board would be scoring
+themselves.
+
+Small boards need a brake, because two people of whom one is a candidate is
+50% and means nothing, so the denominator carries the same confidence factor
+the company scores have used all along.
+"""
+
+from analysis.scores.base import PeopleScoreModel, Population
+from scrapers.stores import Context
+
+#: Added to the denominator so a tiny board cannot reach a high share. With a
+#: factor of 2, a board of two where the other person is a candidate scores
+#: 1/(1+2) = 0.33, while a board of ten where six are scores 0.6.
+CONFIDENCE_FACTOR = 2.0
+
+#: Boards past this size say nothing about the people on them.
+MAX_ROSTER = 200
+
+#: How much a person the site has already confirmed counts for, against 1.0 for
+#: somebody who merely stood in an election. Standing for office is public and
+#: common; being written up on koryta.pl is neither.
+CONFIRMED_WEIGHT = 2.0
+
+
+def political_weight(population: Population, name: str) -> float:
+    """How much this person contributes to their board looking captured."""
+    if population.seed_weights.get(name, 0.0) > 0:
+        return CONFIRMED_WEIGHT
+    return 1.0 if population.has_candidacy(name) else 0.0
+
+
+class PeopleScoresCapture(PeopleScoreModel):
+    filename = "people_scores_capture"
+    model_tag = "pipeline-capture"
+
+    def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
+        rosters = {
+            krs: people
+            for krs, people in population.roster.items()
+            # A board of one has nobody else on it to be captured by.
+            if 2 <= len(people) <= MAX_ROSTER
+        }
+
+        weights = {
+            krs: {name: political_weight(population, name) for name in set(people)}
+            for krs, people in rosters.items()
+        }
+        totals = {krs: sum(w.values()) for krs, w in weights.items()}
+
+        scores: dict[str, float] = {}
+        for name in population.shortlist:
+            worst = 0.0
+            for post in population.employments.get(name, []):
+                people = rosters.get(post.krs)
+                if not people:
+                    continue
+                others = len(set(people)) - 1
+                captured = totals[post.krs] - weights[post.krs].get(name, 0.0)
+                worst = max(worst, captured / (others + CONFIDENCE_FACTOR))
+            if worst:
+                scores[name] = worst
+
+        print(f"{len(scores)} people sit somewhere with a political board")
+        return scores

--- a/data/scrapers/src/analysis/scores/coappointment.py
+++ b/data/scrapers/src/analysis/scores/coappointment.py
@@ -1,0 +1,76 @@
+"""Who keeps turning up on a board next to the same known faces.
+
+Sharing an employer with somebody the site has confirmed is weak evidence:
+public institutions are large and everybody in local government has passed
+through a few of them. Sharing *two* employers with the same person is a
+different claim. Two people can end up on one board by chance; ending up on the
+board of a spolka komunalna and then, years later, on the supervisory board of
+a different one is a working relationship somebody arranged.
+
+That is the pattern this model looks for, and it is one PageRank blurs. To a
+random walk, two people who share two employers are just two short paths, worth
+about as much as two separate acquaintances who share one each. Here only the
+repeat counts, and a candidate's score is the weight of the confirmed people
+they travel with rather than the number of doors they have been through.
+"""
+
+import collections
+
+from analysis.scores.base import PeopleScoreModel, Population
+from scrapers.stores import Context
+
+#: How many separate companies two people have to have shared before the
+#: overlap says anything. One is a coincidence and there are a great many of
+#: them; two is the whole point of the model.
+MIN_SHARED_COMPANIES = 2
+
+#: Companies bigger than this are ignored when looking for overlap. Two people
+#: who both appear somewhere with a four-figure roster have not met.
+MAX_ROSTER = 200
+
+
+def shared_company_counts(
+    population: Population, name: str, rosters: dict[str, list[str]]
+) -> collections.Counter:
+    """How many companies this person shares with each other person."""
+    shared: collections.Counter = collections.Counter()
+    for post in population.employments.get(name, []):
+        for colleague in rosters.get(post.krs, []):
+            if colleague != name:
+                shared[colleague] += 1
+    return shared
+
+
+class PeopleScoresCoappointment(PeopleScoreModel):
+    filename = "people_scores_coappointment"
+    model_tag = "pipeline-together"
+
+    def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
+        rosters = {
+            krs: people
+            for krs, people in population.roster.items()
+            if len(people) <= MAX_ROSTER
+        }
+        print(
+            f"Looking for repeat overlap across {len(rosters)} companies "
+            f"(dropped {len(population.roster) - len(rosters)} oversized)"
+        )
+
+        seeds = population.seeds()
+        scores: dict[str, float] = {}
+        for name in population.shortlist:
+            companions = 0.0
+            for colleague, count in shared_company_counts(
+                population, name, rosters
+            ).items():
+                weight = seeds.get(colleague)
+                if weight and count >= MIN_SHARED_COMPANIES:
+                    # Weighted by how firm the confirmation is, not by how many
+                    # companies they shared: the second shared board is what
+                    # makes the case, the fourth adds little.
+                    companions += weight
+            if companions:
+                scores[name] = companions
+
+        print(f"{len(scores)} people travel with somebody already confirmed")
+        return scores

--- a/data/scrapers/src/analysis/scores/company.py
+++ b/data/scrapers/src/analysis/scores/company.py
@@ -63,6 +63,7 @@ class CompanyScores(Pipeline):
         # TODO use koryta_ids here instead of people names
         # names could lead to collisions
         scores = {}
+        unknown_targets = 0
 
         for _, row in self.people_scored.read_or_process(ctx).iterrows():
             is_public = row.get("is_public", False)
@@ -74,18 +75,27 @@ class CompanyScores(Pipeline):
 
         for _, row in self.people_votes.read_or_process(ctx).iterrows():
             person_koryta_id = row.get("person_koryta_id")
-            if not person_koryta_id or person_koryta_id == "":
+            if pd.isna(person_koryta_id) or not str(person_koryta_id).strip():
                 continue
             person_koryta_id = str(person_koryta_id)
             interesting = row.get("interesting", 0)
 
+            # A vote can name a node this pipeline has no person for - a place,
+            # or somebody deleted since the export - and that is the vote being
+            # uninteresting here, not an error worth stopping a run over.
+            name = koryta_id_to_name.get(person_koryta_id)
+            if name is None:
+                unknown_targets += 1
+                continue
+
             # TODO we're overriding votes of multiple people right now
-            name = koryta_id_to_name[person_koryta_id]
             current = scores.get(name, None)
             if current is not None:
                 scores[name] = max(interesting, current)
             scores[name] = interesting
 
+        if unknown_targets:
+            print(f"Ignored {unknown_targets} votes on nodes that are not people")
         return scores
 
     def process(self, ctx: Context):

--- a/data/scrapers/src/analysis/scores/company.py
+++ b/data/scrapers/src/analysis/scores/company.py
@@ -1,4 +1,5 @@
-"""
+"""The model the site started with: a person is as interesting as their employers.
+
 We have source of truth from two sources:
 node_id -> public - from KorytaPeople
 node_id -> interesting - from KorytaVotes
@@ -18,11 +19,10 @@ import dataclasses
 import pandas as pd
 
 from analysis.payloads.person import PeoplePayloads
-from entities.composite import PersonScore
+from analysis.scores.base import IS_PUBLIC_SCORE, PeopleScoreModel, Population
 from scrapers.koryta.download import KorytaPeople, KorytaVotes
 from scrapers.stores import Context, Pipeline
 
-IS_PUBLIC_SCORE = 3
 # Penalize companies with not enough votes
 CONFIDENCE_FACTOR = 2
 
@@ -134,76 +134,42 @@ class CompanyScores(Pipeline):
         return scores_df
 
 
-class PeopleScores(Pipeline):
+class PeopleScores(PeopleScoreModel):
+    """A person's employers' ratings, plus how often they have stood for office.
+
+    The site's first model, and still the default one: its votes are the ones
+    stored under the bare `pipeline` uid, which is why the tag is not renamed
+    to match the others. Renaming it would orphan every score already on the
+    site behind a uid nothing writes to any more.
+    """
+
     filename = "people_scores"
+    model_tag = "pipeline"
 
     company_scores: CompanyScores
-    people_payloads: PeoplePayloads
-    people_koryta: KorytaPeople
 
-    # TODO turn it into a flag
-    # Don't produce scores for people who are already public
-    ignore_public = True
-    # Don't produce scores for people who have votes
-    ignore_votes = True
+    #: How much of the verdict each half carries. Employers dominate because
+    #: standing for office is common and public; being on the board of a
+    #: company whose other board members are known is not.
+    COMPANY_WEIGHT = 0.6
+    ELECTION_WEIGHT = 0.4
 
-    def process(self, ctx: Context):
+    def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
         company_scores_df = self.company_scores.read_or_process(ctx)
-        people_df = self.people_payloads.read_or_process(ctx)
-        koryta_people_df = self.people_koryta.read_or_process(ctx)
-        print(koryta_people_df.head())
-
         company_score_map = dict(
             zip(company_scores_df["krs"], company_scores_df["sum_score"])
         )
-        name_to_node_id: dict[str, str] = dict(
-            zip(koryta_people_df["full_name"], koryta_people_df["id"])
-        )
 
-        records = []
-        for _, row in people_df.iterrows():
-            person_name = str(row.get("name"))
-            node_id = name_to_node_id.get(person_name)
-            if node_id is None:
-                continue
-            koryta_entry = koryta_people_df[koryta_people_df["id"] == node_id].iloc[0]
-            if self.ignore_public and koryta_entry.get("is_public", False):
-                continue
-            if self.ignore_votes and koryta_entry.get("votes_interesting", 0) > 0:
-                continue
-
-            company_score = self.total_company_score(row, company_score_map)
-            election_score = self.elections_score(row)
-            total_score = self.calculate_weighted(
-                (company_score, 0.6), (election_score, 0.4)
+        scores = {}
+        for name in population.shortlist:
+            posts = population.employments.get(name, [])
+            company_score = self.total_company_score(posts, company_score_map)
+            election_score = self.elections_score(population.candidacies.get(name, []))
+            scores[name] = self.calculate_weighted(
+                (company_score, self.COMPANY_WEIGHT),
+                (election_score, self.ELECTION_WEIGHT),
             )
-
-            if total_score >= 0:
-                records.append(
-                    dataclasses.asdict(
-                        PersonScore(
-                            node_id=node_id,
-                            name=str(person_name),
-                            score=total_score,
-                        )
-                    )
-                )
-
-        if not records:
-            return pd.DataFrame(columns=["node_id", "name", "score"])
-        print("Found scores for", len(records), "people")
-
-        df = pd.DataFrame.from_records(records)
-        df = df.sort_values(by="score", ascending=False).reset_index(drop=True)
-        # df["score"] = pd.qcut(df["score"].rank(method="first"), q=6, labels=False)
-        df["score"] *= 5 / df["score"].max()
-        df["score"] = df["score"].round(0)
-        print(df.head())
-
-        print(df["score"].describe())
-        print(df["score"].value_counts())
-
-        return df.astype({"score": "int32"})
+        return scores
 
     def calculate_weighted(self, *args: tuple[float, float]):
         result: float = 0
@@ -214,29 +180,14 @@ class PeopleScores(Pipeline):
             weights += weight
         return result / weights
 
-    def total_company_score(self, row, company_score_map):
-        companies = row.get("companies", [])
+    def total_company_score(self, posts, company_score_map):
+        if not posts:
+            return 0.0
         total_person_score: float = 0
+        for post in posts:
+            if post.krs in company_score_map:
+                total_person_score += company_score_map[post.krs]
+        return total_person_score / len(posts)
 
-        if (
-            isinstance(companies, list)
-            or isinstance(companies, pd.Series)
-            or hasattr(companies, "__iter__")
-        ):
-            for company in companies:
-                krs = None
-                if isinstance(company, dict):
-                    krs = company.get("krs")
-                else:
-                    krs = getattr(company, "krs", None)
-
-                if krs and krs in company_score_map:
-                    total_person_score += company_score_map[krs]
-
-            total_person_score /= len(companies)
-
-        return total_person_score
-
-    def elections_score(self, row):
-        elections = row.get("elections", [])
-        return 1 - (2 / 3) ** len(elections)
+    def elections_score(self, candidacies):
+        return 1 - (2 / 3) ** len(candidacies)

--- a/data/scrapers/src/analysis/scores/pagerank.py
+++ b/data/scrapers/src/analysis/scores/pagerank.py
@@ -1,0 +1,148 @@
+"""Who sits close, in the employment graph, to people we already found.
+
+The model the site started with spreads a person's rating to their companies
+and back out to everybody else on those boards - one hop, then stop. That finds
+the colleagues of a known face and nothing beyond them, and it treats a seat on
+a 400-person supervisory body as the same evidence as a seat on a board of
+three.
+
+Personalised PageRank is the same idea without the one-hop cut-off. A random
+walker starts at somebody the site has already confirmed, walks person ->
+company -> person -> company for as long as it likes, and teleports back to a
+confirmed person with probability 1 - alpha. The score is how much of its time
+it spends on each candidate: high for someone two or three well-chosen steps
+from several known faces, low for someone whose only tie runs through an
+institution that employs half the voivodeship, because a walker leaving a
+400-person board is unlikely to pick you.
+
+Downvotes are used too. A second walk seeded on the people humans rated
+negative measures the same proximity to the known-uninteresting, and it is
+subtracted: whole categories of company (a big employer everyone in town has
+passed through) attract both walks, and the difference is what is left after
+that cancels out.
+"""
+
+import networkx as nx
+
+from analysis.scores.base import PeopleScoreModel, Population
+from scrapers.stores import Context
+
+#: Teleport probability is 1 - alpha. The usual 0.85 lets a walk run about six
+#: hops, which is two or three person-to-person steps.
+ALPHA = 0.85
+
+#: How much a shared employer counts for. The unit the other weights are in.
+EMPLOYMENT_EDGE_WEIGHT = 1.0
+
+#: How much having stood for the same committee counts for. Well below an
+#: employer on purpose: two people on the same board of five have something to
+#: explain, two people on the same party's list in different towns have not.
+POLITICAL_EDGE_WEIGHT = 0.25
+
+#: How much of the proximity-to-downvoted walk to subtract. Below 1 because
+#: there are far fewer downvotes than confirmations, so its scores are noisier.
+NEGATIVE_WEIGHT = 0.5
+
+#: Boards past this size are dropped rather than down-weighted. PageRank
+#: already discounts a hub, but a register entry listing thousands of people is
+#: a scraping artefact rather than a board, and it makes the graph much denser
+#: for nothing.
+MAX_ROSTER = 500
+
+
+def person_node(name: str) -> str:
+    return f"p:{name}"
+
+
+def company_node(krs: str) -> str:
+    return f"c:{krs}"
+
+
+def political_node(group: str) -> str:
+    return f"g:{group}"
+
+
+def build_graph(population: Population) -> nx.DiGraph:
+    """The graph the walk runs on: people joined by employers and committees.
+
+    Directed with both directions present rather than undirected, because
+    `nx.pagerank` needs to be able to walk back out of a company and the two
+    directions do not have to carry the same weight if that ever changes.
+    """
+    graph: nx.DiGraph = nx.DiGraph()
+
+    oversized = {
+        krs for krs, people in population.roster.items() if len(people) > MAX_ROSTER
+    }
+    if oversized:
+        print(f"Skipping {len(oversized)} companies with more than {MAX_ROSTER} people")
+
+    for name, posts in population.employments.items():
+        person = person_node(name)
+        for post in posts:
+            if post.krs in oversized:
+                continue
+            company = company_node(post.krs)
+            graph.add_edge(person, company, weight=EMPLOYMENT_EDGE_WEIGHT)
+            graph.add_edge(company, person, weight=EMPLOYMENT_EDGE_WEIGHT)
+
+    for name, candidacies in population.candidacies.items():
+        person = person_node(name)
+        for candidacy in candidacies:
+            group = candidacy.committee or candidacy.party
+            if not group:
+                continue
+            node = political_node(group)
+            graph.add_edge(person, node, weight=POLITICAL_EDGE_WEIGHT)
+            graph.add_edge(node, person, weight=POLITICAL_EDGE_WEIGHT)
+
+    return graph
+
+
+def walk_from(graph: nx.DiGraph, seeds: dict[str, float]) -> dict[str, float]:
+    """Personalised PageRank teleporting back to `seeds`, or nothing if none.
+
+    Seeds the graph does not contain are dropped: the payload run this model
+    sees may not cover everybody the site has published.
+    """
+    personalization = {
+        person_node(name): weight
+        for name, weight in seeds.items()
+        if graph.has_node(person_node(name))
+    }
+    if not personalization:
+        return {}
+
+    return nx.pagerank(
+        graph,
+        alpha=ALPHA,
+        personalization=personalization,
+        nstart=personalization,
+        weight="weight",
+    )
+
+
+class PeopleScoresPageRank(PeopleScoreModel):
+    filename = "people_scores_pagerank"
+    model_tag = "pipeline-pagerank"
+
+    def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
+        graph = build_graph(population)
+        print(
+            f"Graph: {graph.number_of_nodes()} nodes, {graph.number_of_edges()} edges"
+        )
+
+        confirmed = walk_from(graph, population.seeds())
+        if not confirmed:
+            print("No confirmed person is in the graph, so there is nothing to walk")
+            return {}
+
+        rejected = walk_from(graph, population.seeds(-1))
+        if rejected:
+            print(f"Subtracting proximity to {len(population.seeds(-1))} downvoted")
+
+        return {
+            name: confirmed.get(person_node(name), 0.0)
+            - NEGATIVE_WEIGHT * rejected.get(person_node(name), 0.0)
+            for name in population.shortlist
+        }

--- a/data/scrapers/src/analysis/scores/turnover.py
+++ b/data/scrapers/src/analysis/scores/turnover.py
@@ -1,0 +1,112 @@
+"""Who took a post just after an election they stood in.
+
+The other models ask who a person is near. This one asks what happened to them,
+and it is the only one that looks at the mechanism the site is actually about:
+somebody runs on a committee's list, that committee takes the gmina, and a few
+months later the same person turns up on the board of a company the gmina owns.
+Each of those facts is unremarkable alone. In that order, in that region, they
+are the thing.
+
+The evidence is deliberately layered rather than filtered, because each layer
+is separately incomplete. PKW records the year of a candidacy but not the day,
+so timing can only mean "the election year or the one after". A candidacy's
+teryt and a company's teryt are both often missing or recorded at different
+depths, so the region match is a prefix comparison that abstains when either
+side is silent. And whether a company is public-sector is knowable for only
+some of the register - `is_public` being false mostly means nobody could tell -
+so it adds a point rather than deciding the question. An appointment that
+clears all three is worth four times one that only happened to be well timed.
+"""
+
+from analysis.scores.base import PeopleScoreModel, Population
+from scrapers.stores import Context
+
+#: How many years after an election an appointment still counts as following
+#: it. Polish local elections are held in the autumn and the new council seats
+#: its people over the following months, so the year after is where most of
+#: them land.
+YEARS_AFTER_ELECTION = 1
+
+#: What a well-timed appointment is worth before the other two layers.
+TIMING_POINTS = 1.0
+#: Added when the company sits in the region the candidacy was run in.
+REGION_POINTS = 1.0
+#: Added when the register confirms the company is public-sector.
+PUBLIC_POINTS = 2.0
+
+
+def year_of(value: str | None) -> int | None:
+    """The year in a date or year string, or None if it does not hold one."""
+    if not value:
+        return None
+    text = str(value).strip()[:4]
+    return int(text) if text.isdigit() else None
+
+
+def same_region(candidacy_teryt: str | None, company_teryt: str | None) -> bool:
+    """Whether a candidacy and a company are in the same place.
+
+    TERYT codes nest, and the two sides are recorded at different depths - a
+    candidacy for a sejmik carries two digits, a company carries the powiat's
+    four - so either being a prefix of the other means the smaller sits inside
+    the larger. Neither being known is not a match; it is an abstention, and
+    the caller scores it as such.
+    """
+    if not candidacy_teryt or not company_teryt:
+        return False
+    return candidacy_teryt.startswith(company_teryt) or company_teryt.startswith(
+        candidacy_teryt
+    )
+
+
+class PeopleScoresTurnover(PeopleScoreModel):
+    filename = "people_scores_turnover"
+    model_tag = "pipeline-turnover"
+
+    def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
+        scores: dict[str, float] = {}
+        matched_appointments = 0
+
+        for name in population.shortlist:
+            candidacies = population.candidacies.get(name, [])
+            if not candidacies:
+                continue
+
+            total = 0.0
+            for post in population.employments.get(name, []):
+                started = year_of(post.start)
+                if started is None:
+                    continue
+                company = population.companies.get(post.krs)
+                company_teryt = company.teryt if company else None
+
+                # One appointment, scored once, on whichever candidacy explains
+                # it best. Somebody who stood three times in the same year has
+                # not taken the job three times.
+                best = 0.0
+                for candidacy in candidacies:
+                    stood = year_of(candidacy.year)
+                    if stood is None:
+                        continue
+                    if not stood <= started <= stood + YEARS_AFTER_ELECTION:
+                        continue
+
+                    points = TIMING_POINTS
+                    if same_region(candidacy.teryt, company_teryt):
+                        points += REGION_POINTS
+                    if company and company.is_public:
+                        points += PUBLIC_POINTS
+                    best = max(best, points)
+
+                if best:
+                    matched_appointments += 1
+                    total += best
+
+            if total:
+                scores[name] = total
+
+        print(
+            f"{matched_appointments} appointments followed an election the person "
+            f"stood in, across {len(scores)} people"
+        )
+        return scores

--- a/data/scrapers/src/analysis/tests/test_scores.py
+++ b/data/scrapers/src/analysis/tests/test_scores.py
@@ -1,0 +1,420 @@
+"""The scoring models, and the shared rules about who is worth scoring."""
+
+import pandas as pd
+import pytest
+
+from analysis.scores import (
+    PeopleScoresCapture,
+    PeopleScoresCoappointment,
+    PeopleScoresPageRank,
+    PeopleScoresTurnover,
+)
+from analysis.scores.base import (
+    Candidacy,
+    CompanyFacts,
+    Employment,
+    PeopleScoreModel,
+    Population,
+    banded_scores,
+)
+from analysis.scores.turnover import same_region, year_of
+from entities.person import is_pipeline_uid
+from scrapers.stores import Pipeline
+
+
+def population(
+    employments: dict[str, list[tuple]],
+    candidacies: dict[str, list[Candidacy]] | None = None,
+    seeds: dict[str, float] | None = None,
+    shortlist: list[str] | None = None,
+    companies: dict[str, CompanyFacts] | None = None,
+) -> Population:
+    """A population built from `{name: [(krs, start), ...]}` and its seeds."""
+    posts = {
+        name: [
+            Employment(krs=krs, role=None, start=start, end=None) for krs, start in v
+        ]
+        for name, v in employments.items()
+    }
+    roster: dict[str, list[str]] = {}
+    for name, people_posts in posts.items():
+        for post in people_posts:
+            roster.setdefault(post.krs, []).append(name)
+
+    seeds = seeds or {}
+    return Population(
+        people=pd.DataFrame(),
+        node_ids={name: f"node-{name}" for name in posts},
+        employments=posts,
+        candidacies={name: (candidacies or {}).get(name, []) for name in posts},
+        roster=roster,
+        companies=companies or {},
+        seed_weights=seeds,
+        shortlist=shortlist
+        if shortlist is not None
+        else [name for name in posts if name not in seeds],
+    )
+
+
+def model(model_type):
+    """A model with its sources present but unread."""
+    return Pipeline.create(model_type)
+
+
+class TestBandedScores:
+    def test_drops_people_the_model_said_nothing_about(self):
+        assert banded_scores({"a": 0.0, "b": -1.0}) == {}
+
+    def test_bands_by_rank_not_by_value(self):
+        # One outlier three orders of magnitude above the rest must not push
+        # everybody else to the bottom band - which is what scaling by the
+        # maximum did, and what PageRank output would do to it every run.
+        raw = {f"p{i}": float(i) for i in range(1, 101)}
+        raw["outlier"] = 1_000_000.0
+
+        bands = banded_scores(raw)
+
+        assert bands["outlier"] == 5
+        assert bands["p100"] == 5
+        assert bands["p90"] == 3
+        assert bands["p1"] == 1
+
+    def test_a_lone_score_lands_in_the_top_band(self):
+        assert banded_scores({"a": 0.001}) == {"a": 5}
+
+
+class TestPopulation:
+    """Who a model is allowed to have an opinion about."""
+
+    def build(self, koryta_rows, vote_rows=(), payload_rows=None):
+        scorer = model(PeopleScoresCapture)
+        payloads = pd.DataFrame.from_records(
+            payload_rows
+            if payload_rows is not None
+            else [
+                {"name": row["full_name"], "companies": [{"krs": "1"}], "elections": []}
+                for row in koryta_rows
+            ]
+        )
+        scorer.people_payloads.read_or_process = lambda ctx: payloads
+        scorer.people_koryta.read_or_process = lambda ctx: pd.DataFrame.from_records(
+            koryta_rows
+        )
+        scorer.people_votes.read_or_process = lambda ctx: pd.DataFrame.from_records(
+            list(vote_rows)
+        )
+        scorer.companies_krs.read_or_process = lambda ctx: pd.DataFrame()
+        return scorer.population(None)
+
+    def test_a_published_person_is_a_seed_not_a_candidate(self):
+        result = self.build(
+            [{"id": "n1", "full_name": "Anna", "is_public": True, "parties": []}]
+        )
+
+        assert result.seed_weights["Anna"] > 0
+        assert result.shortlist == []
+
+    def test_a_human_vote_takes_somebody_off_the_shortlist(self):
+        result = self.build(
+            [{"id": "n1", "full_name": "Anna", "is_public": False, "parties": []}],
+            [{"person_koryta_id": "n1", "interesting": 4}],
+        )
+
+        assert result.seed_weights["Anna"] == 4
+        assert result.shortlist == []
+
+    def test_a_downvote_seeds_the_other_way(self):
+        result = self.build(
+            [{"id": "n1", "full_name": "Anna", "is_public": False, "parties": []}],
+            [{"person_koryta_id": "n1", "interesting": -3}],
+        )
+
+        assert result.seeds() == {}
+        assert result.seeds(-1) == {"Anna": 3}
+
+    def test_the_pipelines_own_score_does_not_retire_a_candidate(self):
+        # `votes_interesting` is the site's aggregate and includes whatever the
+        # pipeline last wrote. Reading it as evidence of human review would
+        # mean no run after the first could ever revise its own score.
+        result = self.build(
+            [
+                {
+                    "id": "n1",
+                    "full_name": "Anna",
+                    "is_public": False,
+                    "parties": [],
+                    "votes_interesting": 5,
+                }
+            ]
+        )
+
+        assert result.shortlist == ["Anna"]
+        assert result.seed_weights == {}
+
+    def test_somebody_with_no_payload_is_not_scorable(self):
+        # The payload run is region-scoped, so the site knows people this model
+        # cannot see. Voting on them would be voting on nothing.
+        result = self.build(
+            [{"id": "n1", "full_name": "Anna", "is_public": False, "parties": []}],
+            payload_rows=[],
+        )
+
+        assert result.shortlist == []
+
+
+class TestPageRank:
+    def test_a_colleague_of_a_known_face_outranks_a_stranger(self):
+        pop = population(
+            {
+                "Seed": [("1", None)],
+                "Colleague": [("1", None)],
+                "Stranger": [("2", None)],
+            },
+            seeds={"Seed": 3},
+        )
+
+        scores = model(PeopleScoresPageRank).raw_scores(None, pop)
+
+        assert scores["Colleague"] > scores["Stranger"]
+
+    def test_a_seat_on_a_crowded_board_says_less(self):
+        crowd = {f"Crowd{i}": [("big", None)] for i in range(50)}
+        pop = population(
+            {
+                "Seed": [("small", None), ("big", None)],
+                "Close": [("small", None)],
+                **crowd,
+            },
+            seeds={"Seed": 3},
+        )
+
+        scores = model(PeopleScoresPageRank).raw_scores(None, pop)
+
+        assert scores["Close"] > scores["Crowd0"]
+
+    def test_proximity_to_the_downvoted_is_subtracted(self):
+        pop = population(
+            {
+                "Seed": [("1", None)],
+                "Clean": [("1", None)],
+                "Tainted": [("1", None), ("2", None)],
+                "Rejected": [("2", None)],
+            },
+            seeds={"Seed": 3, "Rejected": -3},
+        )
+
+        scores = model(PeopleScoresPageRank).raw_scores(None, pop)
+
+        assert scores["Clean"] > scores["Tainted"]
+
+    def test_nothing_to_walk_from_is_not_an_error(self):
+        pop = population({"Anna": [("1", None)]})
+
+        assert model(PeopleScoresPageRank).raw_scores(None, pop) == {}
+
+
+class TestCoappointment:
+    def test_one_shared_board_is_a_coincidence(self):
+        pop = population(
+            {"Seed": [("1", None)], "Once": [("1", None)]},
+            seeds={"Seed": 3},
+        )
+
+        assert model(PeopleScoresCoappointment).raw_scores(None, pop) == {}
+
+    def test_following_somebody_between_two_companies_is_not(self):
+        pop = population(
+            {
+                "Seed": [("1", None), ("2", None)],
+                "Twice": [("1", None), ("2", None)],
+                "Once": [("1", None)],
+            },
+            seeds={"Seed": 3},
+        )
+
+        scores = model(PeopleScoresCoappointment).raw_scores(None, pop)
+
+        assert set(scores) == {"Twice"}
+        assert scores["Twice"] == 3
+
+    def test_travelling_with_two_known_faces_beats_travelling_with_one(self):
+        pop = population(
+            {
+                "SeedA": [("1", None), ("2", None)],
+                "SeedB": [("1", None), ("2", None)],
+                "Both": [("1", None), ("2", None)],
+                "One": [("1", None), ("3", None)],
+                "Lone": [("3", None)],
+            },
+            seeds={"SeedA": 3, "SeedB": 3},
+        )
+        pop.employments["Lone"] = [
+            Employment(krs="1", role=None, start=None, end=None),
+            Employment(krs="3", role=None, start=None, end=None),
+        ]
+
+        scores = model(PeopleScoresCoappointment).raw_scores(None, pop)
+
+        assert scores["Both"] == 6
+        assert "One" not in scores
+
+
+class TestTurnover:
+    def test_reads_a_year_out_of_either_shape_it_arrives_in(self):
+        assert year_of("2018-10-21") == 2018
+        assert year_of("2018") == 2018
+        assert year_of(None) is None
+        assert year_of("brak") is None
+
+    def test_a_region_is_matched_at_whichever_depth_is_recorded(self):
+        assert same_region("14", "1465")
+        assert same_region("1465", "14")
+        assert not same_region("14", "24")
+        # Neither side saying anything is an abstention, not a match.
+        assert not same_region(None, "1465")
+
+    def build(self, employments, candidacies, companies=None):
+        return population(
+            employments,
+            candidacies=candidacies,
+            seeds={},
+            companies=companies or {},
+        )
+
+    def test_a_post_taken_up_after_the_election_counts(self):
+        pop = self.build(
+            {"Anna": [("1", "2019-03-01")]},
+            {"Anna": [Candidacy(year="2018", teryt="14", party=None, committee=None)]},
+        )
+
+        scores = model(PeopleScoresTurnover).raw_scores(None, pop)
+
+        assert scores == {"Anna": 1.0}
+
+    def test_a_post_taken_up_years_later_does_not(self):
+        pop = self.build(
+            {"Anna": [("1", "2023-03-01")]},
+            {"Anna": [Candidacy(year="2018", teryt="14", party=None, committee=None)]},
+        )
+
+        assert model(PeopleScoresTurnover).raw_scores(None, pop) == {}
+
+    def test_the_same_region_and_a_public_company_each_add_to_it(self):
+        pop = self.build(
+            {"Anna": [("1", "2019-03-01")]},
+            {"Anna": [Candidacy(year="2018", teryt="14", party=None, committee=None)]},
+            companies={
+                "1": CompanyFacts(name="Gmina sp.", teryt="1465", is_public=True)
+            },
+        )
+
+        scores = model(PeopleScoresTurnover).raw_scores(None, pop)
+
+        assert scores == {"Anna": 4.0}
+
+    def test_standing_three_times_in_a_year_is_still_one_appointment(self):
+        pop = self.build(
+            {"Anna": [("1", "2018-12-01")]},
+            {
+                "Anna": [
+                    Candidacy(year="2018", teryt="14", party=None, committee=None),
+                    Candidacy(year="2018", teryt="14", party=None, committee=None),
+                    Candidacy(year="2018", teryt="24", party=None, committee=None),
+                ]
+            },
+        )
+
+        assert model(PeopleScoresTurnover).raw_scores(None, pop) == {"Anna": 1.0}
+
+    def test_somebody_who_never_stood_is_not_this_models_business(self):
+        pop = self.build({"Anna": [("1", "2019-03-01")]}, {})
+
+        assert model(PeopleScoresTurnover).raw_scores(None, pop) == {}
+
+
+class TestCapture:
+    def stood(self, *names):
+        return {
+            name: [Candidacy(year="2018", teryt=None, party=None, committee=None)]
+            for name in names
+        }
+
+    def test_a_board_of_former_candidates_lifts_the_newcomer(self):
+        pop = population(
+            {
+                "Newcomer": [("captured", None)],
+                "ExA": [("captured", None)],
+                "ExB": [("captured", None)],
+                "ExC": [("captured", None)],
+                "Quiet": [("ordinary", None)],
+                "Nobody": [("ordinary", None)],
+            },
+            candidacies=self.stood("ExA", "ExB", "ExC"),
+        )
+
+        scores = model(PeopleScoresCapture).raw_scores(None, pop)
+
+        assert scores["Newcomer"] > 0
+        assert "Quiet" not in scores
+
+    def test_a_candidate_does_not_capture_their_own_board(self):
+        # The only political thing about this board is Alone. Alone knowing
+        # that about themselves is not a finding; Ordinary sitting next to them
+        # is the one this model has something to say about.
+        pop = population(
+            {"Alone": [("1", None)], "Ordinary": [("1", None)]},
+            candidacies=self.stood("Alone"),
+        )
+
+        scores = model(PeopleScoresCapture).raw_scores(None, pop)
+
+        assert "Alone" not in scores
+        assert scores["Ordinary"] > 0
+
+    def test_a_small_board_cannot_reach_the_top_on_one_colleague(self):
+        small = population(
+            {"Anna": [("s", None)], "Ex": [("s", None)]},
+            candidacies=self.stood("Ex"),
+        )
+        big = population(
+            {
+                "Anna": [("b", None)],
+                **{f"Ex{i}": [("b", None)] for i in range(9)},
+            },
+            candidacies=self.stood(*[f"Ex{i}" for i in range(9)]),
+        )
+
+        anna_small = model(PeopleScoresCapture).raw_scores(None, small)["Anna"]
+        anna_big = model(PeopleScoresCapture).raw_scores(None, big)["Anna"]
+
+        assert anna_small < anna_big
+
+
+class TestPipelineUid:
+    @pytest.mark.parametrize(
+        "uid, expected",
+        [
+            ("pipeline", True),
+            ("pipeline-pagerank", True),
+            ("extraction-pipeline-v2", True),
+            ("aB3xYz", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_matches_the_frontends_rule(self, uid, expected):
+        assert is_pipeline_uid(uid) is expected
+
+
+def test_every_model_votes_under_a_uid_the_site_reads_as_a_robot():
+    tags = set()
+    for model_type in (
+        PeopleScoresPageRank,
+        PeopleScoresCoappointment,
+        PeopleScoresTurnover,
+        PeopleScoresCapture,
+    ):
+        assert issubclass(model_type, PeopleScoreModel)
+        assert is_pipeline_uid(model_type.model_tag)
+        tags.add(model_type.model_tag)
+    assert len(tags) == 4

--- a/data/scrapers/src/analysis/tests/test_scores.py
+++ b/data/scrapers/src/analysis/tests/test_scores.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from analysis.scores import (
+    CompanyScores,
     PeopleScoresCapture,
     PeopleScoresCoappointment,
     PeopleScoresPageRank,
@@ -151,6 +152,23 @@ class TestPopulation:
         assert result.shortlist == ["Anna"]
         assert result.seed_weights == {}
 
+    def test_a_vote_with_no_node_on_it_is_not_a_person(self):
+        # A vote on an extracted fact carries `extractionId` and no `nodeId`,
+        # which arrives here as NaN. NaN is truthy and equals nothing, so the
+        # guards that read "skip the blank ones" used to pass it straight
+        # through and `str(nan)` became a person id of "nan".
+        result = self.build(
+            [{"id": "n1", "full_name": "Anna", "is_public": False, "parties": []}],
+            [
+                {"person_koryta_id": float("nan"), "interesting": 5},
+                {"person_koryta_id": None, "interesting": 4},
+                {"person_koryta_id": "", "interesting": 3},
+            ],
+        )
+
+        assert result.shortlist == ["Anna"]
+        assert result.seed_weights == {}
+
     def test_somebody_with_no_payload_is_not_scorable(self):
         # The payload run is region-scoped, so the site knows people this model
         # cannot see. Voting on them would be voting on nothing.
@@ -160,6 +178,54 @@ class TestPopulation:
         )
 
         assert result.shortlist == []
+
+
+class TestCompanyScores:
+    """The votes half of the model the site started with."""
+
+    def person_scores(self, koryta_rows, vote_rows):
+        scorer = Pipeline.create(CompanyScores)
+        scorer.people_scored.read_or_process = lambda ctx: pd.DataFrame.from_records(
+            koryta_rows
+        )
+        scorer.people_votes.read_or_process = lambda ctx: pd.DataFrame.from_records(
+            list(vote_rows)
+        )
+        return scorer.person_scores(
+            None,
+            dict(
+                zip(
+                    [r["id"] for r in koryta_rows],
+                    [r["full_name"] for r in koryta_rows],
+                )
+            ),
+        )
+
+    def test_a_vote_with_no_node_on_it_does_not_stop_the_run(self):
+        # The crash this replaces: NaN survived the blank check, `str(nan)`
+        # became "nan", and the name lookup raised KeyError mid-pipeline.
+        scores = self.person_scores(
+            [{"id": "n1", "full_name": "Anna", "is_public": False}],
+            [
+                {"person_koryta_id": float("nan"), "interesting": 5},
+                {"person_koryta_id": "n1", "interesting": 2},
+            ],
+        )
+
+        assert scores == {"Anna": 2}
+
+    def test_a_vote_on_something_that_is_not_a_person_is_ignored(self):
+        # Places get voted on too, and a node deleted since the export is gone
+        # from the people table while its votes remain.
+        scores = self.person_scores(
+            [{"id": "n1", "full_name": "Anna", "is_public": False}],
+            [
+                {"person_koryta_id": "some-place", "interesting": 5},
+                {"person_koryta_id": "n1", "interesting": 1},
+            ],
+        )
+
+        assert scores == {"Anna": 1}
 
 
 class TestPageRank:

--- a/data/scrapers/src/entities/composite.py
+++ b/data/scrapers/src/entities/composite.py
@@ -61,3 +61,7 @@ class PersonScore:
     node_id: str
     name: str
     score: float
+    # Which model said so, and the `userUid` the vote is stored under. The
+    # default is the tag the first model has always written under, so a score
+    # produced before models had names still uploads where it used to.
+    model: str = "pipeline"

--- a/data/scrapers/src/entities/person.py
+++ b/data/scrapers/src/entities/person.py
@@ -80,6 +80,18 @@ class PersonVote:
     interesting: int | None
 
 
+def is_pipeline_uid(user_uid: str | None) -> bool:
+    """Whether a vote was cast by a scoring model rather than by a person.
+
+    One model per uid - `pipeline`, `pipeline-pagerank` and so on - and the
+    substring is what tells them apart from a Firebase uid, which is 28
+    alphanumeric characters. Kept identical to `isPipelineUid` in
+    `frontend/shared/stats.ts`: the two sides have to agree on what counts as a
+    human vote or the pipeline ends up seeded on its own output.
+    """
+    return bool(user_uid) and "pipeline" in str(user_uid)
+
+
 @dataclass
 class RejestrIOKey:
     """Represents a person from the RejestrIO dataset."""

--- a/data/scrapers/src/koryta.py
+++ b/data/scrapers/src/koryta.py
@@ -60,11 +60,6 @@ def get_args():
         "(also settable via DISABLE_BACKUP in the environment or .env)",
     )
     parser.add_argument(
-        "--all",
-        action="store_true",
-        help="Run every pipeline except ScrapeRejestrIO, which bills per query.",
-    )
-    parser.add_argument(
         "--exclude",
         action="append",
         default=[],
@@ -102,11 +97,6 @@ def select_pipelines(args) -> set[str]:
             f"Available: {' '.join(sorted(pipeline_names))}"
         )
 
-    if args.all:
-        if args.pipeline:
-            raise ValueError("--all runs everything, so it takes no pipeline names")
-        # ScrapeRejestrIO bills per query -- never part of a bulk run.
-        return pipeline_names - {"ScrapeRejestrIO"} - exclude
     if args.pipeline:
         return set(args.pipeline) - exclude
     raise ValueError("No pipeline specified, use koryta PipelineName or --all")

--- a/data/scrapers/src/pipelines.py
+++ b/data/scrapers/src/pipelines.py
@@ -4,7 +4,14 @@ from analysis.graph import CommitteeParties, PeopleParties
 from analysis.interesting import Companies
 from analysis.payloads import CompaniesPayloads, PeoplePayloads, RegionPayloads
 from analysis.people import PeopleEnriched, PeopleMerged
-from analysis.scores import CompanyScores, PeopleScores
+from analysis.scores import (
+    CompanyScores,
+    PeopleScores,
+    PeopleScoresCapture,
+    PeopleScoresCoappointment,
+    PeopleScoresPageRank,
+    PeopleScoresTurnover,
+)
 from analysis.stats import Statistics
 from scrapers.article.pipelines import (
     ArticleAnalyzed,
@@ -45,6 +52,10 @@ PIPELINES = [
     CompaniesPayloads,
     CompanyScores,
     PeopleScores,
+    PeopleScoresCapture,
+    PeopleScoresCoappointment,
+    PeopleScoresPageRank,
+    PeopleScoresTurnover,
     Extract,
     KRSAlreadyScraped,
     KRSCensoredPeople,

--- a/data/scrapers/src/scrapers/koryta/download.py
+++ b/data/scrapers/src/scrapers/koryta/download.py
@@ -19,7 +19,7 @@ from tqdm import tqdm
 
 from entities.company import KorytaCompany
 from entities.person import Koryta as Person
-from entities.person import PersonVote
+from entities.person import PersonVote, is_pipeline_uid
 from scrapers.stores import (
     CloudStorage,
     Context,
@@ -247,8 +247,8 @@ class KorytaVotes(Pipeline[PersonVote]):
 
         outputs = []
         for data in tqdm(df.to_dict(orient="records")):
-            if data["userUid"] == "pipeline":
-                # Skip pipeline's own votes
+            if is_pipeline_uid(data["userUid"]):
+                # Skip the pipeline's own votes, whichever model cast them.
                 continue
             category_votes = data.get("categoryVotes", {})
             if isinstance(category_votes, float):

--- a/data/scrapers/src/scrapers/koryta/download.py
+++ b/data/scrapers/src/scrapers/koryta/download.py
@@ -254,12 +254,17 @@ class KorytaVotes(Pipeline[PersonVote]):
             if isinstance(category_votes, float):
                 # The vote is not matching the format
                 continue
-            person_koryta_id = data["nodeId"]
-            if not person_koryta_id or person_koryta_id == "":
+            # A vote on an extracted fact carries `extractionId` and no
+            # `nodeId`, which pandas turns into a NaN rather than a blank. NaN
+            # is truthy and equals nothing, so testing it the obvious two ways
+            # lets it through, and `str(nan)` then reaches the consumers as a
+            # person id of "nan" that no person has.
+            person_koryta_id = data.get("nodeId")
+            if pd.isna(person_koryta_id) or not str(person_koryta_id).strip():
                 continue
             outputs.append(
                 PersonVote(
-                    person_koryta_id=data["nodeId"],
+                    person_koryta_id=str(person_koryta_id),
                     interesting=category_votes.get("interesting", None),
                 )
             )

--- a/data/scrapers/src/tests/e2e/baseline.json
+++ b/data/scrapers/src/tests/e2e/baseline.json
@@ -56,6 +56,26 @@
       "non_null": {},
       "rows": null
     },
+    "people_scores_capture": {
+      "format": "jsonl",
+      "non_null": {},
+      "rows": null
+    },
+    "people_scores_coappointment": {
+      "format": "jsonl",
+      "non_null": {},
+      "rows": null
+    },
+    "people_scores_pagerank": {
+      "format": "jsonl",
+      "non_null": {},
+      "rows": null
+    },
+    "people_scores_turnover": {
+      "format": "jsonl",
+      "non_null": {},
+      "rows": null
+    },
     "person_krs": {
       "format": "jsonl",
       "non_null": {},

--- a/data/scrapers/src/tests/pipelines/test_invariants.py
+++ b/data/scrapers/src/tests/pipelines/test_invariants.py
@@ -88,7 +88,8 @@ VOTE_CATEGORIES = {"interesting", "quality", "correct", "insufficient"}
 
 EXTRACTION_FACT_TYPES = {"employment", "party_membership", "personal_relation"}
 
-# `computeVoteStats` never counts the pipeline's own votes as human review.
+# `computeVoteStats` never counts the pipeline's own votes as human review, and
+# each scoring model votes under its own uid containing this word.
 PIPELINE_USER = "pipeline"
 
 
@@ -131,14 +132,28 @@ def compute_vote_stats(votes: list[dict]) -> dict:
     A port of `computeVoteStats` in `frontend/shared/stats.ts`, which the
     `onVoteWritten` trigger runs to maintain `stats.votes`. Only the counters and
     the `humanVoted` flag are reproduced; `lastVotedAt` is a formatted timestamp
-    and nothing queries it.
+    and nothing queries it, and `models` is a breakdown rather than a tally.
+
+    Human votes sum and the scoring models contribute only their best, which is
+    what keeps a new model from rescaling a number the site sorts and buckets
+    on. See `computeVoteStats` for why.
     """
     aggregate: dict = {"interesting": 0, "quality": 0, "humanVoted": False}
+    pipeline_best: dict = {}
     for vote in votes:
-        if vote.get("userUid") != PIPELINE_USER:
+        from_pipeline = PIPELINE_USER in str(vote.get("userUid") or "")
+        if not from_pipeline:
             aggregate["humanVoted"] = True
         for category, value in (vote.get("categoryVotes") or {}).items():
-            aggregate[category] = (aggregate.get(category) or 0) + value
+            if from_pipeline:
+                current = pipeline_best.get(category)
+                pipeline_best[category] = (
+                    value if current is None else max(current, value)
+                )
+            else:
+                aggregate[category] = (aggregate.get(category) or 0) + value
+    for category, best in pipeline_best.items():
+        aggregate[category] = (aggregate.get(category) or 0) + best
     return aggregate
 
 
@@ -152,9 +167,10 @@ def stale_aggregates(documents: dict[str, dict], votes_by_target: dict[str, list
         stored = stats_votes(document)
         expected = compute_vote_stats(votes)
         differences = {}
-        # `lastVotedAt` is a formatted timestamp rather than a tally, and the
-        # recomputation deliberately does not reproduce it.
-        for key in set(expected) | (set(stored) - {"lastVotedAt"}):
+        # `lastVotedAt` is a formatted timestamp and `models` a per-model
+        # breakdown, rather than tallies; the recomputation deliberately
+        # reproduces neither.
+        for key in set(expected) | (set(stored) - {"lastVotedAt", "models"}):
             got = stored.get(key)
             want = expected.get(key, 0)
             # A counter that was never written is a zero, not a difference; the

--- a/data/scrapers/src/tests/test_score_upload.py
+++ b/data/scrapers/src/tests/test_score_upload.py
@@ -1,0 +1,194 @@
+"""Uploading a model's shortlist: what gets written, and what gets taken back.
+
+The score path is the one uploader that deletes, so it is the one worth a test.
+"""
+
+import typing
+
+import pytest
+
+from entities.composite import PersonScore
+from uploader import Args, ScoreUploader
+from util.firestore import Firestore
+
+
+class FakeDoc:
+    def __init__(self, doc_id: str, data: dict):
+        self.id = doc_id
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class FakeQuery:
+    def __init__(self, docs: list[FakeDoc]):
+        self._docs = docs
+
+    def stream(self):
+        return iter(self._docs)
+
+
+class FakeCollection:
+    def __init__(self, documents: dict[str, dict]):
+        self.documents = documents
+
+    def where(self, filter=None):  # noqa: A002 - matches the firestore signature
+        _, _, value = filter.field_path, filter.op_string, filter.value
+        return FakeQuery(
+            [
+                FakeDoc(doc_id, data)
+                for doc_id, data in self.documents.items()
+                if data.get("userUid") == value
+            ]
+        )
+
+    def document(self, doc_id: str) -> str:
+        return doc_id
+
+
+class FakeBatch:
+    def __init__(self, collection: FakeCollection, log: list[tuple]):
+        self.collection = collection
+        self.log = log
+        self.pending: list[tuple] = []
+
+    def set(self, ref, data, merge=False):
+        self.pending.append(("set", ref, data))
+
+    def delete(self, ref):
+        self.pending.append(("delete", ref, None))
+
+    def commit(self):
+        for operation, ref, data in self.pending:
+            if operation == "set":
+                self.collection.documents[ref] = data
+            else:
+                self.collection.documents.pop(ref, None)
+            self.log.append((operation, ref))
+        self.pending = []
+
+
+class FakeDb:
+    def __init__(self, documents: dict[str, dict]):
+        self.votes = FakeCollection(documents)
+        self.log: list[tuple] = []
+
+    def collection(self, name: str) -> FakeCollection:
+        assert name == "votes"
+        return self.votes
+
+    def batch(self) -> FakeBatch:
+        return FakeBatch(self.votes, self.log)
+
+
+def stored(node_id: str, model: str, score: int) -> tuple[str, dict]:
+    return (
+        f"{node_id}_{model}",
+        {"nodeId": node_id, "userUid": model, "categoryVotes": {"interesting": score}},
+    )
+
+
+def firestore_with(*documents: tuple[str, dict]) -> Firestore:
+    client = Firestore.__new__(Firestore)
+    client.db = FakeDb(dict(documents))  # type: ignore[assignment]
+    client.user_id = "pipeline"
+    return client
+
+
+def score(node_id: str, value: int, model: str) -> PersonScore:
+    return PersonScore(node_id=node_id, name=node_id, score=value, model=model)
+
+
+class TestReplaceScores:
+    def test_writes_only_what_changed(self):
+        # Every vote written fires the aggregate trigger, so re-stating a score
+        # the model already holds is a Cloud Function invocation that changes
+        # nothing.
+        client = firestore_with(
+            stored("n1", "pipeline-pagerank", 5),
+            stored("n2", "pipeline-pagerank", 2),
+        )
+
+        written, retracted = client.replace_scores(
+            "pipeline-pagerank",
+            [score("n1", 5, "pipeline-pagerank"), score("n2", 4, "pipeline-pagerank")],
+        )
+
+        assert (written, retracted) == (1, 0)
+        assert client.db.log == [("set", "n2_pipeline-pagerank")]  # type: ignore[attr-defined]
+
+    def test_a_person_the_model_dropped_loses_the_score(self):
+        client = firestore_with(stored("gone", "pipeline-turnover", 3))
+
+        written, retracted = client.replace_scores(
+            "pipeline-turnover", [score("kept", 2, "pipeline-turnover")]
+        )
+
+        assert (written, retracted) == (1, 1)
+        assert "gone_pipeline-turnover" not in client.db.votes.documents  # type: ignore[attr-defined]
+
+    def test_another_models_scores_are_not_touched(self):
+        client = firestore_with(
+            stored("n1", "pipeline-pagerank", 5),
+            stored("n1", "pipeline-capture", 1),
+            stored("n1", "aB3xYz", 4),
+        )
+
+        client.replace_scores("pipeline-pagerank", [])
+
+        documents = client.db.votes.documents  # type: ignore[attr-defined]
+        assert "n1_pipeline-pagerank" not in documents
+        assert documents["n1_pipeline-capture"]["categoryVotes"]["interesting"] == 1
+        assert documents["n1_aB3xYz"]["categoryVotes"]["interesting"] == 4
+
+    def test_a_partial_upload_retracts_nothing(self):
+        client = firestore_with(stored("n1", "pipeline", 5))
+
+        written, retracted = client.replace_scores(
+            "pipeline", [score("n2", 3, "pipeline")], retract=False
+        )
+
+        assert (written, retracted) == (1, 0)
+        assert "n1_pipeline" in client.db.votes.documents  # type: ignore[attr-defined]
+
+
+def uploader_with(**overrides) -> ScoreUploader:
+    args = typing.cast(Args, Args())
+    args.model = overrides.get("model")
+    args.limit = overrides.get("limit")
+    args.offset = overrides.get("offset")
+    instance = ScoreUploader.__new__(ScoreUploader)
+    instance.args = args
+    return instance
+
+
+class TestModelOf:
+    def test_takes_the_tag_the_rows_carry(self):
+        uploader = uploader_with()
+
+        assert (
+            uploader.model_of([score("n1", 3, "pipeline-capture")])
+            == "pipeline-capture"
+        )
+
+    def test_refuses_a_run_that_mixes_models(self):
+        # Reconciliation is per model: uploading two at once would retract each
+        # model's scores on behalf of the other.
+        uploader = uploader_with()
+
+        with pytest.raises(ValueError, match="one model per upload"):
+            uploader.model_of(
+                [score("n1", 3, "pipeline-capture"), score("n2", 3, "pipeline")]
+            )
+
+    def test_refuses_a_uid_the_site_would_read_as_a_person(self):
+        uploader = uploader_with(model="pagerank")
+
+        with pytest.raises(ValueError, match="human review"):
+            uploader.model_of([score("n1", 3, "pipeline-pagerank")])
+
+    def test_an_override_wins_over_the_rows(self):
+        uploader = uploader_with(model="pipeline-experiment")
+
+        assert uploader.model_of([score("n1", 3, "pipeline")]) == "pipeline-experiment"

--- a/data/scrapers/src/uploader.py
+++ b/data/scrapers/src/uploader.py
@@ -10,6 +10,8 @@ import requests
 from analysis.interesting import Companies
 from conductor import setup_context
 from entities.company import display_name
+from entities.composite import PersonScore
+from entities.person import is_pipeline_uid
 from scrapers.stores import iterate_pipeline_dict
 from stores.auth import authenticate_user
 from util.firestore import Firestore
@@ -29,6 +31,7 @@ class Args:
     database: str
     limit: int | None
     offset: int | None
+    model: str | None
 
 
 def parse_args() -> Args:
@@ -55,6 +58,13 @@ def parse_args() -> Args:
     )
     parser.add_argument(
         "--prod", action="store_true", help="Production mode (requires token auth)"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        help="For --type score: store the votes under this pipeline uid instead "
+        "of the one the rows carry. The name must contain 'pipeline', which is "
+        "what marks a vote as not cast by a person.",
     )
     args = parser.parse_known_args()[0]
     return args  # type: ignore
@@ -94,6 +104,8 @@ class Uploader:
             return CompanyUploader(args)
         if args.type == "extraction":
             return ExtractionUploader(args)
+        if args.type == "score":
+            return ScoreUploader(args)
         return Uploader(args)
 
     def submit_entity(self, payload) -> requests.Response:
@@ -150,11 +162,7 @@ class Uploader:
                 )
                 continue
 
-            if self.args.type == "score":
-                self.firestore.submit_score(payload)
-                self.success_count += 1
-            else:
-                self.check_success(self.submit_entity(payload))
+            self.check_success(self.submit_entity(payload))
 
         failures = self.total - self.success_count
         print(
@@ -247,6 +255,69 @@ class PersonUploader(CompanyUploader):
             return self.submit_payload(current_target_url, payload, fail=False)
         else:
             return resp
+
+
+class ScoreUploader(Uploader):
+    """Uploads one scoring model's shortlist of people worth a look.
+
+    Scores go straight to Firestore rather than through the API: they are the
+    pipeline's own opinion rather than a fact about a person, and they are
+    stored as votes so that the site's existing aggregate does the combining.
+    Each model votes under its own uid, so uploading one model never touches
+    another's scores.
+
+    Unlike the per-entity uploaders this writes the whole run at once, because
+    what to write can only be decided against what the model wrote last time -
+    see `Firestore.replace_scores`.
+    """
+
+    @typing.override
+    def submit_results(self, entities):
+        rows = [PersonScore(**e) for e in entities if e is not None]
+        if not rows:
+            print("No scores to upload.", file=sys.stderr)
+            return
+
+        model = self.model_of(rows)
+        # Only part of the run reached us, so a person missing from it may
+        # simply have been cut off rather than dropped by the model.
+        partial = bool(self.args.limit or self.args.offset)
+        written, retracted = self.firestore.replace_scores(
+            model, rows, retract=not partial
+        )
+
+        self.total = len(rows)
+        self.success_count = len(rows)
+        print(
+            f"\nUpload complete. Model: {model}, written: {written}, "
+            f"retracted: {retracted}, unchanged: {len(rows) - written}",
+            file=sys.stderr,
+        )
+
+    def model_of(self, rows: list[PersonScore]) -> str:
+        """The uid to store this run under, and a check that it is a robot's.
+
+        A vote whose uid does not read as the pipeline's would be counted as
+        human review by the frontend, which would mark thousands of people as
+        looked at by somebody when nobody has looked at them.
+        """
+        if self.args.model:
+            model = self.args.model
+        else:
+            models = {row.model for row in rows}
+            if len(models) != 1:
+                raise ValueError(
+                    f"Expected one model per upload, got {sorted(models)}. "
+                    "Upload each model's scores separately, or pass --model."
+                )
+            model = models.pop()
+
+        if not is_pipeline_uid(model):
+            raise ValueError(
+                f"Model uid {model!r} does not contain 'pipeline', so the site "
+                "would count its votes as human review."
+            )
+        return model
 
 
 class ExtractionUploader(Uploader):

--- a/data/scrapers/src/util/firestore.py
+++ b/data/scrapers/src/util/firestore.py
@@ -7,6 +7,9 @@ from firebase_admin import firestore
 
 from entities.composite import PersonScore
 
+#: Firestore takes at most 500 operations in one batch.
+BATCH_LIMIT = 500
+
 
 class Firestore:
     def __init__(self, args):
@@ -39,7 +42,29 @@ class Firestore:
         self.db = firestore.client(app=app, database_id=database_id)
         self.user_id = "pipeline"
 
+    def vote_id(self, node_id: str, user_uid: str) -> str:
+        return f"{node_id}_{user_uid}"
+
+    def existing_scores(self, model: str) -> dict[str, int]:
+        """Node id -> the score this model last wrote, for the whole model.
+
+        One equality query on `userUid`, which the automatic single-field index
+        covers, and it returns only this model's own documents.
+        """
+        existing = {}
+        query = self.db.collection("votes").where(
+            filter=firestore.FieldFilter("userUid", "==", model)
+        )
+        for doc in query.stream():
+            data = doc.to_dict() or {}
+            node_id = data.get("nodeId")
+            interesting = (data.get("categoryVotes") or {}).get("interesting")
+            if node_id and interesting is not None:
+                existing[node_id] = interesting
+        return existing
+
     def submit_score(self, p: dict | PersonScore):
+        """Write one model's rating of one person."""
         if isinstance(p, dict):
             p = PersonScore(**p)
 
@@ -49,13 +74,83 @@ class Firestore:
             file=sys.stderr,
         )
 
-        doc_ref = self.db.collection("votes").document(f"{p.node_id}_{self.user_id}")
+        doc_ref = self.db.collection("votes").document(
+            self.vote_id(p.node_id, p.model or self.user_id)
+        )
         doc_ref.set(
             {
                 "nodeId": p.node_id,
-                "userUid": self.user_id,
+                "userUid": p.model or self.user_id,
                 "categoryVotes": {"interesting": p.score},
             },
             merge=True,
         )
         print(f"  OK: {doc_ref.id}", file=sys.stderr)
+
+    def replace_scores(
+        self, model: str, scores: list[PersonScore], retract: bool = True
+    ) -> tuple[int, int]:
+        """Make this model's stored opinion match the run that just finished.
+
+        Written as a diff against what the model wrote last time rather than as
+        a blind overwrite, for two reasons. Every vote document written fires
+        `onVoteWritten`, which re-reads every vote on that node and rewrites the
+        node's aggregate, so a run that re-states 40k unchanged scores costs 40k
+        function invocations to change nothing. And a person the model no longer
+        rates has to lose the score rather than keep a stale one - deleting the
+        document says "this model has no opinion", which is what the site should
+        show, whereas writing a zero leaves a vote nobody cast.
+
+        `retract` is off when the caller only uploaded part of the run: a
+        partial upload cannot tell a dropped score from one that was never sent.
+        """
+        existing = self.existing_scores(model)
+        wanted = {s.node_id: s for s in scores}
+
+        changed = [
+            s for node_id, s in wanted.items() if existing.get(node_id) != s.score
+        ]
+        stale = (
+            [node_id for node_id in existing if node_id not in wanted]
+            if retract
+            else []
+        )
+
+        print(
+            f"{model}: {len(wanted)} scores, {len(existing)} already stored -> "
+            f"{len(changed)} to write, {len(stale)} to retract"
+            + ("" if retract else " (retraction skipped for a partial upload)"),
+            file=sys.stderr,
+        )
+
+        collection = self.db.collection("votes")
+        operations = 0
+        batch = self.db.batch()
+        for score in changed:
+            batch.set(
+                collection.document(self.vote_id(score.node_id, model)),
+                {
+                    "nodeId": score.node_id,
+                    "userUid": model,
+                    "categoryVotes": {"interesting": score.score},
+                },
+                merge=True,
+            )
+            operations += 1
+            if operations % BATCH_LIMIT == 0:
+                batch.commit()
+                batch = self.db.batch()
+                print(f"  committed {operations}...", file=sys.stderr)
+
+        for node_id in stale:
+            batch.delete(collection.document(self.vote_id(node_id, model)))
+            operations += 1
+            if operations % BATCH_LIMIT == 0:
+                batch.commit()
+                batch = self.db.batch()
+                print(f"  committed {operations}...", file=sys.stderr)
+
+        if operations % BATCH_LIMIT:
+            batch.commit()
+
+        return len(changed), len(stale)

--- a/data/scrapers/submit_scores.sh
+++ b/data/scrapers/submit_scores.sh
@@ -28,5 +28,5 @@ done
 for MODEL in $MODELS; do
 	echo "koryta $MODEL | koryta_uploader --type score --submit $SUFFIX"
 	uv run koryta "$MODEL"  --no-backup --all --output stderr 2>&1 1>/dev/null |
-		koryta_uploader --type score --submit $SUFFIX
+		uv run koryta_uploader --type score --submit $SUFFIX
 done

--- a/data/scrapers/submit_scores.sh
+++ b/data/scrapers/submit_scores.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+# Runs every scoring model and uploads each one's shortlist under its own
+# pipeline uid, so the site can tell which model nominated whom.
+#
+#   ./submit_scores.sh                    # against a local dev stack
+#   ./submit_scores.sh prod               # against autopush
+#   ./submit_scores.sh "" PeopleScoresPageRank   # one model only
+#
+# Each model is uploaded separately on purpose: `koryta_uploader --type score`
+# reconciles a whole model at once, writing only what changed and retracting
+# what the model no longer stands behind, and it can only do that for one model
+# per run.
+
+if [[ $1 == prod ]]; then
+	SUFFIX="--prod --endpoint https://autopush.koryta.pl"
+fi
+
+MODELS=${2:-"PeopleScores PeopleScoresPageRank PeopleScoresCoappointment PeopleScoresTurnover PeopleScoresCapture"}
+
+for MODEL in $MODELS; do
+	echo "koryta $MODEL | koryta_uploader --type score --submit $SUFFIX"
+	koryta "$MODEL" --output stderr 2>&1 1>/dev/null |
+		koryta_uploader --type score --submit $SUFFIX
+done

--- a/data/scrapers/submit_scores.sh
+++ b/data/scrapers/submit_scores.sh
@@ -19,8 +19,14 @@ fi
 
 MODELS=${2:-"PeopleScores PeopleScoresPageRank PeopleScoresCoappointment PeopleScoresTurnover PeopleScoresCapture"}
 
+echo "Prerunning the models"
+for MODEL in $MODELS; do
+	echo "koryta $MODEL --no-backup --all"
+	uv run koryta "$MODEL"  --no-backup --all
+done
+
 for MODEL in $MODELS; do
 	echo "koryta $MODEL | koryta_uploader --type score --submit $SUFFIX"
-	koryta "$MODEL" --output stderr 2>&1 1>/dev/null |
+	uv run koryta "$MODEL"  --no-backup --all --output stderr 2>&1 1>/dev/null |
 		koryta_uploader --type score --submit $SUFFIX
 done

--- a/frontend/server/utils/activityStats.ts
+++ b/frontend/server/utils/activityStats.ts
@@ -4,6 +4,7 @@ import {
   type ActivityCounts,
   type ActivityKind,
 } from "~~/shared/activity";
+import { isPipelineUid } from "~~/shared/stats";
 
 /** One thing a human did, normalized out of whichever collection recorded it.
  *
@@ -44,10 +45,11 @@ export type ActivityAggregate = {
 };
 
 /** Writes the pipeline makes on a person's behalf. They dwarf everything a
- * human does and would turn the page into a chart of one robot's day. */
-export function isPipelineUid(uid: string | undefined | null): boolean {
-  return !!uid && uid.includes("pipeline");
-}
+ * human does and would turn the page into a chart of one robot's day.
+ *
+ * Defined next to the vote aggregate that has to draw the same line, and
+ * re-exported here because the activity page drew it first. */
+export { isPipelineUid };
 
 /** The UTC day an instant falls on, or null if it cannot be read as one. */
 export function utcDay(at: string | null | undefined): string | null {

--- a/frontend/shared/model.ts
+++ b/frontend/shared/model.ts
@@ -46,6 +46,10 @@ export interface NodeStats {
     quality?: number;
     humanVoted?: boolean;
     lastVotedAt?: string;
+    /** What each scoring model made of this person, keyed by its `userUid`.
+     * Only the best of them is in `interesting`; this is what says which model
+     * put them there. Absent when no model has an opinion. */
+    models?: Record<string, number>;
     [key: string]: unknown;
   };
   edges: {

--- a/frontend/shared/stats.ts
+++ b/frontend/shared/stats.ts
@@ -90,6 +90,38 @@ export function calculateLatestEmploymentStart(edges: Edge[]): string | null {
   return latest;
 }
 
+/** Whether a vote was cast by a scoring model rather than by a person.
+ *
+ * The pipeline runs several models and each votes under its own uid -
+ * `pipeline`, `pipeline-pagerank`, `pipeline-turnover` and so on. Matching on
+ * the substring rather than on the exact name is safe because a Firebase uid is
+ * 28 random alphanumerics and cannot contain a word. Mirrored in Python by
+ * `is_pipeline_uid` in `data/scrapers/src/entities/person.py`, which is what
+ * keeps the models from being seeded on their own output.
+ */
+export function isPipelineUid(uid: string | undefined | null): boolean {
+  return !!uid && uid.includes("pipeline");
+}
+
+/**
+ * The vote aggregate stored on a node: what people said, plus the pipeline's
+ * best guess.
+ *
+ * Human votes sum, because each is somebody's independent opinion and two
+ * people saying +3 is a stronger claim than one. Pipeline votes do not: the
+ * models look at the same data from different angles and largely agree, so
+ * summing them would say "five voters" where there is one dataset, and adding
+ * a sixth model would silently rescale a number the explore table sorts on and
+ * `bucketPublicationCandidates` cuts into 1-5 bands. Instead every model's
+ * verdict collapses to the highest of them - a model that spots somebody the
+ * others miss still surfaces them, and one that has nothing to say costs
+ * nothing.
+ *
+ * `models` keeps each model's own score so a reader can see which one
+ * nominated a person. `lastVotedAt` deliberately ignores the pipeline: it
+ * reads as "when did somebody last look at this", and a nightly re-scoring is
+ * not somebody looking.
+ */
 export function computeVoteStats(
   nodeVotes: VoteDocument[],
 ): Record<string, unknown> {
@@ -100,22 +132,47 @@ export function computeVoteStats(
   };
 
   let latestDate: Date | null = null;
+  const pipelineBest: Record<string, number> = {};
+  const models: Record<string, number> = {};
 
   for (const v of nodeVotes) {
-    if (v.userUid !== "pipeline") {
+    const fromPipeline = isPipelineUid(v.userUid);
+    if (!fromPipeline) {
       aggregatedVotes.humanVoted = true;
-    }
-    if (v.updatedAt) {
-      const d = new Date(v.updatedAt);
-      if (!latestDate || d > latestDate) {
-        latestDate = d;
+      if (v.updatedAt) {
+        const d = new Date(v.updatedAt);
+        if (!latestDate || d > latestDate) {
+          latestDate = d;
+        }
       }
     }
 
     for (const [category, value] of Object.entries(v.categoryVotes)) {
-      aggregatedVotes[category] =
-        ((aggregatedVotes[category] as number) || 0) + (value as number);
+      if (fromPipeline) {
+        const best = pipelineBest[category];
+        pipelineBest[category] =
+          best === undefined
+            ? (value as number)
+            : Math.max(best, value as number);
+      } else {
+        aggregatedVotes[category] =
+          ((aggregatedVotes[category] as number) || 0) + (value as number);
+      }
     }
+
+    const interesting = v.categoryVotes.interesting;
+    if (fromPipeline && typeof interesting === "number") {
+      models[v.userUid] = interesting;
+    }
+  }
+
+  for (const [category, best] of Object.entries(pipelineBest)) {
+    aggregatedVotes[category] =
+      ((aggregatedVotes[category] as number) || 0) + best;
+  }
+
+  if (Object.keys(models).length > 0) {
+    aggregatedVotes.models = models;
   }
 
   if (latestDate) {

--- a/frontend/tests/shared/stats.test.ts
+++ b/frontend/tests/shared/stats.test.ts
@@ -118,6 +118,69 @@ describe("shared/stats.ts", () => {
       const stats = computeVoteStats([]);
       expect(stats).toEqual({ interesting: 0, quality: 0, humanVoted: false });
     });
+
+    const pipelineVote = (uid: string, interesting: number) =>
+      ({
+        userUid: uid,
+        nodeId: "n1",
+        categoryVotes: { interesting },
+      }) as unknown as VoteDocument;
+
+    it("takes the best model rather than summing them", () => {
+      // Five models agreeing that somebody is a 4 is one dataset seen five
+      // ways, not five voters — summing would put them at 20 on a 1-5 scale.
+      const stats = computeVoteStats([
+        pipelineVote("pipeline", 2),
+        pipelineVote("pipeline-pagerank", 4),
+        pipelineVote("pipeline-turnover", 1),
+      ]);
+
+      expect(stats.interesting).toBe(4);
+      expect(stats.humanVoted).toBe(false);
+    });
+
+    it("adds the best model's score on top of the human votes", () => {
+      const stats = computeVoteStats([
+        { userUid: "aB3xYz", categoryVotes: { interesting: 3 } },
+        { userUid: "cD4wVu", categoryVotes: { interesting: 2 } },
+        pipelineVote("pipeline-together", 5),
+        pipelineVote("pipeline-capture", 1),
+      ] as unknown as VoteDocument[]);
+
+      expect(stats.interesting).toBe(3 + 2 + 5);
+      expect(stats.humanVoted).toBe(true);
+    });
+
+    it("records what each model said so a reader can tell them apart", () => {
+      const stats = computeVoteStats([
+        pipelineVote("pipeline-pagerank", 5),
+        pipelineVote("pipeline-capture", 2),
+      ]);
+
+      expect(stats.models).toEqual({
+        "pipeline-pagerank": 5,
+        "pipeline-capture": 2,
+      });
+    });
+
+    it("leaves a re-scoring run out of lastVotedAt", () => {
+      // The field reads as "when did somebody last look at this", and a
+      // nightly re-run is not somebody looking.
+      const stats = computeVoteStats([
+        {
+          userUid: "aB3xYz",
+          categoryVotes: { interesting: 1 },
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          userUid: "pipeline-pagerank",
+          categoryVotes: { interesting: 5 },
+          updatedAt: "2026-08-01T00:00:00.000Z",
+        },
+      ] as unknown as VoteDocument[]);
+
+      expect(stats.lastVotedAt).toBe("2026-01-01T00:00:00.000Z");
+    });
   });
 
   describe("computeEdgeStats", () => {


### PR DESCRIPTION
PeopleScores was the only opinion the pipeline had about who is worth a look, and it had one shape: a person is as interesting as their employers, plus how often they have stood for office. Everything else the pipeline already knows - who somebody keeps turning up next to, when they took a post relative to an election, how political the board they sit on is - went unused.

Four models now answer the question from different angles, each voting under its own uid so the site can tell them apart:

  pipeline-pagerank  proximity in the employment graph to people already
                     confirmed, as a personalised PageRank seeded on the
                     published and upvoted, minus a second walk seeded on the
                     downvoted so a shared big employer cancels out
  pipeline-together  repeat co-appointment - who shares two or more separate
                     companies with a known face, which is the part one shared
                     board cannot tell apart from coincidence
  pipeline-turnover  a post taken up in the election year or the one after, in
                     the region the person stood in, at a company the register
                     calls public
  pipeline-capture   scores the institution and reads it onto the person, so a
                     newcomer on a board of ex-candidates surfaces even with no
                     record of their own

The frontend takes the best model rather than the sum. The models read one dataset from several angles and largely agree, so summing would claim five voters where there is one source, and adding a sixth model would silently rescale the number the explore table sorts on and bucketPublicationCandidates cuts into 1-5 bands. Each model's own verdict is kept in stats.votes.models.

Uploading is a reconciliation rather than a write per row. Every vote document fires onVoteWritten, which re-reads every vote on the node, so re-stating tens of thousands of unchanged scores cost that many invocations to change nothing. The uploader now writes only what moved and deletes the score for anybody the model no longer rates, refuses to upload two models at once, and refuses a uid the site would read as a person.

Two bugs fell out of this. KorytaVotes skipped only the exact uid "pipeline", so a pipeline-pagerank vote would have been read back as a human one and the models seeded on their own output. And the shortlist filter read votes_interesting, the site's aggregate including the pipeline's own vote, so after the first run every scored person was excluded and no run could revise its own score. Both go through is_pipeline_uid, kept identical to isPipelineUid on the frontend.

Scores are banded by rank rather than scaled by the maximum. PageRank masses are a power law and co-appointment counts are small integers with ties everywhere, and with the frontend taking the maximum, whichever model scaled itself most generously would otherwise win every tie.