### PR TITLE
Put the space back between a register and its number

### DIFF
--- a/frontend/app/components/card/CompanySummary.vue
+++ b/frontend/app/components/card/CompanySummary.vue
@@ -10,7 +10,10 @@
 
           <div class="d-flex flex-wrap align-center ga-4 text-body-2">
             <span v-for="identifier in identifiers" :key="identifier.register">
-              <strong>{{ identifier.register }}:</strong>
+              <!-- The gap belongs to the label: Vue drops the whitespace
+                   between two tags, and "REGON:123456785" reads as one number.
+                   Non-breaking, so a register never wraps off its own value. -->
+              <strong>{{ identifier.register }}:&nbsp;</strong>
               <a
                 v-if="identifier.url"
                 :href="identifier.url"

--- a/frontend/tests/components/card/CompanySummary.test.ts
+++ b/frontend/tests/components/card/CompanySummary.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import CompanySummary from "../../../app/components/card/CompanySummary.vue";
+import type { Company } from "../../../shared/model";
+
+const company = {
+  id: "chain-company",
+  type: "place",
+  name: "Firma Testowa",
+  regonNumber: "123456785",
+  nipNumber: "5260250274",
+  krsNumber: "0000357114",
+} as Company;
+
+describe("CardCompanySummary", () => {
+  it("keeps a register apart from its number", async () => {
+    const wrapper = await mountSuspended(CompanySummary, {
+      props: { company, location: "Powiat Testowy" },
+    });
+    // The template writes this gap out: whitespace between two tags is dropped
+    // by the compiler, and "REGON:123456785" reads as one long number. The
+    // linked identifiers lose it the same way, hence KRS here too.
+    expect(wrapper.text().replace(/\s+/g, " ")).toContain("REGON: 123456785");
+    expect(wrapper.text().replace(/\s+/g, " ")).toContain("NIP: 5260250274");
+    expect(wrapper.text().replace(/\s+/g, " ")).toContain("KRS: 0000357114");
+  });
+});


### PR DESCRIPTION
Making the KRS number a link turned the identifier value into tags, and Vue drops a whitespace-only node between two tags - so every company card has been reading "REGON:123456785". The gap belongs to the label now, and is non-breaking, so a register never wraps off its own value.

A unit test covers it: the e2e suite caught this, but only after a full dev stack and six minutes.