### PR TITLE
Give a single note a link somebody can be sent

### DIFF
--- a/frontend/app/pages/admin/notatki/index.vue
+++ b/frontend/app/pages/admin/notatki/index.vue
@@ -18,7 +18,27 @@
       </v-btn>
     </div>
 
-    <v-card class="mb-4 pa-3">
+    <v-alert
+      v-if="singleNote"
+      class="mb-4"
+      type="info"
+      variant="tonal"
+      density="compact"
+    >
+      <div class="d-flex align-center justify-space-between flex-wrap ga-2">
+        <span>Pojedyncza notatka, otwarta z linku.</span>
+        <v-btn
+          size="small"
+          variant="text"
+          :prepend-icon="mdiFormatListBulleted"
+          @click="filterNote = null"
+        >
+          Pokaż wszystkie
+        </v-btn>
+      </div>
+    </v-alert>
+
+    <v-card v-else class="mb-4 pa-3">
       <v-row dense>
         <v-col cols="12" md="4">
           <v-text-field
@@ -93,10 +113,17 @@
         loading-text="Ładowanie..."
         items-per-page-text="Wierszy na stronę:"
       >
+        <!-- The date doubles as the entry's permalink. A reviewer working
+             through the queue needs a way to hand one row to somebody else,
+             and the date is the one cell that was carrying nothing else. -->
         <template #[`item.createdAt`]="{ item }">
-          <span class="text-no-wrap text-caption">
+          <NuxtLink
+            class="text-no-wrap text-caption"
+            :to="{ path: '/admin/notatki', query: { note: item.key } }"
+            title="Link do tej notatki"
+          >
             {{ formatDate(item.createdAt) }}
-          </span>
+          </NuxtLink>
         </template>
 
         <template #[`item.nodeName`]="{ item }">
@@ -136,7 +163,15 @@
 
         <template #[`item.note`]="{ item }">
           <div class="note-cell py-1">
-            <div class="note-text" :title="item.note">{{ item.note }}</div>
+            <!-- Clamped in the queue so a page of rows stays scannable, whole
+                 when the link opened this one entry - there is nothing below
+                 it to keep short for. -->
+            <div
+              :class="singleNote ? 'note-text-full' : 'note-text'"
+              :title="item.note"
+            >
+              {{ item.note }}
+            </div>
             <a
               v-if="item.url"
               :href="item.url"
@@ -214,6 +249,7 @@ import {
   mdiAccountOutline,
   mdiCommentQuestionOutline,
   mdiFileDocumentOutline,
+  mdiFormatListBulleted,
   mdiGestureTapButton,
   mdiHelp,
   mdiLink,
@@ -295,6 +331,12 @@ const filterStatus = stringFilter("status");
 const filterAdminType = stringFilter("adminType");
 const filterNodeType = stringFilter("nodeType");
 const filterSearch = stringFilter("q");
+
+/** The entry a permalink named, if this page was opened from one. Not a filter
+ * but a selector - it addresses one row, so the filter card has nothing left
+ * to narrow and is put away while it is set. */
+const filterNote = stringFilter("note");
+const singleNote = computed(() => Boolean(filterNote.value));
 
 // Typing runs ahead of the url so every keystroke does not push a history entry
 // and a request.
@@ -420,6 +462,7 @@ const apiQuery = computed(() => ({
   deferred: filterAdminType.value === "deferred" ? "true" : undefined,
   nodeType: filterNodeType.value || undefined,
   q: filterSearch.value || undefined,
+  note: filterNote.value || undefined,
 }));
 
 // Requests can land out of order once a filter and a page change chase each
@@ -523,6 +566,10 @@ const formatDate = (value: string | null) =>
 .note-cell {
   min-width: 260px;
   max-width: 520px;
+}
+
+.note-text-full {
+  white-space: pre-wrap;
 }
 
 .note-text {

--- a/frontend/server/api/notes/admin.get.ts
+++ b/frontend/server/api/notes/admin.get.ts
@@ -22,6 +22,10 @@ const queryValidator = z.object({
   nodeType: z.enum(["person", "place", "article", "region"]).optional(),
   /** Free text over the note, its url and the name of the node it is on. */
   q: z.string().min(1).optional(),
+  /** One entry, addressed by its row key - `<noteId>:<sourceIndex>`. A
+   * selector rather than a filter: it names the entry to answer with, so it
+   * takes precedence over everything above. */
+  note: z.string().min(1).optional(),
 
   sortBy: z
     .enum(["createdAt", "nodeName", "nodeType", "kind", "adminStatus"])
@@ -47,6 +51,15 @@ export default defineEventHandler(async (event) => {
 
   const query = await getValidatedQuery(event, (q) => queryValidator.parse(q));
   const rows = await getNoteRows(getFirestore("koryta-pl"));
+
+  // A link to one entry has to open that entry. Answering it as one more
+  // filter would let a `status` or `q` left over in the url quietly empty the
+  // page the link was sent to open, which is the one thing a permalink may not
+  // do - so it is answered on its own, before any of them.
+  if (query.note) {
+    const row = rows.find((candidate) => candidate.key === query.note);
+    return { notes: row ? [row] : [], total: row ? 1 : 0 };
+  }
 
   const needle = query.q?.toLowerCase();
   const matching = rows.filter((row) => {

--- a/frontend/tests/e2e/admin_notes.spec.ts
+++ b/frontend/tests/e2e/admin_notes.spec.ts
@@ -112,6 +112,25 @@ test.describe("Admin notes queue", () => {
     });
     await expect(rows).toHaveCount(1);
 
+    // The date is the entry's permalink, so one row can be handed to somebody
+    // else to resolve. It carries nothing but the entry, dropping the node
+    // type filter that was narrowing the queue around it.
+    await rows.first().getByTitle("Link do tej notatki").click();
+    await expect(page).toHaveURL(/note=/);
+    await expect(page).not.toHaveURL(/nodeType=/);
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText(`nowa notatka ${stamp}`);
+    await expect(page.locator(".v-alert")).toContainText("Pojedyncza notatka");
+
+    // And it survives being pasted somewhere and opened cold, which is the
+    // only way it is ever going to be used.
+    const permalink = page.url();
+    await page.goto(permalink, { waitUntil: "domcontentloaded" });
+    await expect(rows.first()).toContainText(`nowa notatka ${stamp}`, {
+      timeout: 30000,
+    });
+    await expect(rows).toHaveCount(1);
+
     // Clearing the type filter and asking for what is still open hides the
     // entry an admin already signed off.
     await page.goto(`${queue}&status=unresolved`, {

--- a/frontend/tests/server/api/notes-admin.test.ts
+++ b/frontend/tests/server/api/notes-admin.test.ts
@@ -280,6 +280,50 @@ describe("/api/notes/admin", () => {
     expect(byAdminType.notes.map((n) => n.note)).toEqual(["załatwione"]);
   });
 
+  it("answers a permalink with the one entry it names", async () => {
+    mockNotesGet.mockResolvedValue({
+      docs: [
+        noteDoc("note-1", {
+          nodeId: "node-1",
+          userUid: "user-a",
+          sources: [
+            { note: "pierwsza" },
+            { note: "druga", adminStatus: "resolved" },
+          ],
+        }),
+        noteDoc("note-2", {
+          nodeId: "node-2",
+          userUid: "user-b",
+          sources: [{ note: "o spółce" }],
+        }),
+      ],
+    });
+    mockGetAll.mockResolvedValue([
+      nodeDoc("node-1", "Jan Testowy", "person"),
+      nodeDoc("node-2", "Spółka Testowa", "place"),
+    ]);
+
+    const linked = (await callHandler({ note: "note-1:1" })) as Result;
+    expect(linked.total).toBe(1);
+    expect(linked.notes.map((n) => n.note)).toEqual(["druga"]);
+
+    // The whole point of a permalink: a filter left over in the url beside it
+    // cannot empty the page the link was sent to open.
+    const despiteFilters = (await callHandler({
+      note: "note-1:0",
+      status: "resolved",
+      nodeType: "place",
+      q: "coś czego tam nie ma",
+      page: 3,
+    })) as Result;
+    expect(despiteFilters.notes.map((n) => n.note)).toEqual(["pierwsza"]);
+
+    // An entry that has since been deleted answers empty rather than falling
+    // back to the whole queue.
+    const gone = (await callHandler({ note: "note-1:9" })) as Result;
+    expect(gone).toEqual({ notes: [], total: 0 });
+  });
+
   it("serves the phone queue: untyped entries nobody handed back", async () => {
     // What /admin/notatki/kategoryzacja asks for. An entry a reviewer could
     // not classify there is marked deferred and must not come round again.


### PR DESCRIPTION
The notes queue could only be addressed as a list. Handing one entry to somebody else meant describing which row it was, and the filters that narrow the queue are not stable enough to point with - the queue is ordered by when notes were written, so the row moves the moment anybody writes another.

Every entry already has an identity the table keys its rows on, so `note=<noteId>:<sourceIndex>` names one and the date cell carries the link. The endpoint answers it before the filters rather than as one more of them: a status or a search left over in the url beside a permalink would otherwise quietly empty the page the link was sent to open.