### PR TITLE
Let an admin open a page's revisions from the page itself

### DIFF
--- a/frontend/app/components/EntityDetailsCard.vue
+++ b/frontend/app/components/EntityDetailsCard.vue
@@ -10,19 +10,36 @@
         :party="party"
       />
       <v-spacer />
-      <div class="d-none d-md-inline">
-        <v-spacer />
-        <DialogProposeEditNode
-          v-if="entity && type === 'person'"
-          :entity="entity"
-        />
-        <ButtonVoteNumber
-          v-if="entity"
-          :id="entity.id ?? ''"
-          :key="entity.id ?? ''"
-          category="interesting"
-          show-label
-        />
+      <div class="d-none d-md-flex flex-column align-end ga-1">
+        <div>
+          <DialogProposeEditNode
+            v-if="entity && type === 'person'"
+            :entity="entity"
+          />
+          <ButtonVoteNumber
+            v-if="entity"
+            :id="entity.id ?? ''"
+            :key="entity.id ?? ''"
+            category="interesting"
+            show-label
+          />
+        </div>
+        <!-- Admins reach a person from a list - /eksploruj/tabela, a search
+             result - and the revision list, which is where a page gets
+             published, was reachable only by typing the node id into a url. It
+             sits under the other two controls on the page rather than in a row
+             of its own, because it is the same kind of thing: what this reader
+             may do to the entity they are looking at. -->
+        <v-btn
+          v-if="isAdmin && entity?.id"
+          variant="tonal"
+          size="small"
+          :prepend-icon="mdiHistory"
+          :to="`/admin/rewizje/${entity.id}`"
+          data-testid="admin-revisions-link"
+        >
+          Rewizje
+        </v-btn>
       </div>
     </v-card-title>
     <template #append> </template>
@@ -81,6 +98,7 @@
 <script setup lang="ts">
 import {
   mdiFileDocumentOutline,
+  mdiHistory,
   mdiMapMarkerRadiusOutline,
   mdiOfficeBuildingOutline,
 } from "@mdi/js";
@@ -91,6 +109,8 @@ const props = defineProps<{
   entity: Company | Person | Article | Region;
   type: string;
 }>();
+
+const { isAdmin } = useAuthState();
 
 const company = computed(() =>
   props.type === "place" ? (props.entity as Company) : undefined,

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -42,6 +42,26 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
 /** Newest first. Prepend, never insert in the middle. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "entity-page-admin-revisions-link",
+    date: "2026-08-24",
+    title: "Skrót do rewizji i publikacji ze strony osoby",
+    description:
+      "Admin na stronie osoby wchodzi wprost na jej listę rewizji, gdzie " +
+      "stronę się publikuje, zamiast szukać jej po id w /admin/rewizje. " +
+      "Przycisk stoi pod ołówkiem i oceną, razem z resztą tego, co można na " +
+      "tej stronie zrobić.",
+    steps: [
+      "Jako admin wejdź na /eksploruj/tabela i kliknij dowolną osobę.",
+      "Przy nazwisku, pod przyciskiem edycji i oceną, kliknij „Rewizje i publikacja” - ma otworzyć listę rewizji tej właśnie osoby.",
+      "Sprawdź na górze tamtej strony, czy osoba jest opublikowana, i w razie potrzeby opublikuj ją.",
+      "Wróć na stronę osoby i sprawdź, że przycisk prowadzi tam samo.",
+      "Wyloguj się (albo zaloguj jako zwykły użytkownik) i otwórz tę samą stronę - przycisku ma nie być.",
+      "Zwęź okno poniżej 960 px - przycisk chowa się razem z edycją i oceną, tak jak one.",
+    ],
+    link: "/eksploruj/tabela",
+    area: "admin",
+  },
+  {
     id: "home-compact-on-phone",
     date: "2026-08-24",
     title: "Strona główna na telefonie zaczyna się od wyszukiwarki",

--- a/frontend/tests/e2e/entity_admin_revisions_link.spec.ts
+++ b/frontend/tests/e2e/entity_admin_revisions_link.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+import { logIn, USERS } from "./helpers/auth";
+
+/** Jan Kowalski, seeded with an approved revision. */
+const PERSON_URL = "/osoba/jan-kowalski-1";
+const PERSON_ID = "1";
+
+test.describe("Admin shortcut from an entity page", () => {
+  test("an admin reaches the node's revision list from the page", async ({
+    page,
+  }) => {
+    await logIn(page, USERS.admin, PERSON_URL);
+
+    const link = page.getByTestId("admin-revisions-link");
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", `/admin/rewizje/${PERSON_ID}`);
+    await link.click();
+    await expect(page).toHaveURL(new RegExp(`/admin/rewizje/${PERSON_ID}$`));
+    await expect(
+      page.getByRole("heading", { name: /Szczegóły rewizji/ }),
+    ).toBeVisible();
+  });
+
+  test("a signed in reader without the claim never sees it", async ({
+    page,
+  }) => {
+    await logIn(page, USERS.normal, PERSON_URL);
+
+    // Anchored on something the page renders for everybody, so an assertion
+    // about what is absent cannot pass on a page that never loaded.
+    await expect(page.getByText("Jan Kowalski").first()).toBeVisible();
+    await expect(page.getByTestId("admin-revisions-link")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Publishing a page happens on /admin/rewizje/[id], and an admin who found the person from /eksploruj/tabela had no way there short of typing the node id into the url. The entity page carries a link to it when the reader holds the admin claim.