### PR TITLE
Let the datascience group upload pipeline scores

### DIFF
--- a/data/scrapers/src/tests/e2e/test_vote_rules.py
+++ b/data/scrapers/src/tests/e2e/test_vote_rules.py
@@ -1,0 +1,188 @@
+"""What `firestore.rules` lets the score uploader do.
+
+The uploader stopped going through the Admin SDK against a deployed site: a
+person's account holds no Firestore IAM role, so it writes over the REST API
+with their Firebase id token and is judged by the rules instead. That makes the
+rules part of the upload path, and the only honest way to check them is to put
+them in front of an emulator and try.
+
+Needs the auth and firestore emulators, so it skips without them:
+
+    cd frontend && devns npx firebase emulators:exec --project demo-koryta-pl \\
+        --only auth,firestore \\
+        "cd ../data/scrapers && .venv/bin/python -m pytest -m e2e \\
+            src/tests/e2e/test_vote_rules.py"
+"""
+
+import os
+import socket
+
+import firebase_admin
+import pytest
+import requests
+from firebase_admin import auth
+
+from entities.composite import PersonScore
+from util.firestore import AdminVotes, RestVotes, vote_id
+
+pytestmark = pytest.mark.e2e
+
+FIRESTORE_HOST = os.environ.get("FIRESTORE_EMULATOR_HOST", "127.0.0.1:8080")
+AUTH_HOST = os.environ.get("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
+#: `emulators:exec --project` and the `firestore.database` in firebase.json.
+PROJECT = os.environ.get("GCLOUD_PROJECT", "demo-koryta-pl")
+DATABASE = "koryta-pl"
+
+MODEL = "pipeline-rules-test"
+
+
+def listening(host_port: str) -> bool:
+    host, _, port = host_port.rpartition(":")
+    try:
+        with socket.create_connection((host, int(port)), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(scope="module", autouse=True)
+def emulators():
+    for name, host in (("firestore", FIRESTORE_HOST), ("auth", AUTH_HOST)):
+        if not listening(host):
+            pytest.skip(f"no {name} emulator on {host}")
+
+
+def id_token(uid: str, **claims) -> str:
+    """A signed-in user carrying `claims`, the way the rules will see them.
+
+    The auth emulator issues unsigned tokens, so this needs no credentials -
+    the same custom-token exchange the extractor service does in production.
+    """
+    os.environ.setdefault("GCLOUD_PROJECT", PROJECT)
+    try:
+        app = firebase_admin.get_app("rules-test")
+    except ValueError:
+        app = firebase_admin.initialize_app(
+            options={"projectId": PROJECT}, name="rules-test"
+        )
+
+    custom_token = auth.create_custom_token(uid, claims, app=app)
+    response = requests.post(
+        f"http://{AUTH_HOST}/identitytoolkit.googleapis.com/v1/"
+        "accounts:signInWithCustomToken",
+        params={"key": "emulator"},
+        json={"token": custom_token.decode(), "returnSecureToken": True},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()["idToken"]
+
+
+def votes_as(uid: str, **claims) -> RestVotes:
+    return RestVotes(
+        PROJECT, DATABASE, id_token(uid, **claims), origin=f"http://{FIRESTORE_HOST}"
+    )
+
+
+def score(node_id: str, value: int) -> PersonScore:
+    return PersonScore(node_id=node_id, name=node_id, score=value, model=MODEL)
+
+
+class TestDatascienceMember:
+    def test_writes_reads_and_retracts_a_models_scores(self):
+        votes = votes_as("analyst", datascience=True)
+
+        votes.apply(MODEL, [score("n1", 5), score("n2", 3)], [])
+        assert votes.scores(MODEL) == {"n1": 5, "n2": 3}
+
+        votes.apply(MODEL, [], ["n1", "n2"])
+        assert votes.scores(MODEL) == {}
+
+    def test_cannot_vote_in_a_persons_name(self):
+        # The claim buys the right to write a model's opinion, not to put a
+        # verdict on the site under somebody else's uid.
+        votes = votes_as("analyst", datascience=True)
+
+        with pytest.raises(PermissionError):
+            votes.apply("aB3xYzHumanLookingUid", [score("n1", 5)], [])
+
+    def test_cannot_disguise_a_vote_as_another_document(self):
+        # The document id has to spell out the nodeId and uid it carries,
+        # otherwise a write could land on a person's own vote document.
+        votes = votes_as("analyst", datascience=True)
+        forged = {
+            "writes": [
+                {
+                    "update": {
+                        "name": votes.document_name(
+                            vote_id("n1", "aB3xYzHumanLookingUid")
+                        ),
+                        "fields": {
+                            "nodeId": {"stringValue": "n1"},
+                            "userUid": {"stringValue": MODEL},
+                            "categoryVotes": {
+                                "mapValue": {
+                                    "fields": {"interesting": {"integerValue": "5"}}
+                                }
+                            },
+                        },
+                    }
+                }
+            ]
+        }
+
+        response = votes.session.post(f"{votes.documents}:commit", json=forged)
+
+        assert response.status_code == 403, response.text
+
+
+class TestEveryoneElse:
+    def test_a_signed_in_user_without_the_claim_is_refused(self):
+        votes = votes_as("passer-by")
+
+        with pytest.raises(PermissionError, match="datascience"):
+            votes.apply(MODEL, [score("n1", 5)], [])
+
+    def test_a_person_can_still_cast_their_own_vote(self):
+        # The branch the site itself writes through, kept alongside the new one
+        # so a change to either is checked against the same emulator.
+        votes = votes_as("aB3xYzHumanLookingUid")
+        own = {
+            "writes": [
+                {
+                    "update": {
+                        "name": votes.document_name(
+                            vote_id("n1", "aB3xYzHumanLookingUid")
+                        ),
+                        "fields": {
+                            "nodeId": {"stringValue": "n1"},
+                            "userUid": {"stringValue": "aB3xYzHumanLookingUid"},
+                            "categoryVotes": {
+                                "mapValue": {
+                                    "fields": {"interesting": {"integerValue": "5"}}
+                                }
+                            },
+                        },
+                    }
+                }
+            ]
+        }
+
+        response = votes.session.post(f"{votes.documents}:commit", json=own)
+
+        assert response.status_code == 200, response.text
+
+
+class TestLocalStack:
+    """The other way in: the Admin SDK, which the emulator asks nothing of."""
+
+    def test_writes_reads_and_retracts_a_models_scores(self):
+        os.environ["FIRESTORE_EMULATOR_HOST"] = FIRESTORE_HOST
+        votes = AdminVotes(PROJECT, DATABASE)
+        model = f"{MODEL}-admin"
+
+        votes.apply(model, [score("n1", 5), score("n2", 3)], [])
+        assert votes.scores(model) == {"n1": 5, "n2": 3}
+
+        votes.apply(model, [], ["n1", "n2"])
+        assert votes.scores(model) == {}

--- a/data/scrapers/src/tests/test_score_upload.py
+++ b/data/scrapers/src/tests/test_score_upload.py
@@ -9,91 +9,53 @@ import pytest
 
 from entities.composite import PersonScore
 from uploader import Args, ScoreUploader
-from util.firestore import Firestore
+from util.firestore import (
+    BATCH_LIMIT,
+    Firestore,
+    RestVotes,
+    vote_document,
+    vote_id,
+)
 
 
-class FakeDoc:
-    def __init__(self, doc_id: str, data: dict):
-        self.id = doc_id
-        self._data = data
+class FakeVotes:
+    """Stands in for the store, whichever way in it was opened.
 
-    def to_dict(self):
-        return self._data
+    `Firestore` decides what to write and what to take back; both the Admin SDK
+    and the REST backend only carry that out, so the decisions are what these
+    tests hold onto.
+    """
 
-
-class FakeQuery:
-    def __init__(self, docs: list[FakeDoc]):
-        self._docs = docs
-
-    def stream(self):
-        return iter(self._docs)
-
-
-class FakeCollection:
     def __init__(self, documents: dict[str, dict]):
         self.documents = documents
+        self.log: list[tuple[str, str]] = []
 
-    def where(self, filter=None):  # noqa: A002 - matches the firestore signature
-        _, _, value = filter.field_path, filter.op_string, filter.value
-        return FakeQuery(
-            [
-                FakeDoc(doc_id, data)
-                for doc_id, data in self.documents.items()
-                if data.get("userUid") == value
-            ]
-        )
+    def scores(self, model: str) -> dict[str, int]:
+        return {
+            data["nodeId"]: data["categoryVotes"]["interesting"]
+            for data in self.documents.values()
+            if data["userUid"] == model
+        }
 
-    def document(self, doc_id: str) -> str:
-        return doc_id
-
-
-class FakeBatch:
-    def __init__(self, collection: FakeCollection, log: list[tuple]):
-        self.collection = collection
-        self.log = log
-        self.pending: list[tuple] = []
-
-    def set(self, ref, data, merge=False):
-        self.pending.append(("set", ref, data))
-
-    def delete(self, ref):
-        self.pending.append(("delete", ref, None))
-
-    def commit(self):
-        for operation, ref, data in self.pending:
-            if operation == "set":
-                self.collection.documents[ref] = data
-            else:
-                self.collection.documents.pop(ref, None)
-            self.log.append((operation, ref))
-        self.pending = []
-
-
-class FakeDb:
-    def __init__(self, documents: dict[str, dict]):
-        self.votes = FakeCollection(documents)
-        self.log: list[tuple] = []
-
-    def collection(self, name: str) -> FakeCollection:
-        assert name == "votes"
-        return self.votes
-
-    def batch(self) -> FakeBatch:
-        return FakeBatch(self.votes, self.log)
+    def apply(self, model, changed, stale):
+        for score in changed:
+            document_id = vote_id(score.node_id, model)
+            self.documents[document_id] = vote_document(
+                score.node_id, model, score.score
+            )
+            self.log.append(("set", document_id))
+        for node_id in stale:
+            document_id = vote_id(node_id, model)
+            self.documents.pop(document_id, None)
+            self.log.append(("delete", document_id))
 
 
 def stored(node_id: str, model: str, score: int) -> tuple[str, dict]:
-    return (
-        f"{node_id}_{model}",
-        {"nodeId": node_id, "userUid": model, "categoryVotes": {"interesting": score}},
-    )
+    return (vote_id(node_id, model), vote_document(node_id, model, score))
 
 
 def firestore_with(*documents: tuple[str, dict]) -> Firestore:
-    client = Firestore.__new__(Firestore)
-    client.db = FakeDb(dict(documents))  # type: ignore[assignment]
-    client.user_id = "pipeline"
-    return client
+    return Firestore(None, FakeVotes(dict(documents)))
 
 
 def score(node_id: str, value: int, model: str) -> PersonScore:
@@ -116,7 +78,7 @@ class TestReplaceScores:
         )
 
         assert (written, retracted) == (1, 0)
-        assert client.db.log == [("set", "n2_pipeline-pagerank")]  # type: ignore[attr-defined]
+        assert client.votes.log == [("set", "n2_pipeline-pagerank")]
 
     def test_a_person_the_model_dropped_loses_the_score(self):
         client = firestore_with(stored("gone", "pipeline-turnover", 3))
@@ -126,7 +88,7 @@ class TestReplaceScores:
         )
 
         assert (written, retracted) == (1, 1)
-        assert "gone_pipeline-turnover" not in client.db.votes.documents  # type: ignore[attr-defined]
+        assert "gone_pipeline-turnover" not in client.votes.documents
 
     def test_another_models_scores_are_not_touched(self):
         client = firestore_with(
@@ -137,7 +99,7 @@ class TestReplaceScores:
 
         client.replace_scores("pipeline-pagerank", [])
 
-        documents = client.db.votes.documents  # type: ignore[attr-defined]
+        documents = client.votes.documents
         assert "n1_pipeline-pagerank" not in documents
         assert documents["n1_pipeline-capture"]["categoryVotes"]["interesting"] == 1
         assert documents["n1_aB3xYz"]["categoryVotes"]["interesting"] == 4
@@ -150,7 +112,126 @@ class TestReplaceScores:
         )
 
         assert (written, retracted) == (1, 0)
-        assert "n1_pipeline" in client.db.votes.documents  # type: ignore[attr-defined]
+        assert "n1_pipeline" in client.votes.documents
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code: int = 200):
+        self.payload = payload
+        self.status_code = status_code
+        self.ok = status_code < 400
+        self.text = str(payload)
+
+    def json(self):
+        return self.payload
+
+
+class FakeSession:
+    """Records what the REST backend puts on the wire."""
+
+    def __init__(self, *responses: FakeResponse):
+        self.headers: dict[str, str] = {}
+        self.responses = list(responses)
+        self.calls: list[tuple[str, dict]] = []
+
+    def post(self, url, json=None, timeout=None):
+        self.calls.append((url, json))
+        return self.responses.pop(0) if self.responses else FakeResponse({})
+
+
+def rest_with(session: FakeSession) -> RestVotes:
+    votes = RestVotes.__new__(RestVotes)
+    votes.collection = "projects/p/databases/d/documents"
+    votes.documents = f"https://firestore.example/v1/{votes.collection}"
+    votes.session = session  # type: ignore[assignment]
+    return votes
+
+
+class TestRestVotes:
+    """The wire format, which is the part `firestore.rules` is judging."""
+
+    def test_reads_a_models_stored_scores(self):
+        session = FakeSession(
+            FakeResponse(
+                [
+                    # The stream opens with a result that carries no document.
+                    {"readTime": "2026-08-16T00:00:00Z"},
+                    {
+                        "document": {
+                            "name": ".../votes/n1_pipeline-pagerank",
+                            "fields": {
+                                "nodeId": {"stringValue": "n1"},
+                                "userUid": {"stringValue": "pipeline-pagerank"},
+                                "categoryVotes": {
+                                    "mapValue": {
+                                        "fields": {"interesting": {"integerValue": "5"}}
+                                    }
+                                },
+                            },
+                        }
+                    },
+                ]
+            )
+        )
+
+        scores = rest_with(session).scores("pipeline-pagerank")
+
+        assert scores == {"n1": 5}
+        url, query = session.calls[0]
+        assert url.endswith(":runQuery")
+        condition = query["structuredQuery"]["where"]["fieldFilter"]
+        assert condition["field"]["fieldPath"] == "userUid"
+        assert condition["value"]["stringValue"] == "pipeline-pagerank"
+
+    def test_writes_a_score_under_the_models_uid(self):
+        session = FakeSession()
+
+        rest_with(session).apply(
+            "pipeline-capture", [score("n1", 4, "pipeline-capture")], []
+        )
+
+        url, body = session.calls[0]
+        assert url.endswith(":commit")
+        (write,) = body["writes"]
+        assert write["update"]["name"].endswith("/votes/n1_pipeline-capture")
+        assert write["update"]["fields"] == {
+            "nodeId": {"stringValue": "n1"},
+            "userUid": {"stringValue": "pipeline-capture"},
+            "categoryVotes": {
+                "mapValue": {"fields": {"interesting": {"integerValue": "4"}}}
+            },
+        }
+        # Naming the leaf is what `merge=True` does: a vote this person cast in
+        # another category on the same document survives the write.
+        assert write["updateMask"]["fieldPaths"] == [
+            "nodeId",
+            "userUid",
+            "categoryVotes.interesting",
+        ]
+
+    def test_retracts_by_deleting(self):
+        session = FakeSession()
+
+        rest_with(session).apply("pipeline", [], ["gone"])
+
+        _, body = session.calls[0]
+        assert body["writes"] == [
+            {"delete": "projects/p/databases/d/documents/votes/gone_pipeline"}
+        ]
+
+    def test_commits_in_batches_firestore_will_accept(self):
+        session = FakeSession()
+        scores = [score(f"n{i}", 3, "pipeline") for i in range(BATCH_LIMIT + 1)]
+
+        rest_with(session).apply("pipeline", scores, [])
+
+        assert [len(body["writes"]) for _, body in session.calls] == [BATCH_LIMIT, 1]
+
+    def test_a_refusal_names_the_claim_the_upload_needs(self):
+        session = FakeSession(FakeResponse({"error": "denied"}, status_code=403))
+
+        with pytest.raises(PermissionError, match="datascience"):
+            rest_with(session).scores("pipeline")
 
 
 def uploader_with(**overrides) -> ScoreUploader:

--- a/data/scrapers/src/uploader.py
+++ b/data/scrapers/src/uploader.py
@@ -88,7 +88,12 @@ class Uploader:
         self.args = args
 
         if args.type in ["score"]:
-            self.firestore = Firestore(args)
+            # Same browser login as every other type, only the token goes to
+            # Firestore rather than to an ingest endpoint. A local stack asks
+            # for none of it, so the login is passed rather than performed.
+            self.firestore = Firestore(
+                args, login=lambda: authenticate_user(args.endpoint)
+            )
         else:
             token = authenticate_user(args.endpoint)
             self.headers = {
@@ -264,7 +269,9 @@ class ScoreUploader(Uploader):
     pipeline's own opinion rather than a fact about a person, and they are
     stored as votes so that the site's existing aggregate does the combining.
     Each model votes under its own uid, so uploading one model never touches
-    another's scores.
+    another's scores. Against a deployed site that write is judged by
+    `firestore.rules`, which want the uploader in the datascience group - see
+    `util.firestore`.
 
     Unlike the per-entity uploaders this writes the whole run at once, because
     what to write can only be decided against what the model wrote last time -

--- a/data/scrapers/src/util/firestore.py
+++ b/data/scrapers/src/util/firestore.py
@@ -1,5 +1,27 @@
+"""Where a scoring model's votes are stored, and what is allowed to store them.
+
+Two ways in, because the two contexts hold different credentials:
+
+* Against a local stack the emulator trusts anybody, so the Admin SDK writes
+  straight through and `firestore.rules` never runs.
+* Against a deployed site the uploader is a person - whoever is running
+  `submit_scores.sh` - and the credentials at hand are the Firebase id token
+  from the same browser login every other `--type` uses. A person's Google
+  account holds no Firestore IAM role, only the deploy service accounts do, so
+  the Admin SDK's application-default path answers `403 Missing or insufficient
+  permissions`. The REST API given an id token is evaluated against
+  `firestore.rules` instead, and those admit a member of the datascience group
+  writing a pipeline's votes.
+
+Set `KORYTA_ID_TOKEN` to skip the browser login and present an id token
+directly - what a service holding its own datascience account would do, and
+what the tests do against the emulator. The login itself is passed in by the
+caller: it lives in `stores.auth`, which this layer may not import.
+"""
+
 import os
 import sys
+import typing
 
 import firebase_admin
 import requests
@@ -7,54 +29,69 @@ from firebase_admin import firestore
 
 from entities.composite import PersonScore
 
-#: Firestore takes at most 500 operations in one batch.
+#: Asks whoever is running the upload to sign in, and returns their id token.
+Login = typing.Callable[[], str]
+
+#: Firestore takes at most 500 operations in one batch, REST commit included.
 BATCH_LIMIT = 500
 
+FIRESTORE_ORIGIN = "https://firestore.googleapis.com"
 
-class Firestore:
-    def __init__(self, args):
-        project_id = getattr(args, "project", None)
-        if args.endpoint.startswith("http://localhost"):
-            os.environ["FIRESTORE_EMULATOR_HOST"] = "localhost:8080"
-            if not project_id:
-                try:
-                    resp = requests.get("http://127.0.0.1:4000/api/config", timeout=2)
-                    if resp.status_code == 200:
-                        project_id = resp.json().get("projectId")
-                except Exception as e:
-                    print(
-                        f"Warning: Could not detect emulator project ID: {e}",
-                        file=sys.stderr,
-                    )
-                if not project_id:
-                    project_id = "demo-koryta-pl"
+#: A full reconciliation reads back every vote the model holds, tens of
+#: thousands of documents in one response.
+QUERY_TIMEOUT_S = 300
+COMMIT_TIMEOUT_S = 120
 
-        options = {}
-        if project_id:
-            options["projectId"] = project_id
 
+class VoteStore(typing.Protocol):
+    """The two operations reconciling a model's scores needs of Firestore."""
+
+    def scores(self, model: str) -> dict[str, int]:
+        """Node id -> the score this model last wrote, for the whole model."""
+        ...
+
+    def apply(self, model: str, changed: list[PersonScore], stale: list[str]) -> None:
+        """Write these scores and retract the scores on these node ids."""
+        ...
+
+
+def batched(items: list, size: int = BATCH_LIMIT):
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def vote_id(node_id: str, user_uid: str) -> str:
+    return f"{node_id}_{user_uid}"
+
+
+def vote_document(node_id: str, model: str, score: float) -> dict:
+    return {
+        "nodeId": node_id,
+        "userUid": model,
+        "categoryVotes": {"interesting": score},
+    }
+
+
+class AdminVotes:
+    """Writes as the project itself, bypassing rules. Local stacks only.
+
+    The emulator asks for no credentials at all, which is what makes this the
+    path for a dev stack: no browser login in the middle of a pipeline run.
+    """
+
+    def __init__(self, project_id: str | None, database_id: str):
+        options = {"projectId": project_id} if project_id else {}
         try:
             app = firebase_admin.get_app("uploader")
         except ValueError:
             app = firebase_admin.initialize_app(options=options, name="uploader")
-
-        database_id = getattr(args, "database", "koryta-pl")
         self.db = firestore.client(app=app, database_id=database_id)
-        self.user_id = "pipeline"
 
-    def vote_id(self, node_id: str, user_uid: str) -> str:
-        return f"{node_id}_{user_uid}"
-
-    def existing_scores(self, model: str) -> dict[str, int]:
-        """Node id -> the score this model last wrote, for the whole model.
-
-        One equality query on `userUid`, which the automatic single-field index
-        covers, and it returns only this model's own documents.
-        """
-        existing = {}
+    def scores(self, model: str) -> dict[str, int]:
         query = self.db.collection("votes").where(
             filter=firestore.FieldFilter("userUid", "==", model)
         )
+        existing = {}
         for doc in query.stream():
             data = doc.to_dict() or {}
             node_id = data.get("nodeId")
@@ -63,29 +100,205 @@ class Firestore:
                 existing[node_id] = interesting
         return existing
 
-    def submit_score(self, p: dict | PersonScore):
-        """Write one model's rating of one person."""
-        if isinstance(p, dict):
-            p = PersonScore(**p)
+    def apply(self, model: str, changed: list[PersonScore], stale: list[str]) -> None:
+        collection = self.db.collection("votes")
+        writes: list = [(score.node_id, score.score) for score in changed]
+        writes += [(node_id, None) for node_id in stale]
 
-        print(
-            f"Uploading score {p.score} for {p.name} (nodeId: {p.node_id})...",
-            end=" ",
-            file=sys.stderr,
-        )
+        written = 0
+        for chunk in batched(writes):
+            batch = self.db.batch()
+            for node_id, score in chunk:
+                reference = collection.document(vote_id(node_id, model))
+                if score is None:
+                    batch.delete(reference)
+                else:
+                    batch.set(
+                        reference, vote_document(node_id, model, score), merge=True
+                    )
+            batch.commit()
+            written += len(chunk)
+            if written < len(writes):
+                print(f"  committed {written}...", file=sys.stderr)
 
-        doc_ref = self.db.collection("votes").document(
-            self.vote_id(p.node_id, p.model or self.user_id)
+
+class RestVotes:
+    """Writes as the signed-in person, subject to `firestore.rules`.
+
+    The id token is what the rules see: `request.auth.token.datascience` has to
+    be true, and each document has to read as a model's own vote. Nothing here
+    can write a vote in a person's name, which is the point of going through
+    the rules rather than around them.
+    """
+
+    def __init__(
+        self,
+        project_id: str,
+        database_id: str,
+        id_token: str,
+        origin: str = FIRESTORE_ORIGIN,
+    ):
+        # A write names its document by resource path, which is not the URL the
+        # request goes to - Firestore refuses one given in place of the other.
+        self.collection = f"projects/{project_id}/databases/{database_id}/documents"
+        self.documents = f"{origin}/v1/{self.collection}"
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = f"Bearer {id_token}"
+
+    def document_name(self, document_id: str) -> str:
+        return f"{self.collection}/votes/{document_id}"
+
+    def scores(self, model: str) -> dict[str, int]:
+        query: dict[str, typing.Any] = {
+            "structuredQuery": {
+                "from": [{"collectionId": "votes"}],
+                "where": {
+                    "fieldFilter": {
+                        "field": {"fieldPath": "userUid"},
+                        "op": "EQUAL",
+                        "value": {"stringValue": model},
+                    }
+                },
+            }
+        }
+        response = self.session.post(
+            f"{self.documents}:runQuery", json=query, timeout=QUERY_TIMEOUT_S
         )
-        doc_ref.set(
+        self.check(response, f"reading {model}'s votes")
+
+        existing = {}
+        for result in response.json():
+            fields = (result.get("document") or {}).get("fields")
+            if not fields:
+                # A result carrying no document is a keep-alive from the
+                # streamed response, not a vote.
+                continue
+            node_id = fields.get("nodeId", {}).get("stringValue")
+            categories = fields.get("categoryVotes", {}).get("mapValue", {})
+            interesting = categories.get("fields", {}).get("interesting")
+            if node_id and interesting is not None:
+                existing[node_id] = number(interesting)
+        return existing
+
+    def apply(self, model: str, changed: list[PersonScore], stale: list[str]) -> None:
+        writes: list[dict] = [
             {
-                "nodeId": p.node_id,
-                "userUid": p.model or self.user_id,
-                "categoryVotes": {"interesting": p.score},
-            },
-            merge=True,
+                "update": {
+                    "name": self.document_name(vote_id(score.node_id, model)),
+                    "fields": {
+                        "nodeId": {"stringValue": score.node_id},
+                        "userUid": {"stringValue": model},
+                        "categoryVotes": {
+                            "mapValue": {
+                                "fields": {
+                                    "interesting": {
+                                        "integerValue": str(int(score.score))
+                                    }
+                                }
+                            }
+                        },
+                    },
+                },
+                # The Admin SDK's `merge=True`, spelled out: naming the leaf
+                # rather than `categoryVotes` leaves a vote in another category
+                # on the same document alone.
+                "updateMask": {
+                    "fieldPaths": [
+                        "nodeId",
+                        "userUid",
+                        "categoryVotes.interesting",
+                    ]
+                },
+            }
+            for score in changed
+        ]
+        writes += [
+            {"delete": self.document_name(vote_id(node_id, model))} for node_id in stale
+        ]
+
+        written = 0
+        for chunk in batched(writes):
+            response = self.session.post(
+                f"{self.documents}:commit",
+                json={"writes": chunk},
+                timeout=COMMIT_TIMEOUT_S,
+            )
+            self.check(response, f"writing {len(chunk)} of {model}'s votes")
+            written += len(chunk)
+            if written < len(writes):
+                print(f"  committed {written}...", file=sys.stderr)
+
+    @staticmethod
+    def check(response: requests.Response, what: str) -> None:
+        if response.ok:
+            return
+        if response.status_code == 403:
+            raise PermissionError(
+                f"Firestore refused {what}: {response.text}\n"
+                "Uploading scores needs the `datascience` claim on the account "
+                "you logged in as - the same one /ekstrakcje requires."
+            )
+        raise RuntimeError(
+            f"Firestore failed {what}: {response.status_code} {response.text}"
         )
-        print(f"  OK: {doc_ref.id}", file=sys.stderr)
+
+
+def number(value: dict) -> int:
+    """A Firestore REST value back into the integer a score is stored as."""
+    if "integerValue" in value:
+        return int(value["integerValue"])
+    return int(float(value["doubleValue"]))
+
+
+def emulator_project_id() -> str:
+    """The project the running emulator serves, so writes land in its data."""
+    try:
+        response = requests.get("http://127.0.0.1:4000/api/config", timeout=2)
+        if response.status_code == 200:
+            project_id = response.json().get("projectId")
+            if project_id:
+                return project_id
+    except Exception as e:
+        print(f"Warning: Could not detect emulator project ID: {e}", file=sys.stderr)
+    return "demo-koryta-pl"
+
+
+def open_votes(args, login: Login | None = None) -> VoteStore:
+    """The way in that suits the endpoint this run is uploading to."""
+    database_id = getattr(args, "database", "koryta-pl")
+    project_id = getattr(args, "project", None)
+
+    if args.endpoint.startswith("http://localhost"):
+        os.environ["FIRESTORE_EMULATOR_HOST"] = "localhost:8080"
+        return AdminVotes(project_id or emulator_project_id(), database_id)
+
+    id_token = os.environ.get("KORYTA_ID_TOKEN")
+    if not id_token:
+        if login is None:
+            raise ValueError(
+                f"Writing to {args.endpoint} needs a Firebase id token: set "
+                "KORYTA_ID_TOKEN, or hand this call a way to log in."
+            )
+        id_token = login()
+    return RestVotes(project_id or "koryta-pl", database_id, id_token)
+
+
+class Firestore:
+    def __init__(
+        self,
+        args,
+        votes: VoteStore | None = None,
+        login: Login | None = None,
+    ):
+        self.votes = votes if votes is not None else open_votes(args, login)
+
+    def existing_scores(self, model: str) -> dict[str, int]:
+        """Node id -> the score this model last wrote, for the whole model.
+
+        One equality query on `userUid`, which the automatic single-field index
+        covers, and it returns only this model's own documents.
+        """
+        return self.votes.scores(model)
 
     def replace_scores(
         self, model: str, scores: list[PersonScore], retract: bool = True
@@ -123,34 +336,5 @@ class Firestore:
             file=sys.stderr,
         )
 
-        collection = self.db.collection("votes")
-        operations = 0
-        batch = self.db.batch()
-        for score in changed:
-            batch.set(
-                collection.document(self.vote_id(score.node_id, model)),
-                {
-                    "nodeId": score.node_id,
-                    "userUid": model,
-                    "categoryVotes": {"interesting": score.score},
-                },
-                merge=True,
-            )
-            operations += 1
-            if operations % BATCH_LIMIT == 0:
-                batch.commit()
-                batch = self.db.batch()
-                print(f"  committed {operations}...", file=sys.stderr)
-
-        for node_id in stale:
-            batch.delete(collection.document(self.vote_id(node_id, model)))
-            operations += 1
-            if operations % BATCH_LIMIT == 0:
-                batch.commit()
-                batch = self.db.batch()
-                print(f"  committed {operations}...", file=sys.stderr)
-
-        if operations % BATCH_LIMIT:
-            batch.commit()
-
+        self.votes.apply(model, changed, stale)
         return len(changed), len(stale)

--- a/data/scrapers/submit_scores.sh
+++ b/data/scrapers/submit_scores.sh
@@ -12,6 +12,11 @@ set -e
 # reconciles a whole model at once, writing only what changed and retracting
 # what the model no longer stands behind, and it can only do that for one model
 # per run.
+#
+# A prod run asks you to log in through the browser, once per model, and the
+# account has to be in the datascience group - that is what `firestore.rules`
+# lets write a pipeline's votes. Set KORYTA_ID_TOKEN to reuse one id token
+# instead of logging in for every model.
 
 if [[ $1 == prod ]]; then
 	SUFFIX="--prod --endpoint https://autopush.koryta.pl"

--- a/firestore.rules
+++ b/firestore.rules
@@ -35,11 +35,38 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // A score written by a scoring model rather than cast by a person: stored
+    // under the model's own uid, which is what `isPipelineUid` on both the
+    // frontend and the scrapers reads as non-human. Requiring the document id
+    // to spell out the same nodeId and uid is what stops this branch from being
+    // used to vote in somebody else's name.
+    function isPipelineVote(voteId, data) {
+      return data.nodeId is string
+          && data.userUid is string
+          && data.userUid.matches('.*pipeline.*')
+          && voteId == data.nodeId + '_' + data.userUid;
+    }
+
     match /votes/{voteId} {
       allow read: if true;
-      allow create, update, delete: if request.auth != null 
+      allow create, update, delete: if request.auth != null
           && voteId.matches('.*_' + request.auth.uid)
           && request.resource.data.userUid == request.auth.uid;
+
+      // Nobody signs in as a scoring model, so the check above can never cover
+      // the pipeline's own scores - they are uploaded by whoever runs
+      // `koryta_uploader --type score`, writing under the model's uid. Limited
+      // to the datascience group, the same gate the extractions they are
+      // computed from sit behind.
+      allow create, update: if request.auth != null
+          && request.auth.token.datascience == true
+          && isPipelineVote(voteId, request.resource.data);
+      // A model that no longer rates somebody retracts the score, so the
+      // reconciliation is a delete rather than a zero; `resource` is the
+      // document as stored, since a delete carries no payload.
+      allow delete: if request.auth != null
+          && request.auth.token.datascience == true
+          && isPipelineVote(voteId, resource.data);
       }
     }
   }


### PR DESCRIPTION
Uploading a model's shortlist went through the Admin SDK, which authenticates with application-default credentials and is judged by IAM rather than by firestore.rules. A person's Google account carries no Firestore role - only the deploy service accounts do - so anyone outside the admins got 403 Missing or insufficient permissions from the batch commit, however good their datascience claim was.

Against a deployed endpoint the uploader now presents the Firebase id token from the same browser login every other --type uses, and writes over the Firestore REST API, which evaluates the rules. The rules grow a branch for it: a datascience member may write a vote whose uid reads as a model's and whose document id spells out that uid and node, which is the shape replace_scores writes and the shape nobody can vote in a person's name with. A local stack is unchanged - the emulator asks for no credentials, so the Admin SDK path stays.

The rules are now part of the upload path, so tests/e2e/test_vote_rules.py puts them in front of the emulator and tries: both backends round-trip a model's scores, the claim is required, a forged document id is refused, and a person can still cast their own vote.