### PR TITLE
Give every table row its own relations back

### DIFF
--- a/frontend/app/composables/entity/listWithStats.ts
+++ b/frontend/app/composables/entity/listWithStats.ts
@@ -66,6 +66,10 @@ export async function useListWithStats(
 
       if (nodes.length > 0) {
         const firstId = nodes[0]?.id;
+        // `subjects`, not `expand`: every row on the page is asked about in
+        // its own right. An `expand` is a node a reader clicked on somebody
+        // else's graph, and the endpoint draws it a ring out - which here left
+        // nine of the ten rows with no companies at all.
         const otherIds = nodes
           .slice(1)
           .map((n) => n.id)
@@ -73,7 +77,7 @@ export async function useListWithStats(
         try {
           const subRes = await $fetch(`/api/graph/local/${firstId}`, {
             method: "POST",
-            body: { expand: otherIds, distance: 1, latest: true },
+            body: { subjects: otherIds, distance: 1, latest: true },
             headers,
           });
           if (subRes) {

--- a/frontend/server/api/graph/local/[id].post.ts
+++ b/frontend/server/api/graph/local/[id].post.ts
@@ -11,11 +11,23 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "id is required" });
   }
 
-  let expansions: string[] = [];
-  if (body.expand) {
-    expansions =
-      typeof body.expand === "string" ? body.expand.split(",") : body.expand;
-  }
+  const list = (value: unknown): string[] => {
+    if (!value) return [];
+    return (typeof value === "string" ? value.split(",") : (value as string[]))
+      .map((id) => id.trim())
+      .filter(Boolean);
+  };
 
-  return getLocalGraph(focusNodeId, latest, distance, expansions);
+  // `subjects` and `expand` are not the same request. The table sends the
+  // other nine rows of the page as `subjects` - it wants each of their
+  // neighbourhoods in full - where an `expand` is one node a reader on the
+  // canvas asked to see more of, drawn a ring out from whoever the page is
+  // about. See `getLocalGraph`.
+  return getLocalGraph(
+    focusNodeId,
+    latest,
+    distance,
+    list(body.expand),
+    list(body.subjects),
+  );
 });

--- a/frontend/server/utils/localGraph.ts
+++ b/frontend/server/utils/localGraph.ts
@@ -104,13 +104,26 @@ async function fetchNeighbourhood(
   return { edges: Array.from(edges.values()), nodes };
 }
 
+/** `peers` are further nodes the layout is *about*, alongside `focusNodeId`.
+ *
+ * The table is the caller: a page of it is ten people who happen to share a
+ * sort order, and it needs every one of their employers, not the first one's
+ * plus whatever the other nine have in common with them. Passing them as
+ * `expansions` instead would rank them a ring below the first row for no
+ * reason a reader could see - and hand the nine rows' companies to the outer
+ * ring budget, which would then drop most of them.
+ */
 export async function getLocalGraph(
   focusNodeId: string,
   showUnapproved: boolean,
   distance: number,
   expansions: string[],
+  peers: string[] = [],
 ) {
-  const focusIds = new Set([focusNodeId]);
+  const subjectIds = [focusNodeId, ...peers.filter((id) => !!id)].filter(
+    (id, at, all) => all.indexOf(id) === at,
+  );
+  const focusIds = new Set(subjectIds);
   for (const id of expansions) {
     if (id) focusIds.add(id);
   }
@@ -183,8 +196,8 @@ export async function getLocalGraph(
 
   // Actually perform BFS from backend
   const reachable = getGraphBFS(
-    focusNodeId,
-    expansions.filter((id) => id && id !== focusNodeId),
+    subjectIds,
+    expansions.filter((id) => id && !subjectIds.includes(id)),
     distance,
     edges,
     nodesAll,

--- a/frontend/shared/graph/util.ts
+++ b/frontend/shared/graph/util.ts
@@ -202,7 +202,7 @@ export function getEdges(edgesFromDB: DBEdge[]) {
   });
 }
 
-/** The nodes within `maxDepth` relations of the subject, each stamped with how
+/** The nodes within `maxDepth` relations of the subjects, each stamped with how
  * far away it is.
  *
  * The stamp is the point as much as the filter. A two hop graph drawn flat
@@ -210,57 +210,99 @@ export function getEdges(edgesFromDB: DBEdge[]) {
  * person's employer and which is a colleague's - so every node carries the hop
  * count that put it there, and the canvas draws the rings differently.
  *
- * `expandedIds` are nodes the reader asked to see more of. They are extra
- * roots for the walk, but they start at one rather than nought: a page has a
- * single subject, and a neighbour drawn at depth nought gets the subject's
- * size, ring and label - which is a claim about whose page this is. Starting
- * them at one also puts whatever they reveal in the outer ring, where
- * `pruneOuterRing` can budget it rather than letting an expansion smuggle an
- * unbounded number of nodes past it. */
+ * `subjectIds` are the nodes the layout is *about*, all of them at depth
+ * nought. A person's page has exactly one; the table asks about a page of ten
+ * people at once, and none of the ten is a footnote to the first.
+ *
+ * `expandedIds` are nodes the reader asked to see more of. They walk as far as
+ * a subject does - a "Rozwiń" that fetched a node's relations and then drew
+ * none of them is the whole of the button - but they are *stamped* one ring
+ * out: a neighbour drawn at depth nought gets the subject's size, ring and
+ * label, which is a claim about whose page this is. That also puts whatever
+ * they reveal in the outer ring, where `pruneOuterRing` can budget it rather
+ * than letting an expansion smuggle an unbounded number of nodes past it.
+ *
+ * Which is why the walk and the stamp are two passes over the same edges
+ * rather than one. Folding them together is what broke this: expansions seeded
+ * at depth one against `maxDepth` of one were finished before they started, so
+ * every node but the first subject came back with no relations at all. */
 export function getGraphBFS(
-  subjectId: string,
+  subjectIds: string[],
   expandedIds: string[],
   maxDepth: number,
   edges: Edge[],
   interestingNodes: Record<string, Node & { stats: NodeStats }>,
 ): Record<string, Node & { stats: NodeStats; depth: number }> {
-  const depths = new Map<string, number>();
+  const subjects = subjectIds.filter((id) => !!id);
+  const expansions = expandedIds.filter((id) => !!id && !subjects.includes(id));
 
-  const queue: { id: string; d: number }[] = [];
-  const roots: [string, number][] = [
-    [subjectId, 0],
-    ...expandedIds.map((id): [string, number] => [id, 1]),
-  ];
-  for (const [id, d] of roots) {
-    if (depths.has(id)) continue;
-    queue.push({ id, d });
-    depths.set(id, d);
-  }
-
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    if (current.d >= maxDepth) continue;
-
-    const neighbors = edges
-      .filter((e) => e.source === current.id || e.target === current.id)
-      .map((e) => (e.source === current.id ? e.target : e.source));
-
-    for (const neighborId of neighbors) {
-      if (!interestingNodes[neighborId]) {
-        continue;
-      }
-
-      if (!depths.has(neighborId)) {
-        depths.set(neighborId, current.d + 1);
-        queue.push({ id: neighborId, d: current.d + 1 });
-      }
+  // Built once. Both passes ask "who is next to this node" for every node they
+  // reach, and the scan that answered it by filtering the whole edge list did
+  // that work again per node.
+  const neighbours = new Map<string, string[]>();
+  for (const edge of edges) {
+    for (const [from, to] of [
+      [edge.source, edge.target],
+      [edge.target, edge.source],
+    ]) {
+      const known = neighbours.get(from!);
+      if (known) known.push(to!);
+      else neighbours.set(from!, [to!]);
     }
   }
 
+  /** Breadth first from `roots`, `limit` hops, through `within` only. Seeds
+   * may start at different depths; they differ by at most one, so the queue
+   * stays in nondecreasing order and the first depth reached is the shortest. */
+  const walk = (
+    roots: [string, number][],
+    limit: number,
+    within: (id: string) => boolean,
+  ) => {
+    const depths = new Map<string, number>();
+    const queue: { id: string; d: number }[] = [];
+    for (const [id, d] of roots) {
+      if (depths.has(id)) continue;
+      depths.set(id, d);
+      queue.push({ id, d });
+    }
+    for (let head = 0; head < queue.length; head++) {
+      const current = queue[head]!;
+      if (current.d >= limit) continue;
+      for (const neighbour of neighbours.get(current.id) ?? []) {
+        if (depths.has(neighbour) || !within(neighbour)) continue;
+        depths.set(neighbour, current.d + 1);
+        queue.push({ id: neighbour, d: current.d + 1 });
+      }
+    }
+    return depths;
+  };
+
+  // Who is in: every root walks its own `maxDepth` hops, expansions included.
+  const reached = walk(
+    [...subjects, ...expansions].map((id): [string, number] => [id, 0]),
+    maxDepth,
+    (id) => !!interestingNodes[id],
+  );
+
+  // How far out each of them is drawn. The same roots over the same nodes, so
+  // nothing is added or lost - only expansions move, to the ring past the
+  // subjects'. No hop limit, because whatever an expansion revealed sits one
+  // past `maxDepth` by construction, and that ring is the whole point: it is
+  // what `pruneOuterRing` gets to budget.
+  const rings = walk(
+    [
+      ...subjects.map((id): [string, number] => [id, 0]),
+      ...expansions.map((id): [string, number] => [id, 1]),
+    ].filter(([id]) => reached.has(id)),
+    Infinity,
+    (id) => reached.has(id),
+  );
+
   return Object.fromEntries(
     Object.entries(interestingNodes)
-      .filter(([key]) => depths.has(key))
-      .map(([key, node]) => [key, { ...node, depth: depths.get(key)! }]),
+      .filter(([key]) => reached.has(key))
+      .map(([key, node]) => [key, { ...node, depth: rings.get(key)! }]),
   );
 }
 

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -42,6 +42,28 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
 /** Newest first. Prepend, never insert in the middle. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "tabela-firmy-wszystkich-wierszy",
+    date: "2026-08-26",
+    title: "Kolumna „Firmy” znowu wypełniona w całej tabeli",
+    description:
+      "W tabeli na Eksploruj kolumna „Firmy” była pusta we wszystkich " +
+      "wierszach poza pierwszym - mimo że dana osoba miała w bazie " +
+      "zatrudnienie. Zapytanie o powiązania całej strony wyników traktowało " +
+      "pierwszy wiersz jako temat, a pozostałe dziewięć jako jego sąsiadów, " +
+      "więc ich własne firmy nigdy nie wracały z serwera. Teraz każdy wiersz " +
+      "jest pytany o swoje powiązania osobno. Przy okazji działa znowu " +
+      "przycisk „Rozwiń” na grafie przy domyślnej głębokości 1.",
+    steps: [
+      "Wejdź na /eksploruj/tabela?sortBy=latestEmploymentStart&sortDesc=true - kolumna „Firmy” ma być wypełniona w każdym wierszu, w którym osoba ma zatrudnienie, a nie tylko w pierwszym.",
+      "Sprawdź konkretnie Marzenę Słomkę (trzeci wiersz przy tym sortowaniu) - ma pokazywać firmę, a nie pustą komórkę.",
+      "Kliknij nazwisko z dalszego wiersza: firmy w szufladzie i w kolumnie mają się zgadzać.",
+      "Przejdź na drugą stronę wyników i na inne sortowanie - to samo ma być prawdą tam.",
+      "Wejdź na stronę dowolnej osoby, na grafie kliknij sąsiedni węzeł i wybierz „Rozwiń” przy suwaku głębokości ustawionym na 1 - mają dojść jego powiązania, narysowane bledszym, zewnętrznym pierścieniem.",
+    ],
+    link: "/eksploruj/tabela?sortBy=latestEmploymentStart&sortDesc=true",
+    area: "public",
+  },
+  {
     id: "filtr-kategoria-koleje",
     date: "2026-08-26",
     title: "Filtr kategorii firm: koleje",

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -107,52 +107,6 @@ export const QA_ITEMS: QaItem[] = [
     area: "public",
   },
   {
-    id: "kto-kogo-zastapil",
-    date: "2026-08-24",
-    title: "Kto kogo zastąpił w spółce",
-    description:
-      "Na stronie instytucji jest nowa sekcja „Kto kogo zastąpił”: pary " +
-      "ustępujący - obejmujący stanowisko, dobrane w obrębie jednej spółki i " +
-      "jednej funkcji. Zmiany z tego samego dnia zebrane są w jedno " +
-      "wydarzenie, bo tak właśnie rejestr zapisuje wymianę całej rady. Na " +
-      "stronie osoby to samo widać od jej strony, w sekcji „Zmiany na " +
-      "stanowisku”, a w historii powiązań przy takim wpisie stoi linijka " +
-      "„Wcześniej: …”.",
-    steps: [
-      "Wejdź na stronę dużej spółki (np. przez wyszukiwarkę wpisz „Tauron”) i zjedź do sekcji „Kto kogo zastąpił”.",
-      "Znajdź kartę z kilkoma zmianami z jednej daty - ma mieć jeden nagłówek z datą i odznakę „N zmian tego samego dnia”, a nie N osobnych kart.",
-      "Sprawdź opis przerwy przy strzałce: „tego samego dnia”, „po N dniach przerwy” albo „wpisy nachodzą na siebie o N dni”.",
-      "Kliknij nazwisko po obu stronach strzałki - ma otwierać stronę tej osoby.",
-      "Zwęź okno do szerokości telefonu - wiersz ma się przełamać w pionie, strona nie może przewijać się w bok.",
-      "Wejdź na stronę osoby, która kogoś zastąpiła (np. /osoba/marzena-slomka-a8sCGsKrCC6OyVDmkOeg) - pod historią powiązań ma być sekcja „Zmiany na stanowisku” z liczbą „N z M powiązań”.",
-      "Wyloguj się i otwórz tę samą stronę spółki - zmian ma być mniej, a pod sekcją ma stać informacja, ilu nie pokazujemy, bo brakuje strony jednej z osób.",
-      "Zaloguj się z powrotem i odśwież tę stronę (F5, nie klikając w menu) - napis „nie pokazujemy” ma zniknąć, a brakujące osoby mają się pojawić z nazwiskami.",
-    ],
-    link: "/eksploruj/tabela",
-    area: "public",
-  },
-  {
-    id: "instytucja-ma-wlasna-strone",
-    date: "2026-08-24",
-    title: "Instytucja ma znów własną stronę",
-    description:
-      "Kliknięcie w spółkę nie przenosi już do tabeli osób przefiltrowanej " +
-      "do niej, tylko na stronę tej spółki: numery rejestrowe z odnośnikiem " +
-      "do rejestr.io, siedziba, właściciele, spółki zależne, obecny skład, " +
-      "historia powiązań i graf. Tabela jest nadal dostępna przyciskiem " +
-      "„Eksploruj powiązania”.",
-    steps: [
-      "W wyszukiwarce u góry wpisz nazwę spółki i wybierz ją - ma się otworzyć adres /instytucja/… , a nie /eksploruj/tabela.",
-      "Sprawdź kartę na górze: nazwa, „Instytucja publiczna”, numer KRS jako podkreślony odnośnik (nie jasnozielony) prowadzący do rejestr.io.",
-      "Kliknij „Eksploruj powiązania” - ma otworzyć starą tabelę przefiltrowaną do tej spółki.",
-      "Sprawdź, że sekcja „Historia powiązań” pojawia się raz, a nie dwa razy (kiedyś te same powiązania rysowały się też jako kafelki niżej).",
-      "Wejdź na stronę osoby i kliknij w jej miejsce pracy - ma prowadzić na stronę spółki.",
-      "Otwórz stronę instytucji bez numeru KRS (ministerstwo, urząd) - zamiast KRS mają być REGON i NIP.",
-    ],
-    link: "/",
-    area: "public",
-  },
-  {
     id: "extraction-matched-person",
     date: "2026-08-25",
     title: "Fakt z artykułu pokazuje, do kogo z bazy został przypisany",
@@ -274,6 +228,52 @@ export const QA_ITEMS: QaItem[] = [
     ],
     link: "/admin/opinie",
     area: "admin",
+  },
+  {
+    id: "kto-kogo-zastapil",
+    date: "2026-08-24",
+    title: "Kto kogo zastąpił w spółce",
+    description:
+      "Na stronie instytucji jest nowa sekcja „Kto kogo zastąpił”: pary " +
+      "ustępujący - obejmujący stanowisko, dobrane w obrębie jednej spółki i " +
+      "jednej funkcji. Zmiany z tego samego dnia zebrane są w jedno " +
+      "wydarzenie, bo tak właśnie rejestr zapisuje wymianę całej rady. Na " +
+      "stronie osoby to samo widać od jej strony, w sekcji „Zmiany na " +
+      "stanowisku”, a w historii powiązań przy takim wpisie stoi linijka " +
+      "„Wcześniej: …”.",
+    steps: [
+      "Wejdź na stronę dużej spółki (np. przez wyszukiwarkę wpisz „Tauron”) i zjedź do sekcji „Kto kogo zastąpił”.",
+      "Znajdź kartę z kilkoma zmianami z jednej daty - ma mieć jeden nagłówek z datą i odznakę „N zmian tego samego dnia”, a nie N osobnych kart.",
+      "Sprawdź opis przerwy przy strzałce: „tego samego dnia”, „po N dniach przerwy” albo „wpisy nachodzą na siebie o N dni”.",
+      "Kliknij nazwisko po obu stronach strzałki - ma otwierać stronę tej osoby.",
+      "Zwęź okno do szerokości telefonu - wiersz ma się przełamać w pionie, strona nie może przewijać się w bok.",
+      "Wejdź na stronę osoby, która kogoś zastąpiła (np. /osoba/marzena-slomka-a8sCGsKrCC6OyVDmkOeg) - pod historią powiązań ma być sekcja „Zmiany na stanowisku” z liczbą „N z M powiązań”.",
+      "Wyloguj się i otwórz tę samą stronę spółki - zmian ma być mniej, a pod sekcją ma stać informacja, ilu nie pokazujemy, bo brakuje strony jednej z osób.",
+      "Zaloguj się z powrotem i odśwież tę stronę (F5, nie klikając w menu) - napis „nie pokazujemy” ma zniknąć, a brakujące osoby mają się pojawić z nazwiskami.",
+    ],
+    link: "/eksploruj/tabela",
+    area: "public",
+  },
+  {
+    id: "instytucja-ma-wlasna-strone",
+    date: "2026-08-24",
+    title: "Instytucja ma znów własną stronę",
+    description:
+      "Kliknięcie w spółkę nie przenosi już do tabeli osób przefiltrowanej " +
+      "do niej, tylko na stronę tej spółki: numery rejestrowe z odnośnikiem " +
+      "do rejestr.io, siedziba, właściciele, spółki zależne, obecny skład, " +
+      "historia powiązań i graf. Tabela jest nadal dostępna przyciskiem " +
+      "„Eksploruj powiązania”.",
+    steps: [
+      "W wyszukiwarce u góry wpisz nazwę spółki i wybierz ją - ma się otworzyć adres /instytucja/… , a nie /eksploruj/tabela.",
+      "Sprawdź kartę na górze: nazwa, „Instytucja publiczna”, numer KRS jako podkreślony odnośnik (nie jasnozielony) prowadzący do rejestr.io.",
+      "Kliknij „Eksploruj powiązania” - ma otworzyć starą tabelę przefiltrowaną do tej spółki.",
+      "Sprawdź, że sekcja „Historia powiązań” pojawia się raz, a nie dwa razy (kiedyś te same powiązania rysowały się też jako kafelki niżej).",
+      "Wejdź na stronę osoby i kliknij w jej miejsce pracy - ma prowadzić na stronę spółki.",
+      "Otwórz stronę instytucji bez numeru KRS (ministerstwo, urząd) - zamiast KRS mają być REGON i NIP.",
+    ],
+    link: "/",
+    area: "public",
   },
   {
     id: "entity-page-admin-revisions-link",

--- a/frontend/tests/components/extraction/WrongPersonButton.test.ts
+++ b/frontend/tests/components/extraction/WrongPersonButton.test.ts
@@ -97,9 +97,23 @@ describe("ExtractionWrongPersonButton", () => {
       go: () => {},
     });
     currentUser.value = null;
+    const router = useRouter();
     const button = await mount();
 
     await button.find("button").trigger("click");
+
+    // Waited for rather than assumed. The component does not await its own
+    // `router.push`, and vue-router finishes the navigation on a timer - so
+    // under a full run the last leg of it lands after this file's teardown has
+    // taken the stub back, and `history is not defined` is reported as an
+    // unhandled rejection against whatever was running by then. Holding the
+    // test open until the route has actually moved keeps the stub in place for
+    // as long as the navigation needs it, and says what the redirect is while
+    // it is here.
+    await vi.waitFor(() =>
+      expect(router.currentRoute.value.path).toBe("/login"),
+    );
+    expect(router.currentRoute.value.query.redirect).toBeDefined();
 
     expect(castVoteOnce).not.toHaveBeenCalled();
   });

--- a/frontend/tests/server/utils/localGraph.test.ts
+++ b/frontend/tests/server/utils/localGraph.test.ts
@@ -154,6 +154,43 @@ describe("getLocalGraph", () => {
     expect(frontier).toEqual(many.slice(0, 40).map((n) => n.id));
   });
 
+  it("gives every subject its own companies, not just the first one's", async () => {
+    // The table's request. p2 shares nothing with p1, and its employer has to
+    // come back all the same - "Firmy" was empty for every row but the first
+    // when these arrived as expansions instead.
+    world(
+      [
+        node("p1", "person"),
+        node("p2", "person"),
+        node("c1", "place"),
+        node("c2", "place"),
+      ],
+      [edge("p1", "c1", "employed"), edge("p2", "c2", "employed")],
+    );
+
+    const layout = await getLocalGraph("p1", true, 1, [], ["p2"]);
+
+    expect(Object.keys(layout.nodes).sort()).toEqual(["c1", "c2", "p1", "p2"]);
+    // One hop from either subject, so the ring budget never gets a say.
+    expect(layout.nodes.p2?.depth).toBe(0);
+    expect(layout.nodes.c2?.depth).toBe(1);
+    expect(layout.omitted).toBe(0);
+  });
+
+  it("shows what a reader expanded, at the one hop the canvas asks for", async () => {
+    // "Rozwiń" on c1 with the depth control at one: p2 is a hop past the
+    // horizon of p1's own graph, and that is the point of the button.
+    world(NODES, EDGES);
+
+    const layout = await getLocalGraph("p1", true, 1, ["c1"]);
+
+    expect(layout.nodes.p2).toBeDefined();
+    // A ring out from the subject, so it is drawn - and budgeted - as somebody
+    // else's relation rather than p1's.
+    expect(layout.nodes.c1?.depth).toBe(1);
+    expect(layout.nodes.p2?.depth).toBe(2);
+  });
+
   it("keeps a logged out reader from seeing an unapproved person", async () => {
     world(
       [node("p1", "person"), { ...node("p2", "person"), visibility: false }],

--- a/frontend/tests/shared/graph/util.test.ts
+++ b/frontend/tests/shared/graph/util.test.ts
@@ -216,7 +216,7 @@ describe("getGraphBFS", () => {
   const edges = [spell("F", "A"), spell("B", "A"), spell("B", "y")];
 
   it("stamps every node with how far out it sits", () => {
-    const result = getGraphBFS("F", [], 2, edges, nodes);
+    const result = getGraphBFS(["F"], [], 2, edges, nodes);
 
     expect(result.F?.depth).toBe(0);
     expect(result.A?.depth).toBe(1);
@@ -224,13 +224,13 @@ describe("getGraphBFS", () => {
   });
 
   it("stops at the depth it was asked for, and keeps nothing unreachable", () => {
-    const result = getGraphBFS("F", [], 2, edges, nodes);
+    const result = getGraphBFS(["F"], [], 2, edges, nodes);
 
     expect(Object.keys(result).sort()).toEqual(["A", "B", "F"]);
   });
 
   it("draws one hop the way it always did", () => {
-    const result = getGraphBFS("F", [], 1, edges, nodes);
+    const result = getGraphBFS(["F"], [], 1, edges, nodes);
 
     expect(Object.keys(result).sort()).toEqual(["A", "F"]);
   });
@@ -239,7 +239,7 @@ describe("getGraphBFS", () => {
     // A page has one subject. Drawing the node a reader asked to see more of
     // at depth nought would give it the subject's size, ring and label, which
     // says the page is about it.
-    const result = getGraphBFS("F", ["B"], 2, edges, nodes);
+    const result = getGraphBFS(["F"], ["B"], 2, edges, nodes);
 
     expect(result.F?.depth).toBe(0);
     expect(result.B?.depth).toBe(1);
@@ -249,9 +249,41 @@ describe("getGraphBFS", () => {
   });
 
   it("ignores an expansion of the subject itself", () => {
-    const result = getGraphBFS("F", ["F"], 2, edges, nodes);
+    const result = getGraphBFS(["F"], ["F"], 2, edges, nodes);
 
     expect(result.F?.depth).toBe(0);
+  });
+
+  it("walks an expansion at the one hop the canvas asks for by default", () => {
+    // "Rozwiń" on a person's page, where the depth control sits at one. The
+    // node the reader clicked is stamped a ring out, but it still gets to
+    // reveal something - seeding it at depth one against a limit of one left
+    // it finished before it started, and the button did nothing at all.
+    const result = getGraphBFS(["F"], ["B"], 1, edges, nodes);
+
+    expect(result.B?.depth).toBe(1);
+    expect(result.y?.depth).toBe(2);
+  });
+
+  it("gives every subject its own neighbourhood, all on the same ring", () => {
+    // The table's request: a page of rows, none of them a footnote to the
+    // first. `B` is not related to `F`, and its employer has to come back
+    // anyway.
+    const result = getGraphBFS(["F", "B"], [], 1, edges, nodes);
+
+    expect(result.F?.depth).toBe(0);
+    expect(result.B?.depth).toBe(0);
+    expect(result.A?.depth).toBe(1);
+    expect(result.y?.depth).toBe(1);
+  });
+
+  it("keeps a subject's own ring out of the outer one", () => {
+    // Which is what keeps `pruneOuterRing` off a page of table rows: a one hop
+    // graph is never thinned.
+    const result = getGraphBFS(["F", "B"], [], 1, edges, nodes);
+    const depths = Object.values(result).map((n) => n.depth);
+
+    expect(Math.max(...depths)).toBe(1);
   });
 });
 


### PR DESCRIPTION
The "Firmy" column on /eksploruj/tabela was empty in every row but the first. The table fetches one subgraph for the whole page - the first row as the focus node, the other nine as `expand` - and `getGraphBFS` had just started seeding expansions at depth one. Against the `distance: 1` the table asks for, a root at depth one is already at the limit, so it never walked: nine of the ten rows came back with no edges at all, and the only companies that showed up for them were the ones they happened to share with the first row.

Two things were folded into one number. How far a node is *drawn* from the subject is a drawing decision - an expansion should not get the subject`s ring, size and label, and what it reveals belongs in the outer ring where `pruneOuterRing` can budget it. How far the walk may *go* is a fetch decision. So the walk and the stamp are now two passes: every root walks its own `maxDepth`, and the rings are laid out afterwards. That also fixes "Rozwiń" on a person`s graph, which at the default depth of one had been doing nothing since the same commit.

The table needed one thing more. Its ten rows are not expansions of the first one - none of them is a footnote to whoever sorted highest - so `/api/graph/local` takes `subjects` alongside `expand`, and the table sends the rest of its page that way. They are all drawn at depth nought, which keeps the page a one hop graph and so keeps the ring budget out of it: on a real page of results the budget had been dropping thirty two of the seventy nine nodes, which is most of the companies in the column.