### PR TITLE
Give the pipeline runner back its everything flag, under a free name

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -173,7 +173,7 @@ jobs:
           # run for a dataset nothing serves yet. Excluding the top-level one
           # takes the dependency with it.
           if [ "$TIER" = "full" ]; then
-            selection="--all --exclude ProcessWikiNer"
+            selection="--all-pipelines --exclude ProcessWikiNer"
           else
             # Wiki only: the rest reads GCS or Firestore, which a fork PR has
             # no credentials for. ProcessWiki needs none.

--- a/data/scrapers/README.md
+++ b/data/scrapers/README.md
@@ -121,7 +121,7 @@ is fine: the slice tier's pipelines do not need any.
 To reproduce a CI run locally:
 
 ```bash
-uv run koryta --all --exclude ProcessWikiNer \
+uv run koryta --all-pipelines --exclude ProcessWikiNer \
   --refresh all --no-backup --assume-yes \
   --wiki-dump-url https://dumps.wikimedia.org/plwiki/20260701/plwiki-20260701-pages-articles-multistream1.xml-p1p187037.bz2 \
   --wiki-dump-file plwiki-20260701-shard1.bz2

--- a/data/scrapers/src/koryta.py
+++ b/data/scrapers/src/koryta.py
@@ -74,10 +74,18 @@ def get_args():
         "Streams from disk. Still disabled by --no-backup/DISABLE_BACKUP.",
     )
     parser.add_argument(
+        "--all-pipelines",
+        action="store_true",
+        help="Run every pipeline except ScrapeRejestrIO, which bills per "
+        "query. Not spelled --all: scrapers.analysis.extract owns that one "
+        "('extract all people') and reads it off the same argv.",
+    )
+    parser.add_argument(
         "--exclude",
         action="append",
         default=[],
-        help="Pipeline name to skip running. Repeatable, and applies to --all.",
+        help="Pipeline name to skip running. Repeatable, and applies to "
+        "--all-pipelines.",
     )
     parser.add_argument(
         "pipeline",
@@ -111,9 +119,18 @@ def select_pipelines(args) -> set[str]:
             f"Available: {' '.join(sorted(pipeline_names))}"
         )
 
+    if args.all_pipelines:
+        if args.pipeline:
+            raise ValueError(
+                "--all-pipelines runs everything, so it takes no pipeline names"
+            )
+        # ScrapeRejestrIO bills per query -- never part of a bulk run.
+        return pipeline_names - {"ScrapeRejestrIO"} - exclude
     if args.pipeline:
         return set(args.pipeline) - exclude
-    raise ValueError("No pipeline specified, use koryta PipelineName or --all")
+    raise ValueError(
+        "No pipeline specified, use koryta PipelineName or --all-pipelines"
+    )
 
 
 def selected_resources(selected: set[str]) -> set[type[ContextResource]]:


### PR DESCRIPTION
`--all` was removed from `koryta` because `analysis.extract` already owns it -- both read the same argv through parse_known_args, and there it means 'extract all people'. But nothing that passed it was updated, so the nightly full tier has been dying at startup on "No pipeline specified", from an error message still advertising the flag it just rejected.

Same behaviour under `--all-pipelines`: every pipeline but ScrapeRejestrIO, which bills per query, with `--exclude` applying on top. Excluding ProcessWikiNer still takes ProcessWikiPeopleNames with it -- nothing else depends on it -- which is what the workflow comment claims and now gets to be true again.