### PR TITLE
Stop argparse from reading --all as --all-pipelines

### DIFF
--- a/data/scrapers/src/koryta.py
+++ b/data/scrapers/src/koryta.py
@@ -47,7 +47,10 @@ class Printer:
 
 
 def get_args():
-    parser = argparse.ArgumentParser()
+    # allow_abbrev=False: argparse would otherwise accept --all as an
+    # unambiguous abbreviation of --all-pipelines and swallow the flag that
+    # scrapers.analysis.extract reads off the same argv.
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument(
         "--refresh",
         help="Pipeline name to refresh, : to exclude or 'all'",


### PR DESCRIPTION
--all-pipelines was deliberately not named --all so that scrapers.analysis.extract could read --all off the same argv, but argparse's prefix abbreviation expands the short form anyway: nothing else in the top-level parser starts with --all, so

    koryta PeoplePayloads --all

set all_pipelines and then died on its own pipeline name.  Turn abbreviation off, and the flag reaches the parser that owns it.