### PR TITLE
Stop uploading the crawl mirror to Cloud Build

### DIFF
--- a/data/scrapers/.gcloudignore
+++ b/data/scrapers/.gcloudignore
@@ -30,8 +30,18 @@ docker-compose.yml
 *.ipynb
 .ipynb_checkpoints/
 
+# Tool caches. Worth naming individually rather than trusting `.gitignore`,
+# which does not list the first two at all: a checkout someone has run mypy in
+# carries ~9,000 files and several hundred MB of `.mypy_cache` alone, so whether
+# the upload is 2 MB or 460 MB comes down to whether that person type-checks.
+.mypy_cache/
+.dmypy.json
+.ruff_cache/
 .pytest_cache/
 .pytest-runtimes
+.hypothesis/
+htmlcov/
+*.egg-info/
 **/__pycache__/
 *.pyc
 .coverage

--- a/data/scrapers/.gcloudignore
+++ b/data/scrapers/.gcloudignore
@@ -1,0 +1,43 @@
+# What `gcloud builds submit data/scrapers` may upload.
+#
+# Needed because `.dockerignore` is too late: it is applied by the docker build
+# running inside Cloud Build, long after gcloud has tarred this directory up and
+# pushed it to the staging bucket. Without this file that upload is 1.6 GB — the
+# `downloaded` symlink into the shared crawl mirror, plus whatever venv the
+# checkout happens to have — for an image whose context is 5 MB.
+#
+# gcloud would otherwise derive its own from `.gitignore`, but only for a git
+# repository root, and this is `data/scrapers` inside one.
+
+.gcloudignore
+.git
+.gitignore
+
+# The two big ones. `downloaded` is a symlink to ~/.cache/koryta/downloaded, a
+# mirror of gs://koryta-pl-crawled; `versioned` is pipeline output. The trailing
+# glob matches the way `.gitignore` spells them.
+downloaded*
+versioned*
+.venv/
+models/
+
+# Not copied by the Dockerfile, which installs with `--no-default-groups
+# --group service` and takes only pyproject.toml, uv.lock, README.md and src/.
+tests/
+src/tests/
+.agent/
+docker-compose.yml
+*.ipynb
+.ipynb_checkpoints/
+
+.pytest_cache/
+.pytest-runtimes
+**/__pycache__/
+*.pyc
+.coverage
+logs/
+crawler_output/
+
+# Credentials, on the same reasoning as `.gitignore`: never in a build context.
+.env
+koryta-pl*.json

--- a/data/scrapers/Dockerfile
+++ b/data/scrapers/Dockerfile
@@ -15,6 +15,18 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 WORKDIR /app
 
+# `leveldb-export` is the one dependency resolved from a git url rather than a
+# wheel, and the uv images are too slim to carry a git. Nothing the service
+# imports reaches it — that is `scrapers.koryta.download`, reading the nightly
+# Firestore export — but it is a base dependency of `scrapers`, and taking those
+# wholesale is what this image does on purpose.
+#
+# Its own layer, ahead of the copy, so editing pyproject.toml does not reinstall
+# it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 # Dependencies first, so a change to the source does not refetch them.
 COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --no-default-groups --group service --no-install-project

--- a/data/scrapers/Dockerfile
+++ b/data/scrapers/Dockerfile
@@ -5,7 +5,7 @@
 # their imports, and a trimmed list would break the next time one of them grew
 # an import. The `ml` group — torch, spacy and the nvidia runtimes, 4.5 GB of
 # the tree — is left out, which is where nearly all of the weight was.
-FROM ghcr.io/astral-sh/uv:0.11.33-python3.13-bookworm-slim
+FROM ghcr.io/astral-sh/uv:0.11.33-python3.13-trixie-slim
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \

--- a/data/scrapers/src/service/README.md
+++ b/data/scrapers/src/service/README.md
@@ -110,6 +110,12 @@ gcloud projects add-iam-policy-binding $PROJECT \
 gcloud iam service-accounts add-iam-policy-binding $SA \
   --member=serviceAccount:$SA --role=roles/iam.serviceAccountTokenCreator
 
+# The registry the image is pushed to. `builds submit --tag` will not create it,
+# and a missing one is only reported after the whole image has been built — as
+# `name unknown: Repository "koryta" not found` from the push step.
+gcloud artifacts repositories create koryta --repository-format=docker \
+  --location=$REGION --project=$PROJECT
+
 gcloud builds submit data/scrapers \
   --tag=$REGION-docker.pkg.dev/$PROJECT/koryta/capture-extractor
 

--- a/data/scrapers/src/service/README.md
+++ b/data/scrapers/src/service/README.md
@@ -110,6 +110,15 @@ gcloud projects add-iam-policy-binding $PROJECT \
 gcloud iam service-accounts add-iam-policy-binding $SA \
   --member=serviceAccount:$SA --role=roles/iam.serviceAccountTokenCreator
 
+# Read the secrets the revision mounts. Checked when the revision is created, so
+# without this the deploy fails rather than the first capture — and a secret
+# that does not exist at all reports the same "Permission denied on secret",
+# because Cloud Run will not say which of the two it is.
+for SECRET in openrouter-api-key url-store-api-key; do
+  gcloud secrets add-iam-policy-binding $SECRET --project=$PROJECT \
+    --member=serviceAccount:$SA --role=roles/secretmanager.secretAccessor
+done
+
 # The registry the image is pushed to. `builds submit --tag` will not create it,
 # and a missing one is only reported after the whole image has been built — as
 # `name unknown: Repository "koryta" not found` from the push step.
@@ -128,6 +137,13 @@ gcloud run deploy capture-extractor \
 
 gcloud tasks queues create article-extraction --location=$REGION
 ```
+
+`URL_STORE_API_KEY` above is mounted without a `URL_STORE_URL` beside it, and
+`url_store_enabled` wants both — so as written the key is inert and captures are
+never registered as fetched. Everything else works; what is lost is the nightly
+re-parse, because `ArticleDoneUrls` reads that registration. Add
+`URL_STORE_URL=…` to `--set-env-vars` to close the loop, or drop the secret from
+`--set-secrets` and accept the fast path as the only one that reads a capture.
 
 Then let the frontend reach it. The App Hosting backend runs as its own service
 account (`APP=…`); it needs to write the archive, enqueue the task, and act as

--- a/data/scrapers/src/service/README.md
+++ b/data/scrapers/src/service/README.md
@@ -110,14 +110,22 @@ gcloud projects add-iam-policy-binding $PROJECT \
 gcloud iam service-accounts add-iam-policy-binding $SA \
   --member=serviceAccount:$SA --role=roles/iam.serviceAccountTokenCreator
 
-# Read the secrets the revision mounts. Checked when the revision is created, so
-# without this the deploy fails rather than the first capture — and a secret
-# that does not exist at all reports the same "Permission denied on secret",
-# because Cloud Run will not say which of the two it is.
-for SECRET in openrouter-api-key url-store-api-key; do
-  gcloud secrets add-iam-policy-binding $SECRET --project=$PROJECT \
-    --member=serviceAccount:$SA --role=roles/secretmanager.secretAccessor
-done
+# The LLM key, as a secret rather than an env var, and read by the account the
+# revision runs as. `printf` rather than `echo`: a trailing newline becomes part
+# of the secret, and OpenRouter then answers 401 exactly as it would to a wrong
+# key. `read -rs` keeps it out of the shell history.
+gcloud secrets create openrouter-api-key --project=$PROJECT \
+  --replication-policy=automatic
+read -rs -p "OpenRouter key: " KEY
+printf '%s' "$KEY" | gcloud secrets versions add openrouter-api-key \
+  --project=$PROJECT --data-file=-
+unset KEY
+
+# Checked when the revision is created, so a missing grant fails the deploy
+# rather than the first capture. A secret that does not exist reports the same
+# "Permission denied on secret" — Cloud Run will not distinguish the two.
+gcloud secrets add-iam-policy-binding openrouter-api-key --project=$PROJECT \
+  --member=serviceAccount:$SA --role=roles/secretmanager.secretAccessor
 
 # The registry the image is pushed to. `builds submit --tag` will not create it,
 # and a missing one is only reported after the whole image has been built — as
@@ -133,17 +141,38 @@ gcloud run deploy capture-extractor \
   --region=$REGION --service-account=$SA --no-allow-unauthenticated \
   --memory=2Gi --cpu=1 --timeout=1800 --max-instances=4 \
   --set-env-vars=KORYTA_API_URL=https://koryta.pl,FIREBASE_WEB_API_KEY=AIzaSyD54RK-k0TIcJtVbZerx2947XiduteqvaM \
-  --set-secrets=LLM_API_KEY=openrouter-api-key:latest,URL_STORE_API_KEY=url-store-api-key:latest
+  --set-secrets=LLM_API_KEY=openrouter-api-key:latest
 
+gcloud services enable cloudtasks.googleapis.com --project=$PROJECT
 gcloud tasks queues create article-extraction --location=$REGION
 ```
 
-`URL_STORE_API_KEY` above is mounted without a `URL_STORE_URL` beside it, and
-`url_store_enabled` wants both — so as written the key is inert and captures are
-never registered as fetched. Everything else works; what is lost is the nightly
-re-parse, because `ArticleDoneUrls` reads that registration. Add
-`URL_STORE_URL=…` to `--set-env-vars` to close the loop, or drop the secret from
-`--set-secrets` and accept the fast path as the only one that reads a capture.
+## Letting the nightly run see a capture
+
+The deploy above leaves `url_store` off, which costs the second pass: a capture
+is extracted once by this service and never re-parsed by the batch pipeline,
+because `ArticleDoneUrls` finds it by the registration that is not being written.
+The facts still land in `/ekstrakcje`; they are just the fast model's only word
+on the page.
+
+`url_store_enabled` wants a url *and* a key, so turning it on is both halves —
+mounting the key alone does nothing, silently:
+
+```bash
+gcloud secrets create url-store-api-key --project=$PROJECT \
+  --replication-policy=automatic
+read -rs -p "url_store key: " KEY
+printf '%s' "$KEY" | gcloud secrets versions add url-store-api-key \
+  --project=$PROJECT --data-file=-
+unset KEY
+
+gcloud secrets add-iam-policy-binding url-store-api-key --project=$PROJECT \
+  --member=serviceAccount:$SA --role=roles/secretmanager.secretAccessor
+
+gcloud run services update capture-extractor --region=$REGION \
+  --update-env-vars=URL_STORE_URL=https://… \
+  --update-secrets=URL_STORE_API_KEY=url-store-api-key:latest
+```
 
 Then let the frontend reach it. The App Hosting backend runs as its own service
 account (`APP=…`); it needs to write the archive, enqueue the task, and act as

--- a/data/scrapers/src/service/README.md
+++ b/data/scrapers/src/service/README.md
@@ -70,7 +70,7 @@ to `$CAPTURE_LOCAL_DIR` (default `$TMPDIR/koryta-captures`) under the same
 | `FIREBASE_WEB_API_KEY`               | —                              | required; public, same value as `nuxt.config.ts`              |
 | `LLM_API_KEY`                        | —                              | required; also read from `OPENROUTER_APIKEY`/`OPENAI_API_KEY` |
 | `LLM_BASE_URL`                       | `https://openrouter.ai/api/v1` | any OpenAI-compatible endpoint                                |
-| `LLM_MODEL`                          | `qwen/qwen3-32b`               |                                                               |
+| `LLM_MODEL`                          | `qwen/qwen3-235b-a22b-2507`    |                                                               |
 | `LLM_LANES`                          | `4`                            | concurrent requests; the per-fact judgements use them         |
 | `EXTRACTOR_UID`                      | `capture-extractor`            | the Firebase uid this service signs in as                     |
 | `EXTRACTION_TAG`                     | `capture_v1`                   | stamped on every submitted fact                               |
@@ -81,6 +81,12 @@ to `$CAPTURE_LOCAL_DIR` (default `$TMPDIR/koryta-captures`) under the same
 The model is deliberately not the batch pipeline's `Qwen/Qwen3-14B`: there is no
 GPU behind Cloud Run, so this goes to a hosted endpoint. Facts from the two
 runs will not be identical, which is what the tag is for.
+
+It is also a much larger model than the batch run's, for the same reason the
+score does not gate extraction here: this is one page a person chose, not one of
+millions crawled, so the per-page cost that makes a 235B model impossible
+nightly is a rounding error on a single capture — and a capture is the one path
+where the reader is waiting for the answer and can see it be wrong.
 
 ## Deploying
 

--- a/data/scrapers/src/service/config.py
+++ b/data/scrapers/src/service/config.py
@@ -89,7 +89,7 @@ def config() -> Config:
         firebase_api_key=required["FIREBASE_WEB_API_KEY"],
         extractor_uid=os.environ.get("EXTRACTOR_UID", "capture-extractor"),
         firestore_database=os.environ.get("FIRESTORE_DATABASE", "koryta-pl"),
-        llm_model=os.environ.get("LLM_MODEL", "qwen/qwen3-32b"),
+        llm_model=os.environ.get("LLM_MODEL", "qwen/qwen3-235b-a22b-2507"),
         llm_base_url=os.environ.get("LLM_BASE_URL", "https://openrouter.ai/api/v1"),
         llm_api_key=required["LLM_API_KEY"],
         llm_lanes=_int("LLM_LANES", 4),

--- a/frontend/apphosting.yaml
+++ b/frontend/apphosting.yaml
@@ -8,14 +8,59 @@ runConfig:
   memoryMiB: 1024
 
 # Environment variables and secrets.
-# env:
-# Configure environment variables.
 # See https://firebase.google.com/docs/app-hosting/configure#user-defined-environment
-# - variable: MESSAGE
-#   value: Hello world!
-#   availability:
-#     - BUILD
-#     - RUNTIME
+#
+# Everything below is BUILD as well as RUNTIME, and the BUILD half is the one
+# that matters: nuxt.config.ts reads these through `process.env` while it is
+# building, and at runtime nitro only overrides runtimeConfig from `NUXT_`-
+# prefixed names. A RUNTIME-only entry here would be read by nobody, and every
+# capture would go on reporting "extractor not configured" with the variable
+# plainly set in the console.
+#
+# Shared by both backends on purpose. `prod` serves koryta.pl, which is the
+# extension's default origin; `autopush` gets the same wiring so the flow can be
+# exercised there. Note the extractor's own KORYTA_API_URL is https://koryta.pl,
+# so facts from either backend's captures are submitted to production.
+env:
+  # Cloud Tasks rather than a direct call: the extraction is tens of seconds and
+  # Cloud Run throttles the cpu once a response is written. "direct" is for a
+  # laptop, where there is no metadata server to mint a token with.
+  - variable: EXTRACTOR_DISPATCH
+    value: tasks
+    availability:
+      - BUILD
+      - RUNTIME
+
+  - variable: EXTRACTOR_URL
+    value: https://capture-extractor-735903577811.europe-central2.run.app
+    availability:
+      - BUILD
+      - RUNTIME
+
+  # The account Cloud Tasks mints the request's OIDC token as, and so the one
+  # holding run.invoker on the service above — not the account this backend runs
+  # as, which only needs serviceAccountUser on it.
+  - variable: EXTRACTOR_SERVICE_ACCOUNT
+    value: capture-extractor@koryta-pl.iam.gserviceaccount.com
+    availability:
+      - BUILD
+      - RUNTIME
+
+  # These two restate what nuxt.config.ts already defaults to. Spelled out anyway
+  # so the deployed wiring reads in one place: the queue is a thing that exists
+  # in gcloud, and someone moving it should not have to know that the only
+  # record of its name is a fallback in a build config.
+  - variable: EXTRACTOR_LOCATION
+    value: europe-central2
+    availability:
+      - BUILD
+      - RUNTIME
+
+  - variable: EXTRACTOR_QUEUE
+    value: article-extraction
+    availability:
+      - BUILD
+      - RUNTIME
 
 # Grant access to secrets in Cloud Secret Manager.
 # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters


### PR DESCRIPTION
`gcloud builds submit data/scrapers` was sending 1.6 GB for an image whose context is under 2 MB: the `downloaded` symlink into ~/.cache/koryta/downloaded is a 1.4 GB mirror of gs://koryta-pl-crawled, and a checkout's .venv is larger still.

`.dockerignore` already names all of them, but it is read by the docker build running inside Cloud Build — long after gcloud has tarred the directory up and pushed it to the staging bucket. The upload reads `.gcloudignore`, and gcloud only derives one from `.gitignore` at a git repository root, which this is not.

Leaves src/**/verified_selectors.json in, which `.gitignore` also un-ignores by hand: oneshot.parse_page reads the learned selectors.