### PR TITLE
Make a node findable the moment it is created

### DIFF
--- a/data/scrapers/src/tests/pipelines/test_invariants.py
+++ b/data/scrapers/src/tests/pipelines/test_invariants.py
@@ -547,6 +547,45 @@ def test_a_published_node_is_in_the_listings(nodes):
     )
 
 
+def test_a_node_with_a_name_index_can_be_searched_for(nodes):
+    """Carrying the search index is not enough to be found by it.
+
+    `/api/search` matches on `nameChunksLower` and orders the hits by
+    `stats.nodeGroupSize`, and Firestore returns no document that lacks the
+    field it is ordered on. So a node can carry a complete name index, have a
+    working page, and still be absent from every search for its own name -
+    which is what a person ingested on 2026-08-21 was reported as.
+
+    Only `/api/stats/computeNodes` really works the counter out, it writes it
+    for every node at once, and an admin runs it by hand, so between two runs
+    everything created in between was in this state.
+    `withSeededNodeStats` in server/utils/revisions.ts now seeds a zero on
+    every node written through a revision, and
+    scripts/migrate/backfill-node-group-size.ts repairs the ones already
+    stored.
+    """
+    # Measured against production on 2026-08-23, before the migration ran:
+    # 474 people and 204 companies. Articles are not searched and so are not
+    # counted here. This goes to zero once the backfill has been run against
+    # production.
+    UNSEEDED = 678
+
+    searchable = {"person", "place", "region"}
+    unfindable = [
+        document["id"]
+        for document in nodes
+        if document.get("type") in searchable
+        and document.get("nameChunksLower")
+        and "nodeGroupSize" not in stats_of(document)
+    ]
+
+    assert len(unfindable) <= UNSEEDED, (
+        f"{len(unfindable)} nodes carry a name index but no "
+        f"`stats.nodeGroupSize`, so no search for their name returns them - up "
+        f"from the {UNSEEDED} known ones: {sample(unfindable)}"
+    )
+
+
 @pytest.mark.parametrize("collection", ["nodes", "edges"])
 def test_revision_id_points_at_the_documents_own_revision(snapshot, collection):
     """`revision_id` names the revision that was published.

--- a/frontend/scripts/migrate/backfill-node-group-size.ts
+++ b/frontend/scripts/migrate/backfill-node-group-size.ts
@@ -1,0 +1,138 @@
+import { initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+import { pageIsPublic } from "../../shared/model";
+
+/**
+ * One-time migration: give every node the counters that make it reachable.
+ *
+ * `/api/search` orders its hits by `stats.nodeGroupSize`, and Firestore's
+ * `orderBy` returns no document that lacks the field it is ordered on. Only
+ * `/api/stats/computeNodes` writes that field, it writes it for every node at
+ * once, and it is an admin endpoint somebody runs by hand — so every node
+ * created between two runs had no `stats` at all and was silently absent from
+ * search. The pages worked, the entries could be linked and voted on, and
+ * typing the name found nothing: that is how a person the scrapers ingested on
+ * 2026-08-21 (`/osoba/ZJNaVX4vvTNAiKfSLj8f`) came to be reported as unfindable.
+ *
+ * Measured against production on 2026-08-23: 474 people and 204 companies were
+ * invisible to search this way, plus 55 articles, which search does not read.
+ * A further 473 people had no `stats.isApproved` — the same absence one filter
+ * over, since `/api/nodes` filters every listing on it; none of those were
+ * published yet, so this is preventive rather than a repair.
+ *
+ * Zero is the honest seed: it means "nobody has counted yet", and the next
+ * `computeNodes` run replaces it with the real group size. Being ranked last
+ * among the hits for a name is what search is for; being absent from them is
+ * not.
+ *
+ * The cause is fixed in `withSeededNodeStats` in `server/utils/revisions.ts`,
+ * which seeds the same two fields on every node written through a revision —
+ * the ingest endpoints and the proposal form alike — so the count cannot grow
+ * back.
+ *
+ * Usage (against the running dev:prod-data emulator):
+ *   npx tsx scripts/migrate/backfill-node-group-size.ts            # dry run
+ *   npx tsx scripts/migrate/backfill-node-group-size.ts --commit   # apply
+ * Against production:
+ *   npx tsx scripts/migrate/backfill-node-group-size.ts --prod --commit
+ */
+
+const isProd = process.argv.includes("--prod");
+const commit = process.argv.includes("--commit");
+
+if (!isProd) {
+  process.env.FIRESTORE_EMULATOR_HOST =
+    process.env.FIRESTORE_EMULATOR_HOST ?? "127.0.0.1:8080";
+  process.env.GCLOUD_PROJECT = "koryta-pl";
+}
+
+const app = initializeApp({ projectId: "koryta-pl" });
+
+function tally(counts: Record<string, number>, type: string) {
+  counts[type] = (counts[type] ?? 0) + 1;
+}
+
+function describe(counts: Record<string, number>): string {
+  const parts = Object.entries(counts)
+    .sort(([, a], [, b]) => b - a)
+    .map(([type, count]) => `${count} ${type}`);
+  return parts.length > 0 ? parts.join(", ") : "none";
+}
+
+async function backfill() {
+  const db = getFirestore(app, "koryta-pl");
+  console.log(
+    `Connecting to ${isProd ? "PRODUCTION" : "local emulator"} Firestore` +
+      (commit ? "" : " (dry run — pass --commit to apply)"),
+  );
+
+  // Only the two fields the predicate needs, plus what decides `isApproved`.
+  // The whole collection is read either way, but not the whole of every
+  // document: the node bodies are the bulk of it and none of them is used.
+  const snapshot = await db
+    .collection("nodes")
+    .select(
+      "type",
+      "published",
+      "deleted",
+      "stats.nodeGroupSize",
+      "stats.isApproved",
+    )
+    .get();
+  console.log(`Scanning ${snapshot.docs.length} node(s).`);
+
+  let batch = db.batch();
+  let pending = 0;
+  const seededSize: Record<string, number> = {};
+  const seededApproved: Record<string, number> = {};
+  let unchanged = 0;
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    const stats = (data.stats ?? {}) as Record<string, unknown>;
+    const type = typeof data.type === "string" ? data.type : "(no type)";
+
+    // Field paths rather than a whole `stats` object: the counters this does
+    // not know about — the vote aggregate, the edge summaries, the note count —
+    // are maintained by triggers and by `computeNodes`, and writing the map
+    // would delete every one of them.
+    const update: Record<string, unknown> = {};
+    if (stats.nodeGroupSize === undefined) {
+      update["stats.nodeGroupSize"] = 0;
+      tally(seededSize, type);
+    }
+    if (stats.isApproved === undefined) {
+      update["stats.isApproved"] = pageIsPublic(data);
+      tally(seededApproved, type);
+    }
+
+    if (Object.keys(update).length === 0) {
+      unchanged++;
+      continue;
+    }
+
+    if (commit) {
+      batch.update(doc.ref, update);
+      pending++;
+      if (pending === 400) {
+        await batch.commit();
+        batch = db.batch();
+        pending = 0;
+      }
+    }
+  }
+
+  if (commit && pending > 0) await batch.commit();
+
+  console.log(`stats.nodeGroupSize seeded: ${describe(seededSize)}`);
+  console.log(`stats.isApproved seeded: ${describe(seededApproved)}`);
+  console.log(`Already complete: ${unchanged}`);
+  if (!commit) console.log("Dry run — nothing written.");
+}
+
+backfill()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/frontend/server/api/revisions/create.post.ts
+++ b/frontend/server/api/revisions/create.post.ts
@@ -4,6 +4,7 @@ import { getUser } from "~~/server/utils/auth";
 import {
   baseNodeFields,
   sanitizeFirestoreData,
+  withSeededNodeStats,
 } from "~~/server/utils/revisions";
 import {
   editSchemas,
@@ -92,18 +93,18 @@ export default defineEventHandler(async (event) => {
     // is approved to show, and with `published: false` said out loud: now that
     // the backfill has run, every document carries the field, and a proposal
     // that left it absent would be the only place the old ambiguity survived.
-    batch.set(nodeRef, {
-      ...(revision.data as Record<string, unknown>),
-      published: false,
-      // `stats` for the same reason, and it is not cosmetic: /api/search sorts
-      // on `stats.nodeGroupSize`, and Firestore's orderBy drops any document
-      // that does not carry the field at all. A person somebody had just
-      // created was therefore invisible to the very picker that created them -
-      // they could be added once and never found again, for good, since nothing
-      // writes the field until /api/stats/computeNodes next runs. Zero is the
-      // honest value: nobody is connected to them yet.
-      stats: { isApproved: false, nodeGroupSize: 0 },
-    });
+    // `stats` is seeded for the same reason, and it is not cosmetic:
+    // /api/search sorts on `stats.nodeGroupSize`, and Firestore's orderBy drops
+    // any document that does not carry the field at all. See
+    // `withSeededNodeStats`, which is where every other node-creating path gets
+    // the same treatment.
+    batch.set(
+      nodeRef,
+      withSeededNodeStats({
+        ...(revision.data as Record<string, unknown>),
+        published: false,
+      }),
+    );
   }
   await batch.commit();
 

--- a/frontend/server/utils/revisions.ts
+++ b/frontend/server/utils/revisions.ts
@@ -5,7 +5,7 @@ import type {
   WriteBatch,
 } from "firebase-admin/firestore";
 import type { Edge, Node, Revision } from "~~/shared/model";
-import { revisionCollection } from "~~/shared/model";
+import { pageIsPublic, revisionCollection } from "~~/shared/model";
 import { recordAudit } from "~~/server/utils/audit";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 
@@ -148,6 +148,29 @@ export function nodeOwnedFields(
   return owned;
 }
 
+/** The counters a node has to carry before anything can find it, for a node
+ * whose counters nothing has computed yet.
+ *
+ * `/api/stats/computeNodes` is what really works these out, and it writes them
+ * for every node - but it is an admin endpoint somebody runs by hand, so
+ * between two runs every node created in between carries no `stats` at all.
+
+ * Only fields that are missing are filled in. A real count computed by
+ * `computeNodes`, or one carried across from the stored document, always wins:
+ * zero here means "nobody has counted yet", never "counted, and it is none".
+ */
+export function withSeededNodeStats(
+  targetData: Record<string, unknown>,
+): Record<string, unknown> {
+  const stats = {
+    ...((targetData.stats as Record<string, unknown> | undefined) ?? {}),
+  };
+  if (stats.nodeGroupSize === undefined) stats.nodeGroupSize = 0;
+  if (stats.isApproved === undefined)
+    stats.isApproved = pageIsPublic(targetData);
+  return { ...targetData, stats };
+}
+
 export interface RevisionWriteOptions {
   /** Written by a pipeline rather than by a person. */
   automatic?: boolean;
@@ -231,7 +254,12 @@ export function createRevisionTransaction(
   if (published !== undefined) {
     targetData.published = published;
   }
-  batch.set(targetRef, targetData);
+  batch.set(
+    targetRef,
+    revision.collection === "nodes"
+      ? withSeededNodeStats(targetData)
+      : targetData,
+  );
 
   return { revisionRef, targetRef };
 }
@@ -294,7 +322,12 @@ export async function applyRevision(
 
   const timestamp = Timestamp.now();
   const batch = db.batch();
-  batch.set(targetRef, targetData);
+  batch.set(
+    targetRef,
+    targetRef.parent.id === "nodes"
+      ? withSeededNodeStats(targetData)
+      : targetData,
+  );
   batch.update(revisionRef, {
     status: "approved",
     review_user: user.uid,

--- a/frontend/tests/e2e/omni_search_add_person.spec.ts
+++ b/frontend/tests/e2e/omni_search_add_person.spec.ts
@@ -72,7 +72,7 @@ test.describe("OmniSearch add person", () => {
   test("creates a person that only logged in users can see", async ({
     page,
   }) => {
-    test.setTimeout(90000);
+    test.setTimeout(150000);
 
     const timestamp = Date.now();
     const personName = `Testowa Osoba ${timestamp}`;
@@ -136,7 +136,28 @@ test.describe("OmniSearch add person", () => {
     const createdUrl = page.url();
     const nodeUrl = createdUrl.split("?")[0]!;
 
-    // 5. A logged out visitor must not see it
+    // 5. Searching the name again finds them. The one thing a picker that
+    // offers to create a person must not do is lose them: /api/search orders by
+    // `stats.nodeGroupSize`, Firestore returns no document that lacks the field
+    // it is ordered on, and nothing writes that field until an admin runs
+    // /api/stats/computeNodes - so a person created here could be added once and
+    // never found again. The name index is written by a Firestore trigger and
+    // lands a moment after the node does, and the menu only queries when the
+    // query changes, so this retypes rather than waiting on a stale menu.
+    await expect(async () => {
+      await page.goto("/");
+      await searchFor(page, personName);
+      await expect(
+        page
+          .locator(
+            '.v-overlay--active .v-list-item:not([data-testid^="omni-search-add-"])',
+            { hasText: personName },
+          )
+          .first(),
+      ).toBeVisible({ timeout: 5000 });
+    }).toPass({ timeout: 45000 });
+
+    // 6. A logged out visitor must not see it
     const anonContext = await page.context().browser()!.newContext();
     const anonPage = await anonContext.newPage();
     await anonPage.goto(nodeUrl);

--- a/frontend/tests/server/utils/revisions.test.ts
+++ b/frontend/tests/server/utils/revisions.test.ts
@@ -134,9 +134,14 @@ describe("createRevisionTransaction", () => {
       data: data,
       update_user: "test-user",
     });
-    // Without approve/published the target document is just the data
+    // Without approve/published the target document is the data, plus the
+    // counters every node has to carry to be found at all - see
+    // `withSeededNodeStats`.
     const targetData = vi.mocked(mockBatch.set).mock.calls[1][1];
-    expect(targetData).toEqual(data);
+    expect(targetData).toEqual({
+      ...data,
+      stats: { nodeGroupSize: 0, isApproved: false },
+    });
   });
 
   it("should set revision_id on the target but not in the revision data when approving", () => {
@@ -201,6 +206,11 @@ describe("createRevisionTransaction", () => {
       node_id: "edge-1",
       collection: "edges",
     });
+    // `stats.nodeGroupSize` is a node's search ranking; an edge has no name to
+    // be found by and nothing reads a counter on one.
+    expect(vi.mocked(mockBatch.set).mock.calls[1][1]).not.toHaveProperty(
+      "stats",
+    );
   });
 
   describe("updating a document that already exists", () => {
@@ -297,13 +307,40 @@ describe("createRevisionTransaction", () => {
     });
 
     it("carries nothing when there is no stored document to carry from", () => {
-      // A document being created owns nothing yet.
+      // A document being created owns nothing yet, beyond the counters seeded
+      // for it so that it can be found.
       expect(targetWrite({ approve: true, published: true })).toEqual({
         name: "Krystian Probierz",
         type: "person",
         parties: ["PiS"],
         revision_id: { id: "new-rev-id" },
         published: true,
+        stats: { nodeGroupSize: 0, isApproved: true },
+      });
+    });
+
+    it("seeds the counters that decide whether a new node can be found", () => {
+      // Not cosmetic, and not only the proposal form's problem: /api/search
+      // orders by `stats.nodeGroupSize` and Firestore drops any document that
+      // lacks the ordered field, so a person the scrapers had just ingested had
+      // a page nobody could search their way to. Zero says "not counted yet";
+      // `computeNodes` replaces it with the real group size.
+      const created = targetWrite({ automatic: true, published: false });
+      expect(created.stats).toEqual({ nodeGroupSize: 0, isApproved: false });
+    });
+
+    it("fills in a counter an existing document is missing", () => {
+      // The nodes written before this was seeded keep arriving here on every
+      // re-ingest; repairing them in passing is free and stops the count from
+      // growing back between migration runs.
+      const incomplete = {
+        ...stored,
+        stats: { isApproved: true, notesCount: 2 },
+      };
+      expect(targetWrite({ approve: true, stored: incomplete }).stats).toEqual({
+        isApproved: true,
+        notesCount: 2,
+        nodeGroupSize: 0,
       });
     });
 
@@ -354,7 +391,7 @@ describe("applyRevision", () => {
       { stats: { isApproved: true, notesCount: 2 }, votes: { interesting: 3 } },
       { name: "Krystian Probierz" },
     );
-    expect(written.stats).toEqual({ isApproved: true, notesCount: 2 });
+    expect(written.stats).toMatchObject({ isApproved: true, notesCount: 2 });
     expect(written.votes).toEqual({ interesting: 3 });
   });
 


### PR DESCRIPTION
/api/search matches on nameChunksLower and orders the hits by stats.nodeGroupSize. Firestore's orderBy returns no document that lacks the field it is ordered on, and only /api/stats/computeNodes writes that field - an admin endpoint somebody runs by hand, for every node at once. So everything created between two runs carried no stats at all and was absent from every search for its own name, while its page worked and whoever knew the address could see it. That is how Adrian Moliński, ingested on 2026-08-21, came to be reported as unfindable.

withSeededNodeStats seeds stats.nodeGroupSize and stats.isApproved on every node written through a revision - the ingest endpoints, the approval path and the proposal form alike - filling in only what is missing, so a count computed by computeNodes always wins. Zero means "nobody has counted yet": ranked last among the hits for a name is what search is for, absent from them is not. Edges are left alone; nothing reads a counter on one.

scripts/migrate/backfill-node-group-size.ts repairs what is already stored. Against production on 2026-08-23 that is 474 people and 204 companies invisible to search, plus 55 articles search does not read, and 473 people missing stats.isApproved. It has not been run yet.