### PR TITLE
Add a koleje category to the company filters

### DIFF
--- a/frontend/scripts/migrate/README.md
+++ b/frontend/scripts/migrate/README.md
@@ -69,6 +69,19 @@ would rather not start it.
   where the code fix lives — a migration without its cause is unreadable a month
   later.
 
+## Scripts that are meant to be re-run
+
+Most of these are one-offs kept as a record. A few are not:
+`recompute-company-categories.ts` re-derives `categories` on company nodes from
+the PKD codes already stored, so it is the thing to run after _any_ change to
+the category list in `shared/companyCategories.ts` — the filter offers a new
+category immediately and finds nothing under it until either the company upload
+runs again or this does. It reads the mapping from that file rather than naming
+any category, so it needs no edit when the list grows.
+
+Everything above still applies to one: the dry run reports, a clean run writes
+nothing, and it takes `--prod --commit` to touch production.
+
 ## Fixing the cause too
 
 A migration repairs documents that are already written; on its own it is

--- a/frontend/scripts/migrate/recompute-company-categories.ts
+++ b/frontend/scripts/migrate/recompute-company-categories.ts
@@ -1,0 +1,215 @@
+import { initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+import {
+  categoriesFromActivity,
+  companyCategories,
+} from "../../shared/companyCategories";
+
+/**
+ * Re-derive `categories` on company nodes from the PKD codes already stored.
+ *
+ * The category filter on /eksploruj reads `categories` off the place node, and
+ * that field is written once, by `/api/ingest/company`, from the `activity`
+ * codes in the payload. So the list of categories is effectively frozen at the
+ * moment a company was last ingested: adding an entry to
+ * `shared/companyCategories.ts` changes what the filter *offers* immediately,
+ * and what it *finds* only after the next full company upload, which is a
+ * manual pipeline run. Between the two the new category reads as empty and
+ * looks broken.
+ *
+ * This closes that gap without a re-ingest — every code the mapping needs is
+ * already in the database, on the same document. It is deliberately not
+ * specific to any one category: it recomputes the whole set from
+ * `categoriesFromActivity`, so it is the script to run after *any* change to
+ * the category list, including narrowing a prefix or dropping a category. Not
+ * a one-off, and re-running it when nothing changed writes nothing.
+ *
+ * Revisions are included for the same reason `unwrap-array-fields.ts` includes
+ * them: a revision is written over its node wholesale when approved, so a
+ * pending one carrying the old set would undo this the first time somebody
+ * approves it.
+ *
+ * What it will not do:
+ *   - touch a document with no `activity`. Companies from the associations
+ *     register (SPZOZ hospitals) have no PKD codes in KRS, so an empty
+ *     recomputed set there means "cannot tell", not "no categories", and
+ *     clearing what is stored would lose whatever put it there.
+ *   - keep a stored category the PKD codes no longer support. Those are
+ *     removed and counted separately in the report, so a dry run shows the
+ *     removals before they happen.
+ *
+ * Usage (against the running dev:prod-data emulator):
+ *   npx tsx scripts/migrate/recompute-company-categories.ts            # dry run
+ *   npx tsx scripts/migrate/recompute-company-categories.ts --commit   # apply
+ * Against production:
+ *   npx tsx scripts/migrate/recompute-company-categories.ts --prod --commit
+ */
+
+const isProd = process.argv.includes("--prod");
+const commit = process.argv.includes("--commit");
+
+if (!isProd) {
+  process.env.FIRESTORE_EMULATOR_HOST =
+    process.env.FIRESTORE_EMULATOR_HOST ?? "127.0.0.1:8080";
+  process.env.GCLOUD_PROJECT = "koryta-pl";
+}
+
+const app = initializeApp({ projectId: "koryta-pl" });
+
+/** Node data written through sanitizeFirestoreData stored arrays as objects
+ * with numbered keys, so array fields have to be read tolerantly - the same
+ * rule `asArray` in server/utils/nodeFilters.ts follows on the read path.
+ * `unwrap-array-fields.ts` repairs the shape; this only has to survive it. */
+function asArray(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.filter((v) => typeof v === "string");
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => Number(a) - Number(b))
+      .map(([, v]) => v)
+      .filter((v): v is string => typeof v === "string");
+  }
+  return [];
+}
+
+/** Same members, in any order: the stored order carries no meaning, and
+ * rewriting a document to reorder it would cost a write for nothing. */
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const seen = new Set(a);
+  return b.every((value) => seen.has(value));
+}
+
+type Stats = {
+  /** Documents that would change. */
+  documents: number;
+  /** Category -> how many documents gained it. */
+  added: Record<string, number>;
+  /** Category -> how many documents lost it. */
+  removed: Record<string, number>;
+  /** Places with no PKD codes stored, so nothing to derive from. */
+  noActivity: number;
+  /** Places whose stored set already matches. */
+  unchanged: number;
+};
+
+function newStats(): Stats {
+  return { documents: 0, added: {}, removed: {}, noActivity: 0, unchanged: 0 };
+}
+
+function tally(counts: Record<string, number>, category: string) {
+  counts[category] = (counts[category] ?? 0) + 1;
+}
+
+function describe(counts: Record<string, number>): string {
+  return (
+    Object.entries(counts)
+      .sort(([, a], [, b]) => b - a)
+      .map(([category, count]) => `${category} ${count}`)
+      .join(", ") || "none"
+  );
+}
+
+async function recompute(
+  db: FirebaseFirestore.Firestore,
+  collection: string,
+  /** Where the node's own fields live; revisions nest them under `data`. */
+  prefix = "",
+): Promise<Stats> {
+  const field = (name: string) => (prefix ? `${prefix}.${name}` : name);
+  const stats = newStats();
+
+  // Only the three fields the mapping needs. The whole collection is read
+  // either way, but the node bodies are the bulk of it and none is used.
+  const snapshot = await db
+    .collection(collection)
+    .select(field("type"), field("activity"), field("categories"))
+    .get();
+  console.log(`Scanning ${snapshot.docs.length} ${collection}.`);
+
+  let batch = db.batch();
+  let pending = 0;
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    const container = (prefix ? data[prefix] : data) as
+      Record<string, unknown> | undefined;
+    if (!container || container.type !== "place") continue;
+
+    const activity = asArray(container.activity);
+    if (activity.length === 0) {
+      stats.noActivity++;
+      continue;
+    }
+
+    const stored = asArray(container.categories);
+    const derived: string[] = categoriesFromActivity(activity);
+    if (sameSet(stored, derived)) {
+      stats.unchanged++;
+      continue;
+    }
+
+    for (const category of derived) {
+      if (!stored.includes(category)) tally(stats.added, category);
+    }
+    for (const category of stored) {
+      if (!derived.includes(category)) tally(stats.removed, category);
+    }
+    stats.documents++;
+
+    if (commit) {
+      // A field path rather than a whole-document set: everything else on the
+      // node - the vote aggregates, the edge summaries, whether it is
+      // published - belongs to other writers.
+      batch.update(doc.ref, { [field("categories")]: derived });
+      pending++;
+      if (pending >= 400) {
+        await batch.commit();
+        batch = db.batch();
+        pending = 0;
+      }
+    }
+  }
+
+  if (commit && pending > 0) await batch.commit();
+
+  console.log(
+    `  ${commit ? "Updated" : "Would update"} ${stats.documents} ${collection}.`,
+  );
+  console.log(`  Categories gained: ${describe(stats.added)}`);
+  console.log(`  Categories dropped: ${describe(stats.removed)}`);
+  console.log(
+    `  Already correct: ${stats.unchanged}; no PKD codes stored: ${stats.noActivity}`,
+  );
+  return stats;
+}
+
+async function migrate() {
+  const db = getFirestore(app, "koryta-pl");
+  console.log(
+    `Connecting to ${isProd ? "PRODUCTION" : "local emulator"} Firestore` +
+      (commit ? "" : " (dry run — pass --commit to apply)"),
+  );
+  console.log(
+    `Categories in shared/companyCategories.ts: ` +
+      companyCategories
+        .map((c) => `${c.value} (${c.pkdPrefixes.join(", ")})`)
+        .join("; "),
+  );
+
+  const nodes = await recompute(db, "nodes");
+  const revisions = await recompute(db, "revisions", "data");
+
+  console.log(
+    `${commit ? "Updated" : "Would update"} ` +
+      `${nodes.documents + revisions.documents} document(s) in total.`,
+  );
+  if (!commit) console.log("Dry run — nothing written.");
+}
+
+migrate()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/frontend/shared/companyCategories.ts
+++ b/frontend/shared/companyCategories.ts
@@ -9,7 +9,7 @@
  * PKD codes in KRS, so they cannot be categorized this way yet.
  */
 
-export type CompanyCategory = "szpitale" | "wodociagi";
+export type CompanyCategory = "szpitale" | "wodociagi" | "koleje";
 
 export const companyCategories: {
   value: CompanyCategory;
@@ -28,6 +28,22 @@ export const companyCategories: {
     // 36.00 Pobór, uzdatnianie i dostarczanie wody
     // 37.00 Odprowadzanie i oczyszczanie ścieków
     pkdPrefixes: ["36.00", "37.00"],
+  },
+  {
+    value: "koleje",
+    title: "Koleje",
+    // 49.10 Transport kolejowy pasażerski międzymiastowy
+    // 49.20 Transport kolejowy towarów
+    // 42.12 Roboty związane z budową dróg szynowych i kolei podziemnej
+    //
+    // The first two are the operators. 42.12 is there for the infrastructure
+    // side: PKP PLK declares 52.21 (usługi wspomagające transport lądowy) as
+    // its main activity, and that code also covers roads, parking and bus
+    // terminals, so it is too broad to filter on - 42.12 catches PLK and the
+    // regional infrastructure companies instead, at the cost of also catching
+    // track-laying contractors. 49.31 (transport miejski i podmiejski) is left
+    // out for the same reason: it is trams and metro together with buses.
+    pkdPrefixes: ["49.10", "49.20", "42.12"],
   },
 ];
 

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -42,6 +42,27 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
 /** Newest first. Prepend, never insert in the middle. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "filtr-kategoria-koleje",
+    date: "2026-08-26",
+    title: "Filtr kategorii firm: koleje",
+    description:
+      "Do filtra kategorii na Eksploruj doszła trzecia pozycja - „Koleje” - " +
+      "obok szpitali oraz wodociągów i kanalizacji. Łapie przewoźników " +
+      "kolejowych (pasażerskich i towarowych) oraz spółki od infrastruktury " +
+      "torowej, po kodach PKD 49.10, 49.20 i 42.12. Kategorie wyliczane są " +
+      "przy imporcie spółki, więc firma dostaje etykietę „Koleje” dopiero po " +
+      "kolejnym przejściu importu spółek.",
+    steps: [
+      "Wejdź na /eksploruj/tabela i rozwiń filtry. Lista „Kategoria” ma mieć trzy pozycje: Szpitale, Wodociągi i kanalizacja, Koleje.",
+      "Wybierz „Koleje” - w tabeli mają zostać tylko osoby powiązane ze spółkami kolejowymi (np. PKP), a adres ma dostać `?category=koleje`.",
+      "Odśwież stronę z tym adresem: filtr ma się odtworzyć z linku, a nie wrócić do „wszystkie”.",
+      "To samo sprawdź na /eksploruj/nowe - ta sama lista kategorii, ta sama zawartość po wybraniu „Koleje”.",
+      "Jeśli lista wyników jest pusta, to znaczy, że import spółek nie przeliczył jeszcze kategorii - sprawdź na spółce, która ma w danych PKD 49.10/49.20/42.12.",
+    ],
+    link: "/eksploruj/tabela",
+    area: "public",
+  },
+  {
     id: "graf-osoby-dwa-kroki",
     date: "2026-08-25",
     title: "Strona osoby przemeblowana, graf czytelniejszy",

--- a/frontend/tests/shared/companyCategories.test.ts
+++ b/frontend/tests/shared/companyCategories.test.ts
@@ -16,6 +16,12 @@ describe("categoriesFromActivity", () => {
     expect(categoriesFromActivity(["37.00.Z"])).toEqual(["wodociagi"]);
   });
 
+  it("tags railways by PKD 49.10, 49.20 and 42.12", () => {
+    expect(categoriesFromActivity(["49.10.Z"])).toEqual(["koleje"]);
+    expect(categoriesFromActivity(["49.20.Z"])).toEqual(["koleje"]);
+    expect(categoriesFromActivity(["42.12.Z"])).toEqual(["koleje"]);
+  });
+
   it("matches any code on the list, not just the main activity", () => {
     expect(categoriesFromActivity(["68.20.Z", "86.10.Z"])).toEqual([
       "szpitale",
@@ -26,5 +32,16 @@ describe("categoriesFromActivity", () => {
     expect(categoriesFromActivity(["68.20.Z", "68.32.Z"])).toEqual([]);
     // 86.21 (medical practice) is not a hospital
     expect(categoriesFromActivity(["86.21.Z"])).toEqual([]);
+    // 52.21 (support activities for land transport) and 49.31 (urban and
+    // suburban transport) both cover roads and buses, so neither is rail
+    expect(categoriesFromActivity(["52.21.Z"])).toEqual([]);
+    expect(categoriesFromActivity(["49.31.Z"])).toEqual([]);
+  });
+
+  it("can return more than one category", () => {
+    expect(categoriesFromActivity(["49.10.Z", "36.00.Z"])).toEqual([
+      "wodociagi",
+      "koleje",
+    ]);
   });
 });


### PR DESCRIPTION
The category filter had two entries, szpitale and wodociagi. Rail is the third sector where the same question - who sits on these boards - is worth asking, and PKP alone spans a dozen companies.

The prefixes are the two rail transport codes plus 42.12 (budowa drog szynowych). PKP PLK files 52.21 as its main activity, which also covers roads, parking and bus terminals, so it is unusable as a filter; 42.12 is rail-specific and reaches PLK, at the price of also reaching track-laying contractors. 49.31 stays out for the same breadth reason - it is trams and metro together with buses.

Categories are computed at ingest, so companies already in the database carry the old set until the next company upload recomputes them.