### PR TITLE
Fix the three e2e specs that fail on main

### DIFF
--- a/frontend/tests/e2e/helpers/omniSearch.ts
+++ b/frontend/tests/e2e/helpers/omniSearch.ts
@@ -7,11 +7,17 @@ import { expect, type Locator, type Page } from "@playwright/test";
  * `fill()` writes the DOM value without it ever reaching the component - Vue
  * then wipes the value on hydration and no search is ever issued. Retrying the
  * whole interaction rides that out: once the field is live the first keystroke
- * triggers the request and the result appears. */
+ * triggers the request and the result appears.
+ *
+ * Retyping also re-issues the query, which is what a caller waiting on
+ * something that is still being written wants: the menu only searches when the
+ * search term changes, so waiting longer on a menu that already answered would
+ * wait forever. Give those a `timeout` that covers the write. */
 export async function omniSearchFor(
   page: Page,
   query: string,
   expected: Locator,
+  timeout = 20_000,
 ) {
   const input = page.locator("input#omni-search");
 
@@ -22,7 +28,7 @@ export async function omniSearchFor(
     await input.fill("");
     await input.fill(query);
     await expect(expected).toBeVisible({ timeout: 1000 });
-  }).toPass({ timeout: 20_000 });
+  }).toPass({ timeout });
 }
 
 /** Open the header search with no query and wait for its menu to appear.

--- a/frontend/tests/e2e/note_source_article.spec.ts
+++ b/frontend/tests/e2e/note_source_article.spec.ts
@@ -46,6 +46,7 @@ test("a source added to a note becomes an article node", async ({ page }) => {
 
   // The promotion runs after the note is stored, so the node arrives a moment
   // later - and only once, however the same url is spelled.
+  let articleId = "";
   await expect(async () => {
     const articles = await db()
       .collection("nodes")
@@ -55,10 +56,15 @@ test("a source added to a note becomes an article node", async ({ page }) => {
     expect(articles.docs[0]!.data().type).toBe("article");
     // No title to be had, so the article goes in under its address.
     expect(articles.docs[0]!.data().name).toBe(url);
+    articleId = articles.docs[0]!.id;
   }).toPass({ timeout: 60_000 });
 
-  // And the note entry now points at the article it became.
-  await expect(companyCard.getByRole("link", { name: "Artykuł" })).toBeVisible({
-    timeout: 30_000,
-  });
+  // And the note entry now points at the article it became - that one, by id.
+  // The card carries a chip per source and keeps them all: `company_notes`
+  // leaves one on this same company, and every retry of this test leaves
+  // another, so "an Artykuł link" is several links by the time it is asked
+  // for.
+  await expect(
+    companyCard.locator(`a[href="/entity/article/${articleId}"]`),
+  ).toBeVisible({ timeout: 30_000 });
 });

--- a/frontend/tests/e2e/omni_search_add_person.spec.ts
+++ b/frontend/tests/e2e/omni_search_add_person.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { omniSearchFor } from "./helpers/omniSearch";
 
 /** Everything a search that found nothing can be turned into, in the order the
  * menu offers them. A person comes first because it is what most searches are
@@ -8,13 +9,21 @@ const CREATE_OPTIONS = ["person", "place", "article"] as const;
 const addOption = (type: string) => `[data-testid="omni-search-add-${type}"]`;
 const ADD_PERSON = addOption("person");
 
-/** Types into the omni search and waits for the menu to react. */
-async function searchFor(page: Page, query: string) {
+/** Types into the omni search and waits for `expected` to show up.
+ *
+ * The typing is retried rather than waited on. `networkidle` never arrives on
+ * a page that holds Firestore listeners open - which every page does once
+ * somebody is signed in - and a fill that lands before Vue has hydrated the
+ * field is wiped without ever reaching the component. See helpers/omniSearch.
+ */
+async function searchFor(
+  page: Page,
+  query: string,
+  expected: Locator,
+  timeout?: number,
+) {
   await expect(page.locator(".v-main")).toBeVisible({ timeout: 15000 });
-  await page.waitForLoadState("networkidle");
-
-  await page.locator("input#omni-search").click();
-  await page.locator("input#omni-search").fill(query);
+  await omniSearchFor(page, query, expected, timeout);
 }
 
 test.describe("OmniSearch add person", () => {
@@ -26,10 +35,9 @@ test.describe("OmniSearch add person", () => {
     page,
   }) => {
     const query = "Zbigniew Nieistniejacy Kompletnie";
-    await searchFor(page, query);
-
     const addPerson = page.locator(ADD_PERSON);
-    await expect(addPerson).toBeVisible({ timeout: 10000 });
+    await searchFor(page, query, addPerson);
+
     await expect(addPerson).toContainText("Dodaj nową osobę");
     await expect(addPerson).toContainText(query);
 
@@ -44,14 +52,12 @@ test.describe("OmniSearch add person", () => {
   });
 
   test("offers adding a person below existing results", async ({ page }) => {
-    // "PO" always matches the hardcoded party entry, independent of seed data
-    await searchFor(page, "PO");
-
     const partyItem = page
       .locator(".v-list-item", { hasText: "PO" })
       .filter({ hasText: "Partia" })
       .first();
-    await expect(partyItem).toBeVisible({ timeout: 10000 });
+    // "PO" always matches the hardcoded party entry, independent of seed data
+    await searchFor(page, "PO", partyItem);
 
     const addPerson = page.locator(ADD_PERSON);
     await expect(addPerson).toBeVisible();
@@ -77,7 +83,7 @@ test.describe("OmniSearch add person", () => {
     const timestamp = Date.now();
     const personName = `Testowa Osoba ${timestamp}`;
 
-    await searchFor(page, personName);
+    await searchFor(page, personName, page.locator(ADD_PERSON));
 
     // 1. Logged out, so the activator asks to log in first
     await page.locator(ADD_PERSON).click();
@@ -144,18 +150,18 @@ test.describe("OmniSearch add person", () => {
     // never found again. The name index is written by a Firestore trigger and
     // lands a moment after the node does, and the menu only queries when the
     // query changes, so this retypes rather than waiting on a stale menu.
-    await expect(async () => {
-      await page.goto("/");
-      await searchFor(page, personName);
-      await expect(
-        page
-          .locator(
-            '.v-overlay--active .v-list-item:not([data-testid^="omni-search-add-"])',
-            { hasText: personName },
-          )
-          .first(),
-      ).toBeVisible({ timeout: 5000 });
-    }).toPass({ timeout: 45000 });
+    await page.goto("/");
+    await searchFor(
+      page,
+      personName,
+      page
+        .locator(
+          '.v-overlay--active .v-list-item:not([data-testid^="omni-search-add-"])',
+          { hasText: personName },
+        )
+        .first(),
+      45000,
+    );
 
     // 6. A logged out visitor must not see it
     const anonContext = await page.context().browser()!.newContext();

--- a/frontend/tests/e2e/user_toolbar_mobile.spec.ts
+++ b/frontend/tests/e2e/user_toolbar_mobile.spec.ts
@@ -49,20 +49,29 @@ test.describe("Logged in toolbar on a phone", () => {
     await expect(content).toHaveCSS("overflow-x", /auto|scroll/);
 
     // The last button starts off screen and becomes reachable after scrolling.
-    const lastButton = page.locator(".user-toolbar .v-btn").last();
-    await lastButton.scrollIntoViewIfNeeded();
+    //
+    // Which button is last depends on the page: registering lands on `/`,
+    // whose meta carries a "Dyskusja w affine" link that `/login` has none of,
+    // and it is appended a tick after the url changes - so a strip scrolled to
+    // its end grows a new end, back at scrollLeft 0. Scroll and measure in one
+    // retried block, so the measurement is always about the button that is
+    // last at the time it is taken.
+    await expect(async () => {
+      const lastButton = page.locator(".user-toolbar .v-btn").last();
+      await lastButton.scrollIntoViewIfNeeded();
 
-    const scrolled = await content.evaluate((el) => el.scrollLeft);
-    expect(scrolled).toBeGreaterThan(0);
+      const scrolled = await content.evaluate((el) => el.scrollLeft);
+      expect(scrolled).toBeGreaterThan(0);
 
-    const box = await lastButton.boundingBox();
-    const contentBox = await content.boundingBox();
-    expect(box).not.toBeNull();
-    expect(contentBox).not.toBeNull();
-    expect(box!.x).toBeGreaterThanOrEqual(contentBox!.x - 1);
-    expect(box!.x + box!.width).toBeLessThanOrEqual(
-      contentBox!.x + contentBox!.width + 1,
-    );
+      const box = await lastButton.boundingBox();
+      const contentBox = await content.boundingBox();
+      expect(box).not.toBeNull();
+      expect(contentBox).not.toBeNull();
+      expect(box!.x).toBeGreaterThanOrEqual(contentBox!.x - 1);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(
+        contentBox!.x + contentBox!.width + 1,
+      );
+    }).toPass({ timeout: 20_000 });
 
     // The strip must not have grown a vertical scrollbar or spilled over the
     // page - the fix is horizontal only.


### PR DESCRIPTION
The playwright suite has been red on main with two failures and a flake. None of the three is a fault in the site; all three are the test asking for the wrong thing.

note_source_article asked for "an Artykuł link" on the company card and got several. company_notes adds a source to the same company and runs first, so its chip is already on the card before this test adds one, and every retry adds another - which is why the strict mode violation listed one more element each time round. The assertion now names the article this test created, by id.

omni_search_add_person timed out waiting on its own predicate rather than on any assertion inside it: searchFor waited for networkidle, and a signed in page holds Firestore listeners open, so it never arrives and the retype never happened. The search itself was never at fault - /api/search answers with the new person on the first poll, index written and stats seeded. helpers/omniSearch retypes instead of waiting and says why; the spec uses it now, with a timeout argument so step 5 keeps the budget that covers the trigger's write.

user_toolbar_mobile measured a button that was not there when it scrolled. Registering lands on /, whose meta carries a "Dyskusja w affine" link that /login has none of, and it is appended a tick after the url changes - so a strip scrolled to its end grows a new end, back at scrollLeft 0. Scrolling and measuring now happen in one retried block.