### PR TITLE
Take the daily export at 04:00 Warsaw time

### DIFF
--- a/frontend/functions/src/index.ts
+++ b/frontend/functions/src/index.ts
@@ -108,9 +108,27 @@ export const getPageMeta = functions.https.onCall<incomingUrl>(
 
 const adminClient = new v1.FirestoreAdminClient();
 
+/**
+ * The nightly dump the scrapers read (`snapshot.py`) and `npm run db:pull`
+ * seeds the emulator from, taken at 04:00 Warsaw time.
+ *
+ * Once a day, not twice, because an export is billed one document read per
+ * document exported - 94,103 of them as of 12 August 2026, and the reads do
+ * not show up in the console's usage figures, so this was a third of the
+ * database's daily cost while being invisible in the place anyone would look
+ * for it. Nothing consumes the second run: `latest_export` and `pull-db.sh`
+ * both take the newest directory, and the pipelines that read it are daily.
+ *
+ * Disaster recovery does not rest on this either: the invoice carries a Cloud
+ * Firestore Zonal Backup Storage line, so the database also has Firestore's own
+ * backup schedule, which is billed by stored size rather than by read.
+ */
 export const scheduledFirestoreExport = onSchedule(
   {
-    schedule: "every 12 hours",
+    // 04:00 in Warsaw, where the people who read the dump are, rather than in
+    // UTC - which would be 06:00 for half the year and 05:00 for the other.
+    schedule: "every day 04:00",
+    timeZone: "Europe/Warsaw",
     region: "europe-west1",
   },
   async (_event: unknown) => {


### PR DESCRIPTION
The schedule ran at 06:16 UTC because that is when it happened to be deployed. Naming the hour and the zone puts the dump in the quiet part of the night where the people who read it are, instead of at 06:00 in summer and 05:00 in winter.