### PR TITLE
Compress what the site serves, instead of shipping it raw

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -281,6 +281,18 @@ export default defineNuxtConfig({
     experimental: {
       asyncContext: true,
     },
+
+    // Nothing between the browser and the container compresses: the Nitro
+    // server does not, and the Envoy in front of it does not either, so
+    // `_nuxt/*` went out raw - 741 KB for the entry chunk, 255 KB for the
+    // stylesheet, ~2.2 MB per page view against an audience that is 69%
+    // mobile. This emits `.gz`/`.br` siblings at build time, which the static
+    // handler serves - with a `Vary: Accept-Encoding` of its own - to clients
+    // that ask. Build-time rather than per-request because these are
+    // immutable and hashed: pay the cost once, at the best ratio, not on
+    // every cache miss. Rendered responses are the other half of this, in
+    // server/plugins/compression.ts.
+    compressPublicAssets: { gzip: true, brotli: true },
   },
   routeRules: {
     "/": { swr: 3600 },

--- a/frontend/server/plugins/compression.ts
+++ b/frontend/server/plugins/compression.ts
@@ -1,0 +1,107 @@
+import { constants, brotliCompress, gzip } from "node:zlib";
+import { promisify } from "node:util";
+
+const compressBrotli = promisify(brotliCompress);
+const compressGzip = promisify(gzip);
+
+/** Types where compression buys anything. Everything the app serves in bulk -
+ * the SSR html, `_payload.json`, the sitemap - is in here; images, fonts and
+ * video are already compressed and only cost cpu to re-do. */
+const COMPRESSIBLE =
+  /^(?:text\/|application\/(?:json|ld\+json|javascript|xml|xhtml\+xml|rss\+xml|manifest\+json)|image\/svg\+xml)/i;
+
+/** Below this the framing overhead is most of the win and the cpu is wasted.
+ * Well under any page this exists for - the smallest is ~450 KB. */
+const MIN_BYTES = 1024;
+
+/** Brotli's default is quality 11, which is a text-book choice for a file you
+ * compress once at build time and a bad one for a response you compress on
+ * every miss: on `/lista`'s 10 MB document it is seconds of a Cloud Run cpu.
+ * 4 is the usual dynamic-content setting, within a few percent of 11 on html
+ * at a fraction of the time. */
+const BROTLI_QUALITY = 4;
+
+/** Neither the Nitro server nor the Envoy in front of it compresses anything,
+ * so koryta.pl ships every response raw - 2.2 MB of it on a plain page view,
+ * to an audience that is 69% mobile. `compressPublicAssets` in nuxt.config.ts
+ * covers what the build emits; this covers what is rendered per request.
+ *
+ * It hooks `beforeResponse` rather than `render:response` on purpose. The swr
+ * route rules cache the *renderer's* output, so compressing there would store
+ * one client's encoding in the cache and replay it to everyone - including a
+ * client that sent no `Accept-Encoding` at all. `beforeResponse` is the
+ * outermost seam, past the cache, and h3 re-reads `response.body` after the
+ * hook, so replacing it here is what actually goes out.
+ *
+ * Handlers that return an object are left alone: h3 serialises those after
+ * this hook, so there is no body to compress yet and no content-type to test.
+ * That is api routes only, which are small and mostly uncached. */
+export default defineNitroPlugin((nitro) => {
+  nitro.hooks.hook("beforeResponse", async (event, response) => {
+    const body = response.body;
+    const isBuffer = Buffer.isBuffer(body);
+    if (typeof body !== "string" && !isBuffer) return;
+
+    // Only compress what is going out over a socket. A sub-request made with
+    // localFetch/$fetch runs through this same hook, and its caller reads the
+    // result back in process - so compressing one hands binary to something
+    // expecting text. Nitro's error handler does exactly that: it renders the
+    // error page by localFetch-ing /__nuxt_error, takes `await res.text()` of
+    // the reply, and copies the reply's headers onto the real response. Every
+    // byte of the brotli that is not valid utf-8 became U+FFFD in that
+    // `text()`, and `content-encoding: br` rode along on a body that was no
+    // longer brotli - so the browser could not decode any 404 or 500, and sat
+    // there until it gave up. node-mock-http, which backs those in-process
+    // requests, leaves `socket` null on its ServerResponse; a real one always
+    // has it by the time a body exists. Skipping when it is absent errs the
+    // safe way: the cost of a false positive is a response that goes out
+    // uncompressed.
+    if (!event.node.res.socket) return;
+
+    // Nitro's static handler serves the build's precompressed `.br`/`.gz`
+    // siblings itself; re-encoding those would produce nonsense.
+    if (getResponseHeader(event, "content-encoding")) return;
+
+    const type = String(getResponseHeader(event, "content-type") || "");
+    if (!COMPRESSIBLE.test(type)) return;
+
+    const raw = isBuffer ? body : Buffer.from(body, "utf8");
+    if (raw.byteLength < MIN_BYTES) return;
+
+    const accepted = String(getRequestHeader(event, "accept-encoding") || "");
+    const encoding = /\bbr\b/.test(accepted)
+      ? "br"
+      : /\bgzip\b/.test(accepted)
+        ? "gzip"
+        : undefined;
+
+    // Whatever the client can take, the CDN has to key the entry on - it sits
+    // in front of us and these responses carry an s-maxage.
+    appendResponseHeader(event, "Vary", "Accept-Encoding");
+    if (!encoding) return;
+
+    let compressed: Buffer;
+    try {
+      compressed =
+        encoding === "br"
+          ? await compressBrotli(raw, {
+              params: {
+                [constants.BROTLI_PARAM_QUALITY]: BROTLI_QUALITY,
+                [constants.BROTLI_PARAM_SIZE_HINT]: raw.byteLength,
+              },
+            })
+          : await compressGzip(raw);
+    } catch (error) {
+      // A response that went out uncompressed is a slow success; one that
+      // failed to render is not. Never let this be the reason a page 500s.
+      event.captureError?.(error as Error, { tags: ["compression"] });
+      return;
+    }
+
+    setResponseHeader(event, "Content-Encoding", encoding);
+    // The stale length is the uncompressed one; h3 sets the right one when it
+    // sends the buffer, but only if this is not already sitting on the event.
+    removeResponseHeader(event, "Content-Length");
+    response.body = compressed;
+  });
+});


### PR DESCRIPTION
Nothing between the browser and the container compressed anything: the Nitro server did not, and the Envoy in front of it did not either, so every response went out uncompressed - ~2.2 MB of avoidable transfer on a plain page view, against an audience that is 69% mobile. The entry chunk was 760 KB, the stylesheet 255 KB, the homepage's html 449 KB.

compressPublicAssets covers what the build emits. Those chunks are hashed and immutable, so they are worth compressing once at the best ratio rather than on every cache miss; Nitro's static handler picks the .br/.gz sibling and sets its own Vary.

The plugin covers what is rendered per request. It hooks beforeResponse rather than render:response because the swr route rules cache the renderer's output, and compressing inside that layer would store one client's encoding in the cache and replay it to a client that asked for none. Brotli runs at quality 4: on a 10 MB document the default 11 is seconds of a Cloud Run cpu for a few percent of size. A handler that returns an object is left alone, because h3 serialises those after the hook - api routes only, which are small and mostly uncached.

What took a second pass is that beforeResponse also fires for requests the server makes to itself. Nitro renders the error page by localFetch-ing /__nuxt_error, reading `await res.text()` of the reply and copying the reply's headers onto the real response. Compressing that inner reply put brotli through a utf-8 decode - every byte that was not valid utf-8 came out as U+FFFD - and sent `content-encoding: br` along with a body that was no longer brotli. Every 404 and 500 would have been undecodable. The hook now skips any response with no socket behind it, which is how the mock ServerResponse backing an in-process request differs from a real one.

Measured against the built server: the homepage's 422,531 bytes leave as 112,591, /o-nas' 70,992 as 14,119, the 760,060-byte entry chunk as 182,176, a client that sends no Accept-Encoding still gets identity, the 404 page renders as html a browser can read, and logo.png is untouched.