### PR TITLE
List only the people the scoring models would have nominated

### DIFF
--- a/data/scrapers/README.md
+++ b/data/scrapers/README.md
@@ -47,6 +47,43 @@ You can run each script with `uv run scripts-name`.
 
 Refer to `pyproject.toml` for the most up-to-date list of the scripts available there.
 
+## Which people a run submits
+
+`PeoplePayloads` builds the payloads the uploader posts to koryta.pl, and
+`Extract`'s flags decide who is in them. `--all` is a hundred thousand people,
+which is more than anybody reviews, so `--min-score` narrows the list to the
+ones the site's own scoring models rate that highly - on the same 1-5 scale the
+site shows:
+
+```bash
+uv run koryta PeoplePayloads --all --min-score 3 --no-backup \
+  --refresh :PeopleEnriched --refresh :CompaniesKRS   # ~25s
+```
+
+All five models in `analysis.scores` run over the payloads before they are
+listed and a person keeps the best band any of them gave, which is the number
+the site displays, so the threshold means there what it means here. Two groups
+are not asked the question: whoever the site has already published or a human
+has already voted on keeps that verdict, and a name from one of the hardcoded
+press lists is listed whatever the models think of them.
+
+The models seed on the site's own export, so a scored run reads
+`person_koryta_<date>` and `person_votes_<date>` as well. It prints the
+distribution before it filters - on the 100,257 people an `--all` run listed on
+2026-08-20 that was:
+
+| band | people |
+| ---- | ------ |
+| 5 | 3,091 |
+| 4 | 8,066 |
+| 3 | 16,495 |
+| 2 | 30,765 |
+| 1 | 40,434 |
+| unrated | 1,406 |
+
+so `--min-score 2` lists nearly three fifths of them and `--min-score 3` about
+a quarter.
+
 ## Centralny Rejestr Umów (CRU)
 
 `CruDump` fetches the public contracts register from a postgres mirror of the

--- a/data/scrapers/src/analysis/extract.py
+++ b/data/scrapers/src/analysis/extract.py
@@ -185,6 +185,19 @@ class Extract(Pipeline):
             action=argparse.BooleanOptionalAction,
         )
         parser.add_argument(
+            "--min-score",
+            type=int,
+            # The bands `analysis.scores.base.SCORE_BANDS` hands out, spelled
+            # out rather than imported: the models are built on the payloads,
+            # which are built on this, so importing them here is a cycle.
+            choices=[1, 2, 3, 4, 5],
+            help="Only list people the scoring models rate this highly, on "
+            "the same 1-5 scale the site shows. Applied one pipeline later, by "
+            "PeoplePayloads - see its `min_score` property.",
+            default=None,
+            required=False,
+        )
+        parser.add_argument(
             "--rejestrio-id",
             help="Extract a person with a given RejestrIO id",
             default=None,
@@ -226,6 +239,17 @@ class Extract(Pipeline):
     @property
     def rejestrio_id(self) -> str | None:
         return self.args.rejestrio_id
+
+    @property
+    def min_score(self) -> int | None:
+        """The lowest band a person can be rated and still be listed, if any.
+
+        Defined with the rest of the filters that decide who this run is about,
+        and applied by `PeoplePayloads` rather than here, because the models
+        that do the rating read a person's employers and candidacies in the
+        payload shapes - which is one pipeline further on than this.
+        """
+        return self.args.min_score
 
     @property
     def employed_after(self) -> bool:

--- a/data/scrapers/src/analysis/payloads/person.py
+++ b/data/scrapers/src/analysis/payloads/person.py
@@ -19,6 +19,15 @@ UNMAPPED_COMMITTEES_REPORTED = 20
 
 
 class PeoplePayloads(Pipeline[Person]):
+    """The person payloads the uploader submits to koryta.pl.
+
+    Who they are for is `Extract`'s question, and its flags answer it.
+    `--min-score` is the one this pipeline has to apply itself: it narrows the
+    list to the people the site's own scoring models rate at least that highly,
+    and those models read a person's employers and candidacies in the shapes
+    built here.
+    """
+
     # TODO save to the same file as extract
     volatile = True
 
@@ -37,10 +46,8 @@ class PeoplePayloads(Pipeline[Person]):
             unmapped.update(unmapped_committees(person.elections))
             result.append(person)
         report_unmapped_committees(unmapped)
-        return (
-            pd.DataFrame.from_records([asdict(p) for p in result])
-            if result
-            else pd.DataFrame(
+        if not result:
+            return pd.DataFrame(
                 columns=[
                     "name",
                     "companies",
@@ -50,7 +57,8 @@ class PeoplePayloads(Pipeline[Person]):
                     "rejestrIo",
                 ]
             )
-        )
+        payloads = pd.DataFrame.from_records([asdict(p) for p in result])
+        return filter_by_score(ctx, payloads, self.people.min_score)
 
     def map_person_payload(self, ctx: Context, row: pd.Series) -> Person:
         def get_scalar(key):
@@ -101,6 +109,72 @@ class PeoplePayloads(Pipeline[Person]):
             wikipedia=wikipedia_url,
             rejestrIo=rejestrIo,
             autoapprove=count > 0,
+        )
+
+
+def filter_by_score(
+    ctx: Context, payloads: pd.DataFrame, min_score: int | None
+) -> pd.DataFrame:
+    """The payloads worth listing, when the run asked for a minimum band.
+
+    A run that lists everybody lists something like a hundred thousand people,
+    which is not a queue anybody works through; `--min-score` narrows it to the
+    ones the site's own scoring models would have nominated. Those models are
+    not sources of this pipeline and cannot be: they are built on its output,
+    which is also why the import below is where it is.
+    """
+    if min_score is None:
+        return payloads
+
+    from analysis.scores.ensemble import score_payloads  # noqa: PLC0415
+
+    scores = score_payloads(ctx, payloads)
+    kept = payloads[keep_mask(payloads, scores, min_score)]
+    report_scores(payloads, scores, kept, min_score)
+    return kept.reset_index(drop=True)
+
+
+def keep_mask(
+    payloads: pd.DataFrame, scores: dict[str, int], min_score: int
+) -> pd.Series:
+    """Which rows a `--min-score` run still lists.
+
+    The threshold is a question about people nobody has judged yet, so it is
+    not asked of those already named by one of the hardcoded press lists: that
+    is what `autoapprove` marks, the ingest approves those revisions without a
+    review, and a model rating them low says only that the model has not heard
+    of them. Whoever the site itself has published or voted on is answered
+    inside `score_payloads`.
+    """
+    rated = payloads["name"].map(lambda name: scores.get(name, 0) >= min_score)
+    return rated | payloads["autoapprove"].fillna(False).astype(bool)
+
+
+def report_scores(
+    payloads: pd.DataFrame,
+    scores: dict[str, int],
+    kept: pd.DataFrame,
+    min_score: int,
+) -> None:
+    """How the run was rated, and what the threshold did to it."""
+    bands = collections.Counter(scores.get(name, 0) for name in payloads["name"])
+    print(f"Listing {len(kept)} of {len(payloads)} people, band {min_score} and up:")
+    for band, count in sorted(bands.items(), reverse=True):
+        label = f"band {band}" if band else "unrated"
+        print(f"  {label:<10}{count:>8}")
+
+    on_a_list = sum(
+        1
+        for name, approved in zip(payloads["name"], payloads["autoapprove"])
+        if approved and scores.get(name, 0) < min_score
+    )
+    if on_a_list:
+        print(f"  {on_a_list} of them listed on a press list's say-so, not on a band")
+    if kept.empty:
+        print(
+            "Nobody cleared the threshold, so this run lists nobody. Either the "
+            "band is higher than anything the models handed out, or the site's "
+            "export the models seed on came back empty."
         )
 
 

--- a/data/scrapers/src/analysis/scores/base.py
+++ b/data/scrapers/src/analysis/scores/base.py
@@ -137,6 +137,22 @@ class Population:
     def has_candidacy(self, name: str) -> bool:
         return bool(self.candidacies.get(name))
 
+    def with_shortlist(self, names: typing.Iterable[str]) -> "Population":
+        """The same population, asked about these people instead.
+
+        Whoever the caller names, the already-judged are dropped from the
+        shortlist: a seed is the answer key, and a model that scored one would
+        be marking its own homework. Duplicates go with them - the site's
+        export is read twice on a day it was dumped twice, and a name rated
+        twice is rated no differently.
+        """
+        return dataclasses.replace(
+            self,
+            shortlist=[
+                name for name in dict.fromkeys(names) if name not in self.seed_weights
+            ],
+        )
+
 
 def banded_scores(raw: typing.Mapping[str, float]) -> dict[str, int]:
     """Put a model's raw output on the shared 1-5 scale.
@@ -225,111 +241,127 @@ class PeopleScoreModel(Pipeline):
         return df.astype({"score": "int32"})
 
     def population(self, ctx: Context) -> Population:
-        people = self.people_payloads.read_or_process(ctx)
-        koryta = self.people_koryta.read_or_process(ctx)
-        votes = self.people_votes.read_or_process(ctx)
-        companies = self.companies_krs.read_or_process(ctx)
-
-        node_ids = dict(zip(koryta["full_name"], koryta["id"]))
-        human_votes = self.human_votes(votes, koryta)
-
-        employments: dict[str, list[Employment]] = {}
-        candidacies: dict[str, list[Candidacy]] = {}
-        roster: dict[str, list[str]] = {}
-
-        for _, row in people.iterrows():
-            name = str(row.get("name"))
-            posts = [
-                Employment(
-                    krs=str(company["krs"]),
-                    role=company.get("role"),
-                    start=company.get("start"),
-                    end=company.get("end"),
-                )
-                for company in iter_dicts(row.get("companies"))
-                if company.get("krs")
-            ]
-            employments[name] = posts
-            for post in posts:
-                roster.setdefault(post.krs, []).append(name)
-
-            candidacies[name] = [
-                Candidacy(
-                    year=election.get("election_year"),
-                    teryt=election.get("teryt"),
-                    party=election.get("party"),
-                    committee=election.get("committee"),
-                )
-                for election in iter_dicts(row.get("elections"))
-            ]
-
-        seed_weights: dict[str, float] = {}
-        shortlist: list[str] = []
-        for _, entry in koryta.iterrows():
-            name = str(entry.get("full_name"))
-            is_public = entry.get("is_public", False)
-            if pd.isna(is_public):
-                is_public = False
-
-            vote = human_votes.get(str(entry.get("id")), 0.0)
-            if is_public:
-                seed_weights[name] = max(seed_weights.get(name, 0.0), IS_PUBLIC_SCORE)
-            elif vote:
-                seed_weights[name] = vote
-            elif name in employments:
-                shortlist.append(name)
-
-        return Population(
-            people=people,
-            node_ids=node_ids,
-            employments=employments,
-            candidacies=candidacies,
-            roster=roster,
-            companies=self.company_facts(companies),
-            seed_weights=seed_weights,
-            shortlist=shortlist,
+        return population_from(
+            people=self.people_payloads.read_or_process(ctx),
+            koryta=self.people_koryta.read_or_process(ctx),
+            votes=self.people_votes.read_or_process(ctx),
+            companies=self.companies_krs.read_or_process(ctx),
         )
 
-    @staticmethod
-    def human_votes(votes: pd.DataFrame, koryta: pd.DataFrame) -> dict[str, float]:
-        """Node id -> the sum of what people voted on it.
 
-        `KorytaPeople.votes_interesting` would be the obvious source and is the
-        wrong one: it is the site's own aggregate, which includes the
-        pipeline's vote. A model seeded on it would be seeded on its own output
-        and, worse, `shortlist` would drop everybody the pipeline had ever
-        scored, so no run after the first could revise a score.
-        """
-        if votes.empty or "person_koryta_id" not in votes:
-            return {}
-        totals: dict[str, float] = {}
-        for _, row in votes.iterrows():
-            target = row.get("person_koryta_id")
-            interesting = row.get("interesting")
-            # NaN rather than a blank is what a vote with no node on it looks
-            # like once pandas has been through it, and NaN is truthy - see
-            # `KorytaVotes.process`, which is where those get dropped now.
-            if pd.isna(target) or interesting is None or pd.isna(interesting):
-                continue
-            node_id = str(target).strip()
-            if not node_id:
-                continue
-            totals[node_id] = totals.get(node_id, 0.0) + float(interesting)
-        return totals
+def population_from(
+    people: pd.DataFrame,
+    koryta: pd.DataFrame,
+    votes: pd.DataFrame,
+    companies: pd.DataFrame,
+) -> Population:
+    """The population, from the four frames it is unpacked out of.
 
-    @staticmethod
-    def company_facts(companies: pd.DataFrame) -> dict[str, CompanyFacts]:
-        if companies.empty or "krs" not in companies:
-            return {}
-        facts = {}
-        for _, row in companies.iterrows():
-            krs = row.get("krs")
-            if not krs or pd.isna(krs):
-                continue
-            is_public = row.get("is_public", False)
-            facts[str(krs)] = CompanyFacts(
-                name=row.get("name"),
-                teryt=str(row["teryt_code"]) if row.get("teryt_code") else None,
-                is_public=bool(is_public) if not pd.isna(is_public) else False,
+    Taken apart from the pipeline that usually reads them because the payloads
+    are not always on disk when somebody wants them scored: `PeoplePayloads`
+    rates the frame it has just built, in the same process, and asking a
+    pipeline for it there would rebuild it underneath the run doing the rating.
+    """
+    node_ids = dict(zip(koryta["full_name"], koryta["id"]))
+    votes_by_node = human_votes(votes)
+
+    employments: dict[str, list[Employment]] = {}
+    candidacies: dict[str, list[Candidacy]] = {}
+    roster: dict[str, list[str]] = {}
+
+    for _, row in people.iterrows():
+        name = str(row.get("name"))
+        posts = [
+            Employment(
+                krs=str(company["krs"]),
+                role=company.get("role"),
+                start=company.get("start"),
+                end=company.get("end"),
             )
-        return facts
+            for company in iter_dicts(row.get("companies"))
+            if company.get("krs")
+        ]
+        employments[name] = posts
+        for post in posts:
+            roster.setdefault(post.krs, []).append(name)
+
+        candidacies[name] = [
+            Candidacy(
+                year=election.get("election_year"),
+                teryt=election.get("teryt"),
+                party=election.get("party"),
+                committee=election.get("committee"),
+            )
+            for election in iter_dicts(row.get("elections"))
+        ]
+
+    seed_weights: dict[str, float] = {}
+    shortlist: list[str] = []
+    for _, entry in koryta.iterrows():
+        name = str(entry.get("full_name"))
+        is_public = entry.get("is_public", False)
+        if pd.isna(is_public):
+            is_public = False
+
+        vote = votes_by_node.get(str(entry.get("id")), 0.0)
+        if is_public:
+            seed_weights[name] = max(seed_weights.get(name, 0.0), IS_PUBLIC_SCORE)
+        elif vote:
+            seed_weights[name] = vote
+        elif name in employments:
+            shortlist.append(name)
+
+    return Population(
+        people=people,
+        node_ids=node_ids,
+        employments=employments,
+        candidacies=candidacies,
+        roster=roster,
+        companies=company_facts(companies),
+        seed_weights=seed_weights,
+        shortlist=shortlist,
+    )
+
+
+def human_votes(votes: pd.DataFrame) -> dict[str, float]:
+    """Node id -> the sum of what people voted on it.
+
+    `KorytaPeople.votes_interesting` would be the obvious source and is the
+    wrong one: it is the site's own aggregate, which includes the pipeline's
+    vote. A model seeded on it would be seeded on its own output and, worse,
+    `shortlist` would drop everybody the pipeline had ever scored, so no run
+    after the first could revise a score.
+    """
+    if votes.empty or "person_koryta_id" not in votes:
+        return {}
+    totals: dict[str, float] = {}
+    for _, row in votes.iterrows():
+        target = row.get("person_koryta_id")
+        interesting = row.get("interesting")
+        # NaN rather than a blank is what a vote with no node on it looks like
+        # once pandas has been through it, and NaN is truthy - see
+        # `KorytaVotes.process`, which is where those get dropped now.
+        if pd.isna(target) or interesting is None or pd.isna(interesting):
+            continue
+        node_id = str(target).strip()
+        if not node_id:
+            continue
+        totals[node_id] = totals.get(node_id, 0.0) + float(interesting)
+    return totals
+
+
+def company_facts(companies: pd.DataFrame) -> dict[str, CompanyFacts]:
+    if companies.empty or "krs" not in companies:
+        return {}
+    facts = {}
+    for _, row in companies.iterrows():
+        krs = row.get("krs")
+        if not krs or pd.isna(krs):
+            continue
+        is_public = row.get("is_public", False)
+        facts[str(krs)] = CompanyFacts(
+            name=row.get("name"),
+            teryt=str(row["teryt_code"]) if row.get("teryt_code") else None,
+            is_public=bool(is_public) if not pd.isna(is_public) else False,
+        )
+    return facts

--- a/data/scrapers/src/analysis/scores/company.py
+++ b/data/scrapers/src/analysis/scores/company.py
@@ -15,6 +15,7 @@ so the uplaoder can diff if we need/have to update the scores or not.
 """
 
 import dataclasses
+import typing
 
 import pandas as pd
 
@@ -45,6 +46,44 @@ def normalized_scores(scores: pd.DataFrame, n: NormalizationFactors) -> pd.Serie
         .sum()
     ) / (len(scores) + CONFIDENCE_FACTOR)
     return pd.Series({"score": ratio})
+
+
+def company_score_map(
+    payloads: pd.DataFrame, person_scores: typing.Mapping[str, float]
+) -> dict[str, float]:
+    """KRS -> how the people in it are rated, from a person->score map.
+
+    A parameter rather than the pipeline's own source because two callers need
+    the same arithmetic over scores the pipeline has not got: the recall
+    harness rebuilds it per fold so a held-out person cannot be graded on their
+    own `is_public`, and `PeoplePayloads` rebuilds it from the population it is
+    filtering, which is mid-run and cannot ask a pipeline built on itself.
+    """
+    records = []
+    for _, row in payloads.iterrows():
+        score = person_scores.get(row["name"], 0)
+        if not score:
+            continue
+
+        for company in as_sequence(row.get("companies")):
+            if isinstance(company, dict):
+                krs = company.get("krs")
+            else:
+                krs = getattr(company, "krs", None)
+            if krs:
+                records.append({"krs": krs, "score": score})
+
+    if not records:
+        return {}
+
+    df = pd.DataFrame.from_records(records)
+    factors = NormalizationFactors(
+        min_score=df["score"].min(), max_score=df["score"].max()
+    )
+    scored = df.groupby("krs", as_index=False)[["score"]].apply(
+        lambda s: normalized_scores(s, factors)
+    )
+    return dict(zip(scored["krs"], scored["score"]))
 
 
 class CompanyScores(Pipeline):
@@ -109,38 +148,16 @@ class CompanyScores(Pipeline):
         scores = self.person_scores(ctx, person_names)
         people_df = self.people_payloads.read_or_process(ctx)
 
-        records = []
-        for _, row in people_df.iterrows():
-            person_score = scores.get(row["name"], 0)
-            if person_score == 0:
-                continue
-
-            for company in as_sequence(row.get("companies")):
-                if isinstance(company, dict):
-                    krs = company.get("krs")
-                else:
-                    krs = getattr(company, "krs", None)
-                if krs:
-                    records.append({"krs": krs, "score": person_score})
-
-        if not records:
+        by_krs = company_score_map(people_df, scores)
+        if not by_krs:
             return pd.DataFrame(columns=["krs", "sum_score"])
 
-        df = pd.DataFrame.from_records(records)
-
-        statistics = NormalizationFactors(
-            min_score=df["score"].min(), max_score=df["score"].max()
+        scores_df = pd.DataFrame(
+            {"krs": list(by_krs.keys()), "sum_score": list(by_krs.values())}
         )
-        scores_df = df.groupby("krs", as_index=False)[["score"]].apply(
-            lambda s: normalized_scores(s, statistics)
-        )
-
-        scores_df = scores_df.rename(columns={"score": "sum_score"})
-        scores_df = scores_df.sort_values(by="sum_score", ascending=False).reset_index(
+        return scores_df.sort_values(by="sum_score", ascending=False).reset_index(
             drop=True
         )
-
-        return scores_df
 
 
 class PeopleScores(PeopleScoreModel):

--- a/data/scrapers/src/analysis/scores/ensemble.py
+++ b/data/scrapers/src/analysis/scores/ensemble.py
@@ -1,0 +1,142 @@
+"""What all five models together say about a person.
+
+Each model in `analysis.scores` writes its own vote and the site takes the best
+of them, because somebody the co-appointment model has nothing to say about may
+be exactly the one PageRank found. Anything that needs one number per person -
+the `--min-score` filter on the payloads, the recall harness that grades the
+models - has to do that same best-of-five, and doing it twice would let the two
+drift apart.
+
+`PeopleScores` is the awkward one. It reads its company scores off a pipeline
+that is itself built from the payloads, so asking for it by pipeline while the
+payloads are being built would rebuild them underneath the run doing the
+asking. Its company scores are recomputed here from the population's own seeds
+instead, which is what `CompanyScores` does with them anyway.
+"""
+
+import typing
+
+import pandas as pd
+
+from analysis.scores import PEOPLE_SCORE_MODELS
+from analysis.scores.base import (
+    SCORE_BANDS,
+    PeopleScoreModel,
+    Population,
+    banded_scores,
+    population_from,
+)
+from analysis.scores.company import PeopleScores, company_score_map
+from scrapers.stores import Context, Pipeline
+
+#: What the site's own judgement is worth on the models' scale. A page somebody
+#: published or a person somebody upvoted is not a nomination to be ranked
+#: against nominations; it is the thing the models are trying to predict.
+CONFIRMED_BAND = max(points for _, points in SCORE_BANDS)
+
+
+def people_scores_raw(
+    model: PeopleScores, population: Population, payloads: pd.DataFrame
+) -> dict[str, float]:
+    """`PeopleScores.raw_scores`, over company scores built here.
+
+    Same two halves in the same proportion - the employers' ratings and how
+    often the person has stood for office - off a company map rebuilt from this
+    population's positive seeds rather than read from `CompanyScores`.
+    """
+    companies = company_score_map(payloads, population.seeds())
+
+    def score(name: str) -> float:
+        posts = population.employments.get(name, [])
+        return model.calculate_weighted(
+            (model.total_company_score(posts, companies), model.COMPANY_WEIGHT),
+            (
+                model.elections_score(population.candidacies.get(name, [])),
+                model.ELECTION_WEIGHT,
+            ),
+        )
+
+    return {name: score(name) for name in population.shortlist}
+
+
+def model_bands(
+    model: PeopleScoreModel,
+    ctx: Context,
+    population: Population,
+    payloads: pd.DataFrame,
+) -> dict[str, int]:
+    """One model's 1-5 verdict on this population's shortlist."""
+    if isinstance(model, PeopleScores):
+        raw = people_scores_raw(model, population, payloads)
+    else:
+        raw = model.raw_scores(ctx, population)
+
+    eligible = set(population.shortlist)
+    return banded_scores({name: s for name, s in raw.items() if name in eligible})
+
+
+def best_bands(
+    ctx: Context,
+    population: Population,
+    payloads: pd.DataFrame,
+    models: typing.Sequence[PeopleScoreModel],
+) -> dict[str, int]:
+    """The best band any of `models` gave each person on the shortlist."""
+    best: dict[str, int] = {}
+    for model in models:
+        bands = model_bands(model, ctx, population, payloads)
+        print(f"  {model.model_tag:<22} rated {len(bands)}")
+        for name, band in bands.items():
+            best[name] = max(best.get(name, 0), band)
+    return best
+
+
+def score_payloads(
+    ctx: Context,
+    payloads: pd.DataFrame,
+    models: typing.Sequence[PeopleScoreModel] | None = None,
+) -> dict[str, int]:
+    """How highly the models rate each person in a payload frame, 1-5.
+
+    The models normally answer a question about the site: of the people it
+    already has a node for and nobody has looked at yet, who should somebody
+    open next. Asked of a payload frame the question is the other one - of the
+    people this run is about to submit, most of whom the site has never heard
+    of, which are worth submitting - so the shortlist is everybody in the frame
+    rather than everybody in the export.
+
+    People the site has already judged keep the site's judgement: a published
+    page or a human upvote is a fact and comes back as the top band, a downvote
+    comes back as nothing. Ranking those against the models' guesses would put
+    the answer key back in with the questions, and `banded_scores` ranks, so a
+    population full of confirmed people would push the merely promising down.
+    """
+    models = models or [Pipeline.create(model) for model in PEOPLE_SCORE_MODELS]
+    # Read off the first model rather than declared as sources of whoever is
+    # scoring: `PeoplePayloads` must not depend on the site's export, or every
+    # payload run would download it whether or not it was asked to score.
+    sources = models[0]
+
+    population = population_from(
+        people=payloads,
+        koryta=sources.people_koryta.read_or_process(ctx),
+        votes=sources.people_votes.read_or_process(ctx),
+        companies=sources.companies_krs.read_or_process(ctx),
+    ).with_shortlist(payloads["name"])
+
+    print(
+        f"Scoring {len(population.shortlist)} people against "
+        f"{len(population.seeds())} confirmed and {len(population.seeds(-1))} "
+        "rejected by the site"
+    )
+    if not population.seeds():
+        print(
+            "WARNING: the site's export names nobody confirmed, so the models "
+            "that measure proximity to a known face have nothing to walk from. "
+            "Check versioned/person_koryta_<date>/ is not empty."
+        )
+
+    scores = best_bands(ctx, population, payloads, models)
+    for name, weight in population.seed_weights.items():
+        scores[name] = CONFIRMED_BAND if weight > 0 else 0
+    return scores

--- a/data/scrapers/src/analysis/scripts/score_recall.py
+++ b/data/scrapers/src/analysis/scripts/score_recall.py
@@ -15,8 +15,10 @@ held-out person comes back with is what the model would have said about them
 before anybody looked.
 
 Two things are deliberately not folded in. ``CompanyScores`` is recomputed per
-fold rather than read from its pipeline, because the stored one is built from
-``is_public`` and would hand ``PeopleScores`` the answer. And a labelled person
+fold rather than read from its pipeline - that is what
+``analysis.scores.ensemble`` does for every caller - because the stored one is
+built from ``is_public`` and would hand ``PeopleScores`` the answer. And a
+labelled person
 the payloads have no row for is reported separately rather than counted as a
 miss: the models never had anything to go on, which is a data problem and not a
 modelling one, and mixing the two hides both.
@@ -42,19 +44,13 @@ import os
 import sys
 from pathlib import Path
 
-import pandas as pd
-
 _SRC_ROOT = Path(__file__).resolve().parents[2]
 if str(_SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(_SRC_ROOT))
 
 from analysis.scores import PEOPLE_SCORE_MODELS  # noqa: E402
-from analysis.scores.base import Population, banded_scores  # noqa: E402
-from analysis.scores.company import (  # noqa: E402
-    NormalizationFactors,
-    PeopleScores,
-    normalized_scores,
-)
+from analysis.scores.base import Population  # noqa: E402
+from analysis.scores.ensemble import model_bands  # noqa: E402
 from conductor import setup_context  # noqa: E402
 from koryta import selected_resources  # noqa: E402
 from scrapers.stores import Pipeline, ProcessPolicy  # noqa: E402
@@ -108,46 +104,6 @@ def process_policy(refresh: list[str]) -> ProcessPolicy:
     )
 
 
-def company_score_map(
-    payloads: pd.DataFrame, person_scores: dict[str, float]
-) -> dict[str, float]:
-    """``CompanyScores.process``, over a person->score map the caller controls.
-
-    Kept deliberately close to the original so the numbers stay comparable with
-    a real run; the only difference is where the person scores come from.
-    """
-    records = []
-    for _, row in payloads.iterrows():
-        score = person_scores.get(row["name"], 0)
-        if not score:
-            continue
-        companies = row.get("companies")
-        if companies is None or isinstance(companies, (str, bytes)):
-            continue
-        if not hasattr(companies, "__iter__"):
-            continue
-        for company in companies:
-            krs = (
-                company.get("krs")
-                if isinstance(company, dict)
-                else getattr(company, "krs", None)
-            )
-            if krs:
-                records.append({"krs": krs, "score": score})
-
-    if not records:
-        return {}
-
-    df = pd.DataFrame.from_records(records)
-    factors = NormalizationFactors(
-        min_score=df["score"].min(), max_score=df["score"].max()
-    )
-    scored = df.groupby("krs", as_index=False)[["score"]].apply(
-        lambda s: normalized_scores(s, factors)
-    )
-    return dict(zip(scored["krs"], scored["score"]))
-
-
 def fold_population(base: Population, held_out: set[str]) -> Population:
     """`base` with `held_out` demoted from answer key to candidate."""
     return dataclasses.replace(
@@ -160,32 +116,6 @@ def fold_population(base: Population, held_out: set[str]) -> Population:
         shortlist=list(base.shortlist)
         + [name for name in sorted(held_out) if name in base.employments],
     )
-
-
-def model_bands(model, ctx, pop: Population, payloads: pd.DataFrame) -> dict[str, int]:
-    """One model's 1-5 verdict on this fold's shortlist."""
-    if isinstance(model, PeopleScores):
-        # PeopleScores reads company scores off a pipeline built from is_public,
-        # so rebuild them on this fold's seeds only.
-        companies = company_score_map(payloads, pop.seeds())
-        raw = {
-            name: model.calculate_weighted(
-                (
-                    model.total_company_score(pop.employments.get(name, []), companies),
-                    model.COMPANY_WEIGHT,
-                ),
-                (
-                    model.elections_score(pop.candidacies.get(name, [])),
-                    model.ELECTION_WEIGHT,
-                ),
-            )
-            for name in pop.shortlist
-        }
-    else:
-        raw = model.raw_scores(ctx, pop)
-
-    eligible = set(pop.shortlist)
-    return banded_scores({n: s for n, s in raw.items() if n in eligible})
 
 
 def report(

--- a/data/scrapers/src/analysis/tests/test_payload_scores.py
+++ b/data/scrapers/src/analysis/tests/test_payload_scores.py
@@ -1,0 +1,115 @@
+"""Narrowing a payload run to the people the models would have nominated."""
+
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from analysis.payloads.person import filter_by_score, keep_mask
+from analysis.scores import PEOPLE_SCORE_MODELS
+from analysis.scores.ensemble import CONFIRMED_BAND, score_payloads
+from pipelines import PeoplePayloads
+from scrapers.stores import Pipeline
+
+KORYTA = [
+    {"id": "n1", "full_name": "Anna", "is_public": True},
+    {"id": "n4", "full_name": "Damian", "is_public": False},
+]
+
+VOTES = [{"person_koryta_id": "n4", "interesting": -3}]
+
+
+def payload(name, companies=(), elections=(), autoapprove=False):
+    return {
+        "name": name,
+        "companies": [{"krs": krs} for krs in companies],
+        "elections": list(elections),
+        "autoapprove": autoapprove,
+    }
+
+
+CANDIDACY = {"election_year": "2018", "teryt": "12", "committee": "KW X"}
+
+PAYLOADS = pd.DataFrame.from_records(
+    [
+        # On the site and published - the answer key, not a question.
+        payload("Anna", companies=["1"]),
+        # A stranger, on the same board as Anna, who has stood for office.
+        payload("Bogdan", companies=["1"], elections=[CANDIDACY]),
+        # A stranger with a company of his own and nothing else.
+        payload("Celina", companies=["9"]),
+        # On the site, and a human said no.
+        payload("Damian", companies=["1"]),
+        # Named by one of the hardcoded press lists.
+        payload("Ewa", autoapprove=True),
+    ]
+)
+
+
+@pytest.fixture
+def models():
+    """Every model, with the site's export and the register stubbed out."""
+    built = [Pipeline.create(model) for model in PEOPLE_SCORE_MODELS]
+    for model in built:
+        model.people_koryta.read_or_process = lambda ctx: pd.DataFrame.from_records(
+            KORYTA
+        )
+        model.people_votes.read_or_process = lambda ctx: pd.DataFrame.from_records(
+            VOTES
+        )
+        model.companies_krs.read_or_process = lambda ctx: pd.DataFrame()
+    return built
+
+
+@pytest.fixture
+def scores(models):
+    return score_payloads(None, PAYLOADS, models)
+
+
+class TestScorePayloads:
+    def test_a_published_person_keeps_the_sites_own_verdict(self, scores):
+        assert scores["Anna"] == CONFIRMED_BAND
+
+    def test_a_downvoted_person_comes_back_with_nothing(self, scores):
+        assert scores["Damian"] == 0
+
+    def test_a_stranger_on_a_confirmed_persons_board_is_rated(self, scores):
+        # Nobody has ever voted on Bogdan and the site has no node for him, so
+        # the models the site runs today say nothing about him at all. That is
+        # the case this scoring exists for.
+        assert scores.get("Bogdan", 0) >= 1
+
+    def test_a_stranger_with_no_tie_to_anybody_is_not(self, scores):
+        assert scores.get("Celina", 0) == 0
+
+
+class TestKeepMask:
+    def test_keeps_the_people_at_or_above_the_band(self):
+        kept = PAYLOADS[keep_mask(PAYLOADS, {"Anna": 5, "Bogdan": 2}, 2)]
+
+        assert set(kept["name"]) == {"Anna", "Bogdan", "Ewa"}
+
+    def test_drops_the_people_below_it(self):
+        kept = PAYLOADS[keep_mask(PAYLOADS, {"Anna": 5, "Bogdan": 2}, 3)]
+
+        assert "Bogdan" not in set(kept["name"])
+
+    def test_a_press_list_name_is_listed_whatever_the_models_think(self):
+        kept = PAYLOADS[keep_mask(PAYLOADS, {"Ewa": 0}, 5)]
+
+        assert "Ewa" in set(kept["name"])
+
+
+class TestFilterByScore:
+    def test_a_run_without_the_flag_lists_everybody(self):
+        assert filter_by_score(None, PAYLOADS, None) is PAYLOADS
+
+    def test_the_flag_is_read_off_extract(self):
+        argv = ["koryta", "PeoplePayloads", "--all", "--min-score=2"]
+        with patch.object(sys, "argv", argv):
+            assert Pipeline.create(PeoplePayloads).people.min_score == 2
+
+    def test_a_run_without_it_asks_extract_for_nothing(self):
+        with patch.object(sys, "argv", ["koryta", "PeoplePayloads", "--all"]):
+            assert Pipeline.create(PeoplePayloads).people.min_score is None

--- a/data/scrapers/src/analysis/tests/test_scores.py
+++ b/data/scrapers/src/analysis/tests/test_scores.py
@@ -18,6 +18,7 @@ from analysis.scores.base import (
     Population,
     banded_scores,
 )
+from analysis.scores.company import company_score_map
 from analysis.scores.turnover import same_region, year_of
 from entities.person import is_pipeline_uid
 from scrapers.stores import Pipeline
@@ -213,6 +214,29 @@ class TestCompanyScores:
         )
 
         assert scores == {"Anna": 2}
+
+    def test_a_company_is_rated_by_everybody_in_it_it_has_a_rating_for(self):
+        payloads = pd.DataFrame.from_records(
+            [
+                {"name": "Anna", "companies": [{"krs": "1"}, {"krs": "2"}]},
+                {"name": "Bogdan", "companies": [{"krs": "1"}]},
+                {"name": "Celina", "companies": [{"krs": "2"}]},
+            ]
+        )
+
+        by_krs = company_score_map(payloads, {"Anna": 5, "Bogdan": 5})
+
+        # Both are somewhere Anna sits, and the confidence factor means the
+        # second rating counts: nobody has rated Celina, so company 2 is one
+        # person's word against company 1's two.
+        assert by_krs["1"] > by_krs["2"]
+
+    def test_a_person_nobody_rated_says_nothing_about_their_employer(self):
+        payloads = pd.DataFrame.from_records(
+            [{"name": "Celina", "companies": [{"krs": "3"}]}]
+        )
+
+        assert company_score_map(payloads, {}) == {}
 
     def test_a_vote_on_something_that_is_not_a_person_is_ignored(self):
         # Places get voted on too, and a node deleted since the export is gone

--- a/data/scrapers/src/scrapers/koryta/download.py
+++ b/data/scrapers/src/scrapers/koryta/download.py
@@ -151,7 +151,7 @@ class FirestoreCollection(Pipeline):
         document once per export. 2026-08-07 has two, and returned 12230 person
         nodes for a site with 6115 people; the same doubling reaches
         `KorytaVotes` as every human vote counted twice, which is somebody's
-        opinion weighed double in `PeopleScoreModel.human_votes`.
+        opinion weighed double in `analysis.scores.base.human_votes`.
 
         The newest export of the day wins, because a later dump supersedes the
         earlier one rather than adding to it. With no date set the caller wants

--- a/data/scrapers/src/tests/pipelines/test_payloads.py
+++ b/data/scrapers/src/tests/pipelines/test_payloads.py
@@ -12,6 +12,10 @@ from scrapers.stores import Context, Pipeline, ProcessPolicy
 class MockPipeline(Pipeline):
     filename = "mock"
 
+    #: `PeoplePayloads` asks its source how narrow the run is, and the source
+    #: it asks is `Extract`, which is what this stands in for.
+    min_score = None
+
     def __init__(self, data):
         super().__init__()
         self.data = pd.DataFrame(data)


### PR DESCRIPTION
`PeoplePayloads --all` emits a hundred thousand payloads, which after the recent extraction fixes is far more than anybody reviews. `--min-score`, which belongs with the rest of the flags that decide who a run is about and so is defined on `Extract`, narrows the list to the people the site's own models rate that highly on the 1-5 scale the site shows.

The flag is applied by `PeoplePayloads` rather than by `Extract`, because the models read a person's employers and candidacies in the payload shapes - one pipeline further on. All five models run over the frame before it is listed and a person keeps the best band any of them gave, which is what the frontend displays, so the threshold means the same thing here as it does there.

The models normally rate the site's own shortlist, which is exactly the people this cannot ask about: a payload run is mostly strangers the site has no node for. So the shortlist is everybody in the frame instead, and the two groups that are already answered are not asked - the site's published and voted-on people keep that verdict, and a name from one of the hardcoded press lists is listed whatever the models make of it.

`Population` and the best-of-five come apart from their pipelines to make that possible: `population_from` builds the population out of frames rather than out of sources, and `analysis.scores.ensemble` runs every model over one, which is what the recall harness had a private copy of. `PeopleScores` is the one model that cannot be asked for by pipeline mid-run - its company scores are built from the payloads - so those are recomputed from the population's own seeds, which is what `CompanyScores` does with them anyway.

On the 100,257 people an `--all` run listed today: 3,091 at band 5, 8,066 at 4, 16,495 at 3, 30,765 at 2, 40,434 at 1 and 1,406 nobody rated.