### PR TITLE
Say which person a fact was matched to, and let a reviewer say it's w…

### DIFF
--- a/frontend/app/components/extraction/Card.vue
+++ b/frontend/app/components/extraction/Card.vue
@@ -2,15 +2,39 @@
   <v-card variant="outlined" class="extraction-card">
     <v-card-text class="pb-3">
       <div class="edge">
-        <!-- Source entity (left) -->
+        <!-- Source entity (left). A fact whose subject the pipeline matched to
+         somebody already in the graph says so, and links there: which person a
+         fact was attached to is the thing a reviewer most needs to see, and the
+         thing most easily got wrong between two people of the same name. -->
         <div class="edge__entity edge__entity--source">
           <div class="edge__name">
-            <v-icon size="16" class="edge__icon me-1">{{
-              mdiAccountOutline
-            }}</v-icon>
-            <span>{{ sourceName }}</span>
+            <v-icon
+              size="16"
+              class="edge__icon me-1"
+              :color="personNode ? 'primary' : undefined"
+              >{{
+                personNode ? mdiAccountCheckOutline : mdiAccountOutline
+              }}</v-icon
+            >
+            <NuxtLink
+              v-if="personNode"
+              :to="personNode.url"
+              class="edge__person-link"
+            >
+              {{ sourceName }}
+            </NuxtLink>
+            <span v-else>{{ sourceName }}</span>
           </div>
-          <div class="edge__kind">osoba</div>
+          <div class="edge__kind">
+            {{ personNode ? "osoba w bazie" : "osoba" }}
+          </div>
+          <ExtractionWrongPersonButton
+            v-if="personNode && fact.id"
+            :id="fact.id"
+            :person-name="personNode.name"
+            :reported="reportedWrongPerson"
+            class="edge__person-flag"
+          />
         </div>
 
         <!-- Connector (center) -->
@@ -76,6 +100,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import {
+  mdiAccountCheckOutline,
   mdiAccountOutline,
   mdiAccountGroupOutline,
   mdiArrowRight,
@@ -92,12 +117,38 @@ import {
   factConnector,
   factTargetKind,
 } from "~/utils/extraction";
+import { generateEntityUrl } from "~/composables/slugs";
+import { ExtractionWrongPersonButton } from "#components";
 
 const { fact } = defineProps<{
   fact: ExtractionFact;
 }>();
 
 const sourceName = computed(() => factSubject(fact));
+
+/** The graph person this fact was matched to, when it was matched to one.
+ *
+ * Both fields are written together at ingest, so a card missing the name has
+ * nothing to build a slug from and is treated as unmatched rather than linked
+ * to `/osoba/-<id>`. */
+const personNode = computed(() => {
+  const { personNodeId, personNodeName } = fact;
+  if (!personNodeId || !personNodeName) return undefined;
+  return {
+    id: personNodeId,
+    name: personNodeName,
+    url: generateEntityUrl("person", personNodeId, personNodeName),
+  };
+});
+
+// How many readers have already said the match is wrong, off the aggregate the
+// fact already carries. `computeVoteStats` only writes a category somebody has
+// voted in, so an unflagged fact has no field here at all.
+const reportedWrongPerson = computed(() => {
+  const votes = fact.stats?.votes as Record<string, unknown> | undefined;
+  const value = votes?.wrongPerson;
+  return typeof value === "number" ? value : 0;
+});
 const targetName = computed(() => factTarget(fact));
 const connectorLabel = computed(() => factConnector(fact));
 const connectorColor = computed(() => factTypeColor(fact));
@@ -198,6 +249,25 @@ const sourceCaption = computed(() => {
 }
 
 .edge__kind {
+  margin-top: 2px;
+}
+
+/* Underlined only on hover: the name is the card's heading first and a link
+   second. */
+.edge__person-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.edge__person-link:hover {
+  color: rgb(var(--v-theme-primary));
+  text-decoration: underline;
+}
+
+/* Pull the flag back into the column the name starts in - a v-btn carries its
+   own horizontal padding. */
+.edge__person-flag {
+  margin-left: -6px;
   margin-top: 2px;
 }
 

--- a/frontend/app/components/extraction/WrongPersonButton.vue
+++ b/frontend/app/components/extraction/WrongPersonButton.vue
@@ -1,0 +1,88 @@
+<template>
+  <client-only>
+    <v-btn
+      class="wrong-person"
+      size="x-small"
+      density="comfortable"
+      variant="text"
+      :color="flagged ? 'warning' : undefined"
+      :prepend-icon="mdiAccountAlertOutline"
+      @click.stop.prevent="toggle"
+    >
+      {{ flagged ? "Zgłoszono złe dopasowanie" : "To nie ta osoba" }}
+      <v-tooltip activator="parent" location="bottom" max-width="280">
+        {{
+          flagged
+            ? `Cofnij zgłoszenie - fakt jednak dotyczy ${personName}.`
+            : `Zgłoś, że ten fakt nie dotyczy ${personName} z bazy, tylko kogoś o tym samym nazwisku.`
+        }}
+      </v-tooltip>
+    </v-btn>
+  </client-only>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { mdiAccountAlertOutline } from "@mdi/js";
+import { castVoteOnce } from "~/composables/votes";
+import { useCurrentUser } from "vuefire";
+import { ClientOnly } from "#components";
+
+const {
+  id,
+  personName,
+  reported = 0,
+} = defineProps<{
+  /** The extraction the flag is about. */
+  id: string;
+  /** The matched node's name, so the tooltip names who is being disputed. */
+  personName: string;
+  /** How many people have already flagged this match, off the fact's own vote
+   * aggregate. Read from the document the card was rendered from, so showing it
+   * costs nothing - unlike `useVotes`, which opens a Firestore listener per
+   * card and would open one for every fact in an expanded article group. */
+  reported?: number;
+}>();
+
+const user = useCurrentUser();
+const router = useRouter();
+const route = useRoute();
+
+/** This reader's own flag, held locally.
+ *
+ * The aggregate above says whether anybody has flagged the match; it cannot say
+ * whether *this* reader did, and asking would cost the per-card listener the
+ * whole point of `reported` is to avoid. Starting from the aggregate means a
+ * fact somebody else already flagged reads as flagged, which is the truth the
+ * card has to tell - and clicking still toggles this reader's own vote.
+ */
+const sent = ref<boolean | null>(null);
+const flagged = computed(() => sent.value ?? reported > 0);
+
+async function toggle() {
+  if (!user.value) {
+    router.push({ path: "/login", query: { redirect: route.fullPath } });
+    return;
+  }
+  const next = !flagged.value;
+  sent.value = next;
+  // 0 rather than a delete: `castVoteOnce` merges into the one vote document
+  // this reader has on the fact, and removing it would take their verdict with
+  // it.
+  await castVoteOnce(id, "wrongPerson", next ? 1 : 0, "extraction");
+}
+</script>
+
+<style scoped>
+/* A flag on a match, not a call to action: sits quietly under the name until
+   somebody disagrees with it. */
+.wrong-person {
+  letter-spacing: normal;
+  text-transform: none;
+  opacity: 0.75;
+}
+
+.wrong-person:hover {
+  opacity: 1;
+}
+</style>

--- a/frontend/app/composables/votes.ts
+++ b/frontend/app/composables/votes.ts
@@ -1,4 +1,5 @@
 import {
+  mdiAccountAlertOutline,
   mdiAlertCircleOutline,
   mdiCheckCircleOutline,
   mdiHelpCircleOutline,
@@ -35,6 +36,12 @@ const configMap: Record<
   insufficient: {
     text: "Za mało informacji",
     icon: mdiHelpCircleOutline,
+    color: "warning",
+    downColor: "warning",
+  },
+  wrongPerson: {
+    text: "To nie ta osoba",
+    icon: mdiAccountAlertOutline,
     color: "warning",
     downColor: "warning",
   },

--- a/frontend/scripts/extractions.json
+++ b/frontend/scripts/extractions.json
@@ -23,6 +23,8 @@
     "url": "https://example.com/do-oceny",
     "articleUrl": "https://example.com/do-oceny",
     "articleDomain": "example.com",
+    "personNodeId": "3",
+    "personNodeName": "Anna Nowak",
     "fact_type": "employment",
     "person": "Anna Nowak",
     "organization": "Spolka Nieoceniona",
@@ -31,13 +33,19 @@
     "tag": "seed",
     "createdAt": "2026-07-21T10:00:00.000Z",
     "stats": {
-      "votes": { "interesting": 0, "quality": 0, "humanVoted": false }
+      "votes": {
+        "interesting": 0,
+        "quality": 0,
+        "humanVoted": false
+      }
     }
   },
   "seed-open-party": {
     "url": "https://example.com/do-oceny-partia",
     "articleUrl": "https://example.com/do-oceny-partia",
     "articleDomain": "example.com",
+    "personNodeId": "3",
+    "personNodeName": "Anna Nowak",
     "fact_type": "party_membership",
     "person": "Anna Nowak",
     "party": "Partia Testowa",
@@ -45,7 +53,11 @@
     "tag": "seed",
     "createdAt": "2026-07-22T10:00:00.000Z",
     "stats": {
-      "votes": { "interesting": 0, "quality": 0, "humanVoted": false }
+      "votes": {
+        "interesting": 0,
+        "quality": 0,
+        "humanVoted": false
+      }
     }
   }
 }

--- a/frontend/server/api/ingest/extraction.post.ts
+++ b/frontend/server/api/ingest/extraction.post.ts
@@ -2,6 +2,7 @@ import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { getApp } from "firebase-admin/app";
 import { getUser, requireDatascience } from "~~/server/utils/auth";
 import type { ExtractionFact } from "~~/shared/model";
+import { normalizePersonName } from "~~/shared/names";
 import { normalizeUrl } from "~~/shared/url";
 import { z } from "zod";
 
@@ -32,6 +33,15 @@ const articleSchema = z.object({
   publication_date: z.string().nullable(),
   extracted_facts: z.array(factSchema),
   tag: z.string(),
+  /** Node ids of the people the pipeline confirmed are named in this article.
+   *
+   * Article-level, because that is what the mention matcher judges: one article
+   * usually carries facts about several people, and only some of them are in
+   * the graph. Which fact belongs to which of these people is settled here, by
+   * name - see `matchPeopleByName`. Optional: the one-shot capture path
+   * (`oneshot.py`) analyses a page before any mention matching has run.
+   */
+  koryta_ids: z.array(z.string()).optional(),
 });
 
 const extractionRequestSchema = z.object({
@@ -74,10 +84,19 @@ export default defineEventHandler(async (event) => {
     if (sourceURL) urlToNodeId.set(normalizeUrl(sourceURL), doc.id);
   }
 
+  // The people the pipeline confirmed in these articles, by node id. Read once
+  // for the whole batch: the same politician shows up in article after article,
+  // so a per-article lookup would fetch them over and over.
+  const peopleById = await readPeople(
+    db,
+    body.articles.flatMap((article) => article.koryta_ids ?? []),
+  );
+
   // Flatten all facts and prepare documents
   const allDocs: FirebaseFirestore.DocumentData[] = [];
   for (const article of body.articles) {
     const articleNodeId = urlToNodeId.get(normalizeUrl(article.url));
+    const peopleByName = matchPeopleByName(article.koryta_ids, peopleById);
     for (const fact of article.extracted_facts) {
       const doc: Record<string, unknown> = {
         url: fact.url,
@@ -99,6 +118,18 @@ export default defineEventHandler(async (event) => {
       };
       if (articleNodeId) {
         doc.articleNodeId = articleNodeId;
+      }
+      // Which of the article's confirmed people this particular fact is about.
+      // `person` for most types, `subject` for a personal_relation - the same
+      // pair `factSubject` reads on the card, so the name shown is the name
+      // matched.
+      const subject = fact.person || fact.subject;
+      const matched = subject
+        ? peopleByName.get(normalizePersonName(subject))
+        : undefined;
+      if (matched) {
+        doc.personNodeId = matched.id;
+        doc.personNodeName = matched.name;
       }
       // Add optional fact-type-specific fields
       if (fact.person !== undefined) doc.person = fact.person;
@@ -131,3 +162,60 @@ export default defineEventHandler(async (event) => {
     count: allDocs.length,
   };
 });
+
+/** The person nodes behind a batch's `koryta_ids`, by id.
+ *
+ * Only `name` and `type` are read - the rest of a person node is large and
+ * nothing here looks at it. Ids that name no document, or name something that
+ * is not a person, are simply absent from the map: the pipeline should only
+ * send people, and a fact linked to an institution's node would be worse than
+ * one linked to nobody.
+ */
+async function readPeople(
+  db: FirebaseFirestore.Firestore,
+  ids: string[],
+): Promise<Map<string, { id: string; name: string }>> {
+  const people = new Map<string, { id: string; name: string }>();
+  const unique = [...new Set(ids)];
+  // getAll is one round trip per call; chunked so a nightly batch of thousands
+  // of articles does not build a single unbounded request.
+  const CHUNK = 300;
+  for (let i = 0; i < unique.length; i += CHUNK) {
+    const refs = unique
+      .slice(i, i + CHUNK)
+      .map((id) => db.collection("nodes").doc(id));
+    const docs = await db.getAll(...refs, { fieldMask: ["name", "type"] });
+    for (const doc of docs) {
+      const data = doc.data();
+      if (!data || data.type !== "person" || typeof data.name !== "string") {
+        continue;
+      }
+      people.set(doc.id, { id: doc.id, name: data.name });
+    }
+  }
+  return people;
+}
+
+/** One article's confirmed people, keyed by their normalized name.
+ *
+ * A name that two of them share is dropped rather than guessed at: the whole
+ * point of the flag on the card is that a namesake is easy to match wrongly, so
+ * a case we already know is ambiguous should not be asserted at all.
+ */
+function matchPeopleByName(
+  korytaIds: string[] | undefined,
+  peopleById: Map<string, { id: string; name: string }>,
+): Map<string, { id: string; name: string }> {
+  const byName = new Map<string, { id: string; name: string }>();
+  const ambiguous = new Set<string>();
+  for (const id of korytaIds ?? []) {
+    const person = peopleById.get(id);
+    if (!person) continue;
+    const key = normalizePersonName(person.name);
+    if (!key) continue;
+    if (byName.has(key) && byName.get(key)!.id !== id) ambiguous.add(key);
+    byName.set(key, person);
+  }
+  for (const key of ambiguous) byName.delete(key);
+  return byName;
+}

--- a/frontend/shared/model.ts
+++ b/frontend/shared/model.ts
@@ -62,7 +62,21 @@ export interface NodeStats {
 }
 
 export type VoteCategory =
-  "interesting" | "quality" | "correct" | "insufficient";
+  | "interesting"
+  | "quality"
+  | "correct"
+  | "insufficient"
+  /** The person node an extracted fact was matched to is not the person the
+   * article is about. Its own axis, not a shade of `correct`: the sentence can
+   * be a perfectly good fact about a namesake the graph has never heard of, and
+   * the mention matcher is what needs telling.
+   *
+   * Like every other vote a person casts, it sets `humanVoted` - so flagging a
+   * match, on its own, takes the fact out of the unreviewed backlog. That is
+   * deliberate rather than incidental: somebody has looked at it. The review
+   * flow keeps the reviewer on the card afterwards, so the usual path is a flag
+   * and then a verdict. */
+  | "wrongPerson";
 
 export type Votes = Record<
   VoteCategory,
@@ -627,6 +641,16 @@ export interface ExtractionFact {
   articleUrl: string;
   articleDomain?: string;
   articleNodeId?: string; // linked node if URL matches an existing article node
+  /** The person node this fact's subject was matched to, when the pipeline
+   * confirmed that person is named in the article (`koryta_ids`) and the name
+   * on the fact is theirs. Resolved once at ingest, so reading a fact never
+   * costs a node lookup. Absent means nobody in the graph was matched - not
+   * that the person is unknown to it. */
+  personNodeId?: string;
+  /** The matched node's own spelling of the name, which is what its url slug is
+   * built from. Stored beside the id so a card can link without a read; the
+   * fact's own `person` is how the article spelled it, and the two differ. */
+  personNodeName?: string;
   tag: string; // extraction model tag (e.g. "v1_qwen3-32b")
   createdAt?: string;
   uploaderUid?: string;

--- a/frontend/shared/names.ts
+++ b/frontend/shared/names.ts
@@ -1,0 +1,23 @@
+/** A person's name reduced to what two spellings of the same person share.
+ *
+ * The extraction pipeline writes the name as the article spelled it, and the
+ * graph stores whatever the register did. Joining a fact to the person node the
+ * mention matcher confirmed means comparing those two strings, and comparing
+ * them verbatim fails on the things that carry no meaning: case, the diacritics
+ * a newsroom CMS sometimes drops, and whether a double surname was hyphenated.
+ *
+ * Deliberately looser than `createSlug`, which has to stay a url segment: this
+ * only has to be stable enough that "Rafał Trzaskowski" and "Rafal
+ * Trzaskowski" land on the same key. It does not try to be clever about
+ * initials, middle names or declension - a fact naming somebody differently
+ * from the graph is left unmatched rather than matched to a guess.
+ */
+export function normalizePersonName(name: string): string {
+  return name
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // ą ć ę ń ó ś ź ż lose their marks
+    .replace(/[łŁ]/g, "l") // ł is its own codepoint, so NFD leaves it alone
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ") // hyphens, dots and quotes are word breaks
+    .trim();
+}

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -42,6 +42,29 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
 /** Newest first. Prepend, never insert in the middle. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "extraction-matched-person",
+    date: "2026-08-25",
+    title: "Fakt z artykułu pokazuje, do kogo z bazy został przypisany",
+    description:
+      "Potok wyszukiwania faktów potrafi już powiedzieć, które osoby z naszej " +
+      "bazy są w artykule wymienione, i każdy fakt jest łączony z tą z nich, " +
+      "której imię i nazwisko nosi. Na karcie faktu ta osoba jest " +
+      "podlinkowana i podpisana jako osoba w bazie. Łączenie po nazwisku " +
+      "bywa mylne - dwie osoby o tym samym nazwisku wyglądają tak samo - " +
+      "więc pod nazwiskiem jest przycisk To nie ta osoba, którym można " +
+      "zgłosić, że fakt dotyczy kogoś innego.",
+    steps: [
+      "Wejdź na /ekstrakcje i rozwiń artykuł: fakt dopasowany do kogoś z bazy ma pod nazwiskiem podpis osoba w bazie, a niedopasowany tylko osoba.",
+      "Kliknij podlinkowane nazwisko - ma otworzyć stronę tej osoby w bazie, nie artykuł.",
+      "Kliknij To nie ta osoba - napis ma się zmienić na Zgłoszono złe dopasowanie, a karta ma zostać na miejscu (to nie jest ocena faktu).",
+      "Kliknij jeszcze raz - zgłoszenie ma zostać cofnięte.",
+      "Wejdź na /ekstrakcje/kategoryzacja - ta sama informacja i ten sam przycisk mają być na karcie do oceny.",
+      "Zgłoś złe dopasowanie i wróć na stronę po dłuższej chwili - fakt ma dalej być podpisany jako zgłoszony (podliczenie głosów idzie w tle, a odpowiedź jest przez minutę cache'owana).",
+    ],
+    link: "/ekstrakcje",
+    area: "contributor",
+  },
+  {
     id: "home-intro-and-no-cta-on-phone",
     date: "2026-08-25",
     title: "Strona główna na telefonie: zdanie, wyszukiwarka, mapa",

--- a/frontend/tests/components/extraction/Card.test.ts
+++ b/frontend/tests/components/extraction/Card.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import Card from "../../../app/components/extraction/Card.vue";
+import type { ExtractionFact } from "../../../shared/model";
+
+function fact(fields: Partial<ExtractionFact> = {}): ExtractionFact {
+  return {
+    id: "fact-1",
+    url: "example.com/a",
+    articleUrl: "example.com/a",
+    articleDomain: "example.com",
+    justification: "radny PiS Piotr Gajda",
+    fact_type: "party_membership",
+    person: "Piotr Gajda",
+    party: "Prawo i Sprawiedliwość",
+    tag: "v26",
+    ...fields,
+  } as ExtractionFact;
+}
+
+describe("ExtractionCard", () => {
+  it("says nothing about the graph when nobody was matched", async () => {
+    const card = await mountSuspended(Card, { props: { fact: fact() } });
+
+    expect(card.text()).toContain("Piotr Gajda");
+    expect(card.text()).toContain("osoba");
+    expect(card.text()).not.toContain("osoba w bazie");
+    // No match, nothing to dispute.
+    expect(card.text()).not.toContain("To nie ta osoba");
+    expect(card.find("a[href^='/osoba/']").exists()).toBe(false);
+  });
+
+  it("links a matched fact to the person it was attached to", async () => {
+    const card = await mountSuspended(Card, {
+      props: {
+        fact: fact({
+          personNodeId: "KIZV3jJgniMdX7AoRxN9",
+          personNodeName: "Piotr Gajda",
+        }),
+      },
+    });
+
+    expect(card.text()).toContain("osoba w bazie");
+    expect(
+      card.find("a[href='/osoba/piotr-gajda-KIZV3jJgniMdX7AoRxN9']").exists(),
+    ).toBe(true);
+  });
+
+  it("shows the name the article used, and links by the node's own", async () => {
+    // The two differ: the article dropped the diacritics, and the url slug has
+    // to be built from what the node is actually called.
+    const card = await mountSuspended(Card, {
+      props: {
+        fact: fact({
+          person: "Krzysztof Kozlowski",
+          personNodeId: "08h8mNRYfRX9AsesDM85",
+          personNodeName: "Krzysztof Kozłowski",
+        }),
+      },
+    });
+
+    expect(card.text()).toContain("Krzysztof Kozlowski");
+    expect(
+      card
+        .find("a[href='/osoba/krzysztof-kozlowski-08h8mNRYfRX9AsesDM85']")
+        .exists(),
+    ).toBe(true);
+  });
+
+  it("offers the flag on a matched fact", async () => {
+    const card = await mountSuspended(Card, {
+      props: {
+        fact: fact({
+          personNodeId: "KIZV3jJgniMdX7AoRxN9",
+          personNodeName: "Piotr Gajda",
+        }),
+      },
+    });
+
+    expect(card.text()).toContain("To nie ta osoba");
+  });
+
+  it("says so when somebody has already flagged the match", async () => {
+    const card = await mountSuspended(Card, {
+      props: {
+        fact: fact({
+          personNodeId: "KIZV3jJgniMdX7AoRxN9",
+          personNodeName: "Piotr Gajda",
+          stats: { votes: { wrongPerson: 1 } } as ExtractionFact["stats"],
+        }),
+      },
+    });
+
+    expect(card.text()).toContain("Zgłoszono złe dopasowanie");
+  });
+
+  it("cannot flag a fact it has no id for", async () => {
+    // Grouped listings render facts straight from the API, and one without an
+    // id has no vote document to write to.
+    const card = await mountSuspended(Card, {
+      props: {
+        fact: fact({
+          id: undefined,
+          personNodeId: "KIZV3jJgniMdX7AoRxN9",
+          personNodeName: "Piotr Gajda",
+        }),
+      },
+    });
+
+    expect(card.text()).toContain("osoba w bazie");
+    expect(card.text()).not.toContain("To nie ta osoba");
+  });
+});

--- a/frontend/tests/components/extraction/WrongPersonButton.test.ts
+++ b/frontend/tests/components/extraction/WrongPersonButton.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import WrongPersonButton from "../../../app/components/extraction/WrongPersonButton.vue";
+
+const { castVoteOnce } = vi.hoisted(() => ({
+  castVoteOnce: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("~/composables/votes", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/composables/votes")>()),
+  castVoteOnce,
+}));
+
+const currentUser = ref<{ uid: string } | null>({ uid: "reviewer" });
+vi.mock("vuefire", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vuefire")>()),
+  useCurrentUser: () => currentUser,
+}));
+
+async function mount(props: Record<string, unknown> = {}) {
+  return mountSuspended(WrongPersonButton, {
+    props: { id: "fact-1", personName: "Piotr Gajda", ...props },
+  });
+}
+
+describe("ExtractionWrongPersonButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    currentUser.value = { uid: "reviewer" };
+  });
+
+  it("files the flag against the extraction, on its own axis", async () => {
+    const button = await mount();
+
+    await button.find("button").trigger("click");
+
+    // Not a shade of `correct`: the sentence can be a good fact about somebody
+    // the graph has never heard of.
+    expect(castVoteOnce).toHaveBeenCalledWith(
+      "fact-1",
+      "wrongPerson",
+      1,
+      "extraction",
+    );
+    expect(button.text()).toContain("Zgłoszono złe dopasowanie");
+  });
+
+  it("takes the flag back with a second click", async () => {
+    const button = await mount();
+
+    await button.find("button").trigger("click");
+    await button.find("button").trigger("click");
+
+    // Zero rather than a delete: the vote document also holds this reviewer's
+    // verdict on the fact itself.
+    expect(castVoteOnce).toHaveBeenLastCalledWith(
+      "fact-1",
+      "wrongPerson",
+      0,
+      "extraction",
+    );
+    expect(button.text()).toContain("To nie ta osoba");
+  });
+
+  it("starts flagged when somebody else already reported the match", async () => {
+    const button = await mount({ reported: 2 });
+
+    expect(button.text()).toContain("Zgłoszono złe dopasowanie");
+
+    await button.find("button").trigger("click");
+
+    expect(castVoteOnce).toHaveBeenCalledWith(
+      "fact-1",
+      "wrongPerson",
+      0,
+      "extraction",
+    );
+  });
+
+  it("files nothing for a logged out reader", async () => {
+    // They are sent to /login instead, the same as every other vote on the
+    // site - what matters here is that the click does not silently write a
+    // flag nobody can be held to.
+    //
+    // That redirect is a real navigation, and the router reaches for a
+    // `history` this environment does not define; without the stub it rejects
+    // out of the click handler and vitest reports an unhandled error for the
+    // whole run.
+    vi.stubGlobal("history", {
+      state: {},
+      length: 1,
+      scrollRestoration: "auto",
+      pushState: () => {},
+      replaceState: () => {},
+      go: () => {},
+    });
+    currentUser.value = null;
+    const button = await mount();
+
+    await button.find("button").trigger("click");
+
+    expect(castVoteOnce).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/e2e/extraction_person_match.spec.ts
+++ b/frontend/tests/e2e/extraction_person_match.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+import { logIn, USERS } from "./helpers/auth";
+
+/** Which person a fact was attached to, and saying so when it is the wrong one.
+ *
+ * The extraction pipeline confirms who an article names and hands the ids over
+ * with the facts; the endpoint joins those to each fact by name. Matching on a
+ * name is the part that goes wrong - two people share one often enough - so the
+ * card both shows the match and offers a way to dispute it.
+ *
+ * `seed-open-party` is the newest unreviewed fact in scripts/extractions.json,
+ * so it is the card /ekstrakcje/kategoryzacja opens on, and it is seeded matched
+ * to Anna Nowak (node 3).
+ *
+ * Deliberately stops at the click: what happens to the flag afterwards is the
+ * onVoteWritten trigger's job, and the fact it lands on is then served from a
+ * 60s response cache - neither of which this feature owns.
+ */
+test("a matched fact names the person, links to them and can be disputed", async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+
+  await logIn(page, USERS.normal, "/ekstrakcje/kategoryzacja");
+
+  const card = page.locator(".swipe-card");
+  await expect(card.locator(".extraction-quote")).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // The match is stated, not just implied by the name being there.
+  await expect(card).toContainText("osoba w bazie");
+  await expect(card.locator("a[href='/osoba/anna-nowak-3']")).toBeVisible();
+
+  const flag = card.getByRole("button", { name: /To nie ta osoba/ });
+  await expect(flag).toBeVisible();
+  await flag.click();
+
+  await expect(
+    card.getByRole("button", { name: /Zgłoszono złe dopasowanie/ }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Flagging must not double as a verdict: the reviewer is still on this card,
+  // with the queue where it was.
+  await expect(card.locator(".extraction-quote")).toBeVisible();
+
+  // And it is takeable back, for the reviewer who clicked it by mistake.
+  await card.getByRole("button", { name: /Zgłoszono złe dopasowanie/ }).click();
+  await expect(
+    card.getByRole("button", { name: /To nie ta osoba/ }),
+  ).toBeVisible({ timeout: 15_000 });
+});

--- a/frontend/tests/server/api/ingest/extraction.test.ts
+++ b/frontend/tests/server/api/ingest/extraction.test.ts
@@ -1,40 +1,63 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import handler from "../../../../server/api/ingest/extraction.post";
 
-const { mockReadBody, mockBatchSet, mockCommit, mockCollection, nodesQuery } =
-  vi.hoisted(() => {
-    const mockReadBody = vi.fn();
-    globalThis.createError = (err: any) => err;
-    globalThis.defineEventHandler = (fn: any) => fn;
-    globalThis.readValidatedBody = async (_event: any, parse: any) =>
-      parse(await mockReadBody());
+const {
+  mockReadBody,
+  mockBatchSet,
+  mockCommit,
+  mockCollection,
+  mockGetAll,
+  nodesQuery,
+  personNodes,
+} = vi.hoisted(() => {
+  const mockReadBody = vi.fn();
+  globalThis.createError = (err: any) => err;
+  globalThis.defineEventHandler = (fn: any) => fn;
+  globalThis.readValidatedBody = async (_event: any, parse: any) =>
+    parse(await mockReadBody());
 
-    const mockBatchSet = vi.fn();
-    const mockCommit = vi.fn().mockResolvedValue(undefined);
+  const mockBatchSet = vi.fn();
+  const mockCommit = vi.fn().mockResolvedValue(undefined);
 
-    // Article-node lookup: no existing nodes match.
-    const nodesQuery: any = {
-      where: vi.fn(() => nodesQuery),
-      select: vi.fn(() => nodesQuery),
-      get: vi.fn().mockResolvedValue({ docs: [] }),
-    };
-    const mockCollection = vi.fn(() => ({
-      where: nodesQuery.where,
-      doc: vi.fn(() => ({ id: "new-extraction-id" })),
+  // Article-node lookup: no existing nodes match.
+  const nodesQuery: any = {
+    where: vi.fn(() => nodesQuery),
+    select: vi.fn(() => nodesQuery),
+    get: vi.fn().mockResolvedValue({ docs: [] }),
+  };
+  // The graph the `koryta_ids` resolve against, keyed by node id; a test adds
+  // whichever people its payload claims.
+  const personNodes = new Map<string, Record<string, unknown>>();
+  const mockCollection = vi.fn((name: string) => ({
+    where: nodesQuery.where,
+    doc: vi.fn((id?: string) => ({
+      id: name === "nodes" ? id : "new-extraction-id",
+    })),
+  }));
+  // getAll takes refs then an options object, and answers from `personNodes`.
+  const mockGetAll = vi.fn(async (...args: any[]) => {
+    const refs = args.filter((arg) => typeof arg?.id === "string");
+    return refs.map((ref: any) => ({
+      id: ref.id,
+      data: () => personNodes.get(ref.id),
     }));
-
-    return {
-      mockReadBody,
-      mockBatchSet,
-      mockCommit,
-      mockCollection,
-      nodesQuery,
-    };
   });
+
+  return {
+    mockReadBody,
+    mockBatchSet,
+    mockCommit,
+    mockCollection,
+    mockGetAll,
+    nodesQuery,
+    personNodes,
+  };
+});
 
 vi.mock("firebase-admin/firestore", () => ({
   getFirestore: () => ({
     collection: mockCollection,
+    getAll: mockGetAll,
     batch: () => ({ set: mockBatchSet, commit: mockCommit }),
   }),
   Timestamp: { now: () => "TS" },
@@ -52,6 +75,7 @@ describe("api/ingest/extraction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     nodesQuery.get.mockResolvedValue({ docs: [] });
+    personNodes.clear();
   });
 
   it("seeds stats.votes so unvoted facts stay queryable", async () => {
@@ -198,5 +222,269 @@ describe("api/ingest/extraction", () => {
       expect.anything(),
       expect.objectContaining({ uploaderUid: "reader-who-captured-it" }),
     );
+  });
+
+  describe("koryta_ids", () => {
+    // The mention matcher confirms people per article, but an article usually
+    // carries facts about several of them - so which fact belongs to which
+    // person is settled here, by name.
+    it("links each fact to the confirmed person its subject names", async () => {
+      personNodes.set("gajda-id", { name: "Piotr Gajda", type: "person" });
+      personNodes.set("kozlowski-id", {
+        name: "Krzysztof Kozłowski",
+        type: "person",
+      });
+      mockReadBody.mockResolvedValue({
+        articles: [
+          {
+            url: "sulejow.naszemiasto.pl/a",
+            domain: "naszemiasto.pl",
+            title: null,
+            publication_date: null,
+            tag: "v26",
+            koryta_ids: ["gajda-id", "kozlowski-id"],
+            extracted_facts: [
+              {
+                url: "sulejow.naszemiasto.pl/a",
+                justification: "radny PiS Piotr Gajda",
+                fact_type: "party_membership",
+                person: "Piotr Gajda",
+                party: "Prawo i Sprawiedliwość",
+              },
+              {
+                url: "sulejow.naszemiasto.pl/a",
+                justification: "Radny Krzysztof Kozlowski",
+                fact_type: "employment",
+                // Spelled without diacritics, as the article had it.
+                person: "Krzysztof Kozlowski",
+                organization: "Rada Miasta",
+              },
+            ],
+          },
+        ],
+      });
+
+      await handler({} as any);
+
+      expect(mockBatchSet).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        expect.objectContaining({
+          personNodeId: "gajda-id",
+          personNodeName: "Piotr Gajda",
+        }),
+      );
+      // The node's own spelling is stored, not the article's, because it is
+      // what the person's url slug is built from.
+      expect(mockBatchSet).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        expect.objectContaining({
+          personNodeId: "kozlowski-id",
+          personNodeName: "Krzysztof Kozłowski",
+        }),
+      );
+    });
+
+    it("leaves a fact about somebody else unmatched", async () => {
+      // Seen in the sample batch: the article confirms Jerzy Barzowski, but
+      // every fact extracted from it is about Leszek Szymczak. Attaching the
+      // one confirmed person to it would be exactly the wrong match the flag
+      // on the card exists to report.
+      personNodes.set("barzowski-id", {
+        name: "Jerzy Barzowski",
+        type: "person",
+      });
+      mockReadBody.mockResolvedValue({
+        articles: [
+          {
+            url: "miastko.naszemiasto.pl/a",
+            domain: "naszemiasto.pl",
+            title: null,
+            publication_date: null,
+            tag: "v26",
+            koryta_ids: ["barzowski-id"],
+            extracted_facts: [
+              {
+                url: "miastko.naszemiasto.pl/a",
+                justification: "Leszek Szymczak z Bytowa",
+                fact_type: "party_membership",
+                person: "Leszek Szymczak",
+                party: "Prawo i Sprawiedliwość",
+              },
+            ],
+          },
+        ],
+      });
+
+      await handler({} as any);
+
+      const [, doc] = mockBatchSet.mock.calls[0]!;
+      expect(doc).not.toHaveProperty("personNodeId");
+      expect(doc).not.toHaveProperty("personNodeName");
+    });
+
+    it("matches a personal_relation on its subject", async () => {
+      personNodes.set("wnukowski-id", {
+        name: "Paweł Wnukowski",
+        type: "person",
+      });
+      mockReadBody.mockResolvedValue({
+        articles: [
+          {
+            url: "podlaskie24.pl/a",
+            domain: "podlaskie24.pl",
+            title: null,
+            publication_date: null,
+            tag: "v26",
+            koryta_ids: ["wnukowski-id"],
+            extracted_facts: [
+              {
+                url: "podlaskie24.pl/a",
+                justification: "moja babcia Kazimiera Wnukowska",
+                fact_type: "personal_relation",
+                subject: "Paweł Wnukowski",
+                object: "Kazimiera Wnukowska",
+                relation: "wnuk",
+              },
+            ],
+          },
+        ],
+      });
+
+      await handler({} as any);
+
+      expect(mockBatchSet).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ personNodeId: "wnukowski-id" }),
+      );
+    });
+
+    it("asserts nothing when two confirmed people share a name", async () => {
+      // A namesake is the case the match gets wrong most often, so one we
+      // already know is ambiguous is left alone rather than picked between.
+      personNodes.set("kowalski-a", { name: "Jan Kowalski", type: "person" });
+      personNodes.set("kowalski-b", { name: "Jan Kowalski", type: "person" });
+      mockReadBody.mockResolvedValue({
+        articles: [
+          {
+            url: "example.com/a",
+            domain: "example.com",
+            title: null,
+            publication_date: null,
+            tag: "v26",
+            koryta_ids: ["kowalski-a", "kowalski-b"],
+            extracted_facts: [
+              {
+                url: "example.com/a",
+                justification: "bo tak",
+                fact_type: "employment",
+                person: "Jan Kowalski",
+                organization: "Orlen",
+              },
+            ],
+          },
+        ],
+      });
+
+      await handler({} as any);
+
+      expect(mockBatchSet.mock.calls[0]![1]).not.toHaveProperty("personNodeId");
+    });
+
+    it("ignores an id that is not a person", async () => {
+      personNodes.set("orlen-id", { name: "Jan Kowalski", type: "place" });
+      mockReadBody.mockResolvedValue({
+        articles: [
+          {
+            url: "example.com/a",
+            domain: "example.com",
+            title: null,
+            publication_date: null,
+            tag: "v26",
+            koryta_ids: ["orlen-id", "missing-id"],
+            extracted_facts: [
+              {
+                url: "example.com/a",
+                justification: "bo tak",
+                fact_type: "employment",
+                person: "Jan Kowalski",
+                organization: "Orlen",
+              },
+            ],
+          },
+        ],
+      });
+
+      await handler({} as any);
+
+      expect(mockBatchSet.mock.calls[0]![1]).not.toHaveProperty("personNodeId");
+    });
+
+    it("reads each confirmed person once for the whole batch", async () => {
+      personNodes.set("holownia-id", {
+        name: "Szymon Hołownia",
+        type: "person",
+      });
+      const article = (url: string) => ({
+        url,
+        domain: "wpolityce.pl",
+        title: null,
+        publication_date: null,
+        tag: "v26",
+        koryta_ids: ["holownia-id"],
+        extracted_facts: [
+          {
+            url,
+            justification: "lider Polski 2050 Szymon Hołownia",
+            fact_type: "employment" as const,
+            person: "Szymon Hołownia",
+            organization: "Polska 2050",
+          },
+        ],
+      });
+      mockReadBody.mockResolvedValue({
+        articles: [article("wpolityce.pl/a"), article("wpolityce.pl/b")],
+      });
+
+      await handler({} as any);
+
+      // One getAll for the batch, holding the one distinct id.
+      expect(mockGetAll).toHaveBeenCalledTimes(1);
+      expect(mockGetAll.mock.calls[0]!.filter((a: any) => a?.id)).toHaveLength(
+        1,
+      );
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not look anybody up when no article carries ids", async () => {
+      // The one-shot capture path analyses a page before mention matching has
+      // run, so its payloads have no koryta_ids at all.
+      mockReadBody.mockResolvedValue({
+        articles: [
+          {
+            url: "example.com/a",
+            domain: "example.com",
+            title: null,
+            publication_date: null,
+            tag: "capture_v1",
+            extracted_facts: [
+              {
+                url: "example.com/a",
+                justification: "bo tak",
+                fact_type: "employment",
+                person: "Jan Kowalski",
+                organization: "Orlen",
+              },
+            ],
+          },
+        ],
+      });
+
+      await handler({} as any);
+
+      expect(mockGetAll).not.toHaveBeenCalled();
+      expect(mockBatchSet.mock.calls[0]![1]).not.toHaveProperty("personNodeId");
+    });
   });
 });

--- a/frontend/tests/shared/names.test.ts
+++ b/frontend/tests/shared/names.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { normalizePersonName } from "../../shared/names";
+
+describe("normalizePersonName", () => {
+  it("ignores case and diacritics", () => {
+    // What the article printed vs what the register stored: the same person.
+    expect(normalizePersonName("Rafał Trzaskowski")).toBe(
+      normalizePersonName("RAFAL TRZASKOWSKI"),
+    );
+    expect(normalizePersonName("Szymon Hołownia")).toBe("szymon holownia");
+    expect(normalizePersonName("Paweł Wnukowski")).toBe("pawel wnukowski");
+  });
+
+  it("treats a hyphenated surname as two words", () => {
+    expect(normalizePersonName("Anna Kowalska-Nowak")).toBe(
+      normalizePersonName("Anna Kowalska Nowak"),
+    );
+  });
+
+  it("collapses surrounding and repeated whitespace", () => {
+    expect(normalizePersonName("  Jan   Kowalski\n")).toBe("jan kowalski");
+  });
+
+  it("keeps different people apart", () => {
+    expect(normalizePersonName("Piotr Gajda")).not.toBe(
+      normalizePersonName("Krzysztof Kozłowski"),
+    );
+    // A surname on its own is not the same key as the full name, so a fact
+    // naming only "Obajtek" is left unmatched rather than attached to a guess.
+    expect(normalizePersonName("Obajtek")).not.toBe(
+      normalizePersonName("Daniel Obajtek"),
+    );
+  });
+
+  it("has no key for a name made only of punctuation", () => {
+    expect(normalizePersonName("—")).toBe("");
+  });
+});


### PR DESCRIPTION
…rong

The extraction pipeline now confirms which people already in the graph an article names, and hands those node ids over with the facts. Article-level is all the mention matcher can judge, but a single article usually carries facts about several people - so /api/ingest/extraction joins each fact to the one whose name its own subject bears, and stores the match on the fact. A name that two confirmed people share is left unmatched rather than guessed at.

On the card, a matched fact links to that person and is captioned 'osoba w bazie' instead of 'osoba'; nothing changes for a fact matched to nobody. Matching on a name is the part that goes wrong - the sample batch has an article confirming Jerzy Barzowski whose every fact is about Leszek Szymczak - so under the name there is now a button to report it. It files a wrongPerson vote, which reuses the vote document, the aggregate the onVoteWritten trigger keeps and the nightly export, rather than inventing a channel for one flag. It reads its state back off the aggregate the card was rendered from, so no card opens a Firestore listener for it, and it is not a verdict: the review flow leaves the reviewer on the card afterwards.