### PR TITLE
Link a company's KRS number to its rejestr.io entry

### DIFF
--- a/frontend/app/components/card/CompanySummary.vue
+++ b/frontend/app/components/card/CompanySummary.vue
@@ -11,7 +11,16 @@
           <div class="d-flex flex-wrap align-center ga-4 text-body-2">
             <span v-for="identifier in identifiers" :key="identifier.register">
               <strong>{{ identifier.register }}:</strong>
-              {{ identifier.value }}
+              <a
+                v-if="identifier.url"
+                :href="identifier.url"
+                target="_blank"
+                class="text-primary text-decoration-none"
+              >
+                {{ identifier.value }}
+                <v-icon :icon="mdiOpenInNew" size="small" />
+              </a>
+              <template v-else>{{ identifier.value }}</template>
             </span>
             <span v-if="location">
               <strong>Lokalizacja:</strong> {{ location }}

--- a/frontend/shared/identifiers.ts
+++ b/frontend/shared/identifiers.ts
@@ -7,6 +7,26 @@
  * plausible-looking number nobody can look up.
  */
 
+export type CompanyIdentifier = {
+  register: string;
+  value: string;
+  /** Where the register itself lists this number, when it has such a page. */
+  url?: string;
+};
+
+/** The entry rejestr.io publishes for a KRS number.
+ *
+ * It addresses a company by the number alone: the readable slug its own links
+ * carry ("/krs/348888/nowa-energia") is decorative, and a number padded to the
+ * official ten digits resolves the same as a bare one - so neither the
+ * company's name nor the shape of the stored number has to be right for the
+ * link to land. REGON and NIP have no comparable public page. */
+function registerUrl(register: string, value: string): string | undefined {
+  if (register !== "KRS") return undefined;
+  const digits = value.replace(/[\s-]/g, "");
+  return /^\d+$/.test(digits) ? `https://rejestr.io/krs/${digits}` : undefined;
+}
+
 /** The registers a place is listed in, most specific first, skipping the ones
  * it has no number for. An institution outside KRS is left with REGON and NIP,
  * and showing nothing at all would leave a reader no way to check who it is. */
@@ -14,14 +34,19 @@ export function companyIdentifiers(company: {
   krsNumber?: string;
   regonNumber?: string;
   nipNumber?: string;
-}): { register: string; value: string }[] {
+}): CompanyIdentifier[] {
   return [
     { register: "KRS", value: company.krsNumber },
     { register: "REGON", value: company.regonNumber },
     { register: "NIP", value: company.nipNumber },
-  ].filter(
-    (entry): entry is { register: string; value: string } => !!entry.value,
-  );
+  ]
+    .filter(
+      (entry): entry is { register: string; value: string } => !!entry.value,
+    )
+    .map((entry) => ({
+      ...entry,
+      url: registerUrl(entry.register, entry.value),
+    }));
 }
 
 /** Digits of an identifier as typed, with the separators people use.

--- a/frontend/tests/e2e/company_krs_link.spec.ts
+++ b/frontend/tests/e2e/company_krs_link.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+/** KRS of the company seeded for the emulator, the one identifier the seed and
+ * prod share - see company_notes.spec.ts. */
+const COMPANY_KRS = "0000357114";
+
+test("links a company's KRS number to its entry in rejestr.io", async ({
+  page,
+}) => {
+  await page.goto(`/eksploruj/tabela?krs=${COMPANY_KRS}`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  const card = page.locator(`.v-card:has-text("${COMPANY_KRS}")`).first();
+  // Client rendered, and only after the place list arrives.
+  await expect(card).toBeVisible({ timeout: 30_000 });
+
+  // The number itself is the link, so a reader can check the company against
+  // the register without copying it into a search box.
+  const link = card.getByRole("link", { name: COMPANY_KRS });
+  await expect(link).toHaveAttribute(
+    "href",
+    `https://rejestr.io/krs/${COMPANY_KRS}`,
+  );
+  // Somebody following it is mid-way through reading the table.
+  await expect(link).toHaveAttribute("target", "_blank");
+});

--- a/frontend/tests/shared/identifiers.test.ts
+++ b/frontend/tests/shared/identifiers.test.ts
@@ -100,4 +100,26 @@ describe("companyIdentifiers", () => {
   it("has nothing to show for a place with no number at all", () => {
     expect(companyIdentifiers({})).toEqual([]);
   });
+
+  it("points a KRS number at the entry rejestr.io keeps for it", () => {
+    expect(companyIdentifiers({ krsNumber: "0000348888" })).toEqual([
+      {
+        register: "KRS",
+        value: "0000348888",
+        url: "https://rejestr.io/krs/0000348888",
+      },
+    ]);
+  });
+
+  it("links a KRS number written with separators", () => {
+    expect(companyIdentifiers({ krsNumber: " 0000 348-888 " })[0]?.url).toBe(
+      "https://rejestr.io/krs/0000348888",
+    );
+  });
+
+  it("leaves a KRS number that is not one unlinked", () => {
+    // Free text got typed into the field at some point; a link built from it
+    // would land on rejestr.io's 404 rather than on the company.
+    expect(companyIdentifiers({ krsNumber: "brak" })[0]?.url).toBeUndefined();
+  });
 });


### PR DESCRIPTION
The summary card on /eksploruj/tabela named a company by its KRS number and left the reader to copy it into a search box to check who the company is. rejestr.io publishes a page per number, so the number can be the link.

It addresses a company by the number alone - the slug its own links carry is decorative, and a number padded to the official ten digits resolves the same as a bare one - so nothing about the stored name or the shape of the number has to match for the link to land. A value that is not a number at all stays plain text rather than pointing at a 404, and REGON and NIP, which have no comparable page, are unchanged.