### PR TITLE
Open /eksploruj/nowe on the newest hires rather than the best rated

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -439,6 +439,32 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "stats.votes.humanVoted",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "stats.edges.all.latestEmploymentStart",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "stats.votes.interesting",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "nodes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "stats.isApproved",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "type",
           "order": "ASCENDING"
         }

--- a/frontend/app/pages/eksploruj/nowe.vue
+++ b/frontend/app/pages/eksploruj/nowe.vue
@@ -4,7 +4,11 @@
       <h1 class="text-h4 mb-4">Eksploruj nowe osoby</h1>
 
       <div class="d-flex align-start ga-4 mb-4 flex-wrap">
-        <ExploreProgressBar hide-cta :query="apiQuery" class="flex-grow-1" />
+        <ExploreProgressBar
+          hide-cta
+          :query="progressQuery"
+          class="flex-grow-1"
+        />
         <v-select
           v-model="filterCategory"
           :items="availableCategories"
@@ -15,6 +19,43 @@
           clearable
           style="min-width: 220px; max-width: 280px"
         />
+      </div>
+
+      <div class="d-flex align-center ga-4 mb-4 flex-wrap">
+        <v-btn-toggle
+          v-model="filterOrder"
+          mandatory
+          divided
+          variant="outlined"
+          density="comfortable"
+        >
+          <v-btn value="recent" class="text-none" :prepend-icon="mdiClockFast">
+            Najnowsze zatrudnienia
+          </v-btn>
+          <v-btn value="votes" class="text-none" :prepend-icon="mdiStarOutline">
+            Najwyżej oceniane
+          </v-btn>
+        </v-btn-toggle>
+
+        <v-text-field
+          v-if="orderRecent"
+          v-model="minVotes"
+          type="number"
+          :min="0"
+          label="Min. suma głosów"
+          variant="outlined"
+          density="comfortable"
+          hide-details
+          style="max-width: 180px"
+        />
+
+        <span class="text-body-2 text-medium-emphasis">
+          {{
+            orderRecent
+              ? `Osoby, które zaczęły pracę najpóźniej, z sumą ocen co najmniej ${minVotes} i bez głosu od żadnej osoby.`
+              : "Osoby z najwyższą sumą ocen, bez głosu od żadnej osoby."
+          }}
+        </span>
       </div>
 
       <!-- CLOSED STATE -->
@@ -218,8 +259,10 @@
 import {
   mdiCheckboxBlankCircleOutline,
   mdiCheckboxMarkedCircle,
+  mdiClockFast,
   mdiInformation,
   mdiCircleSmall,
+  mdiStarOutline,
 } from "@mdi/js";
 import { ref, computed, watch } from "vue";
 import { useListWithStats } from "~/composables/entity/listWithStats";
@@ -250,11 +293,43 @@ const availableCategories = companyCategories.map((c) => ({
   title: c.title,
   value: c.value,
 }));
-const { stringFilter } = useQueryFilters();
+const { stringFilter, choiceFilter, numberFilter } = useQueryFilters();
 const filterCategory = stringFilter("category");
 
+/** Which end of the queue to work through.
+ *
+ * `recent` is the default: somebody who started a job last month is worth
+ * looking at while it is still news, and the pipeline's own rating is enough to
+ * tell an interesting one from the rest. `votes` is the older behaviour - the
+ * highest rated first, however long ago they were hired.
+ */
+const filterOrder = choiceFilter<"recent" | "votes">("order", "recent");
+const orderRecent = computed(() => filterOrder.value === "recent");
+
+/** The aggregate score a person needs to show up in `recent`. Three is where
+ * the pipeline's rating starts to mean something - 1,050 of the ~5,200
+ * unpublished people clear it, against a maximum observed score of 5 - so the
+ * queue stays a shortlist rather than everyone ever ingested. */
+const DEFAULT_MIN_VOTES = 3;
+const filterMinVotes = numberFilter("minVotes");
+/** Kept out of the url while it equals the default, like every other filter
+ * here. Clearing the field therefore reads back as the default rather than as
+ * "no minimum" - the two are the same absent-from-the-url state. */
+const minVotes = computed<number, number | string | null>({
+  get: () => filterMinVotes.value ?? DEFAULT_MIN_VOTES,
+  set: (value) => {
+    // The text field hands back a string, and an empty one once it is cleared.
+    const parsed =
+      typeof value === "number"
+        ? value
+        : Number.parseInt(String(value ?? ""), 10);
+    filterMinVotes.value =
+      !Number.isFinite(parsed) || parsed === DEFAULT_MIN_VOTES ? null : parsed;
+  },
+});
+
 // The card stack is paged in memory rather than through the url.
-watch(filterCategory, () => {
+watch([filterCategory, filterOrder, minVotes], () => {
   page.value = 1;
 });
 
@@ -278,9 +353,13 @@ watch(page, () => {
   actionVoted.value = false;
 });
 
-const sortBy = ref([
-  { key: "stats.votes.interesting", order: "desc" as const },
-]);
+/** The column the api sorts on, which is also the one the table marks as
+ * sorted. Both modes read top-down, so the direction is always descending. */
+const sortKey = computed(() =>
+  orderRecent.value ? "latestEmploymentStart" : "stats.votes.interesting",
+);
+
+const sortBy = computed(() => [{ key: sortKey.value, order: "desc" as const }]);
 
 const headers = computed(() => {
   const baseHeaders = [
@@ -330,19 +409,34 @@ const headers = computed(() => {
   return baseHeaders;
 });
 
+// Sorting on `latestEmploymentStart` leaves out the people who have no
+// employment edge to date at all - 135 of the 1,050 above the default score.
+// That is the point of the mode rather than a gap in it: "hired recently" has
+// nothing to say about somebody with no known job.
 const apiQuery = computed(
   () =>
     ({
       type: "person",
       limit: 1,
       page: page.value,
-      sortBy: "stats.votes.interesting",
+      sortBy: sortKey.value,
       sortDesc: "true",
       visibility: "private",
       hideVoted: "no_votes",
       category: filterCategory.value || undefined,
+      minVotes: orderRecent.value ? minVotes.value : undefined,
     }) as Query,
 );
+
+/** The bar counts the same people it always did: everybody the reader could be
+ * asked to check, narrowed only by the filters that say who that is. The score
+ * threshold decides the order of the queue, not its scope, so folding it in
+ * would silently redefine "sprawdzono N z M" the moment the page loads - and
+ * the denominator would move again every time somebody nudged the threshold. */
+const progressQuery = computed(() => ({
+  ...apiQuery.value,
+  minVotes: undefined,
+}));
 
 // Same as /eksploruj/tabela: the template is a single <ClientOnly>, so nothing
 // this returns is rendered on the server.

--- a/frontend/scripts/nodes.json
+++ b/frontend/scripts/nodes.json
@@ -255,7 +255,15 @@
       "nodeGroupSize": 1,
       "votes": {
         "humanVoted": false,
-        "interesting": 0
+        "interesting": 3
+      },
+      "edges": {
+        "all": {
+          "latestEmploymentStart": "2026-02-01"
+        },
+        "approved": {
+          "latestEmploymentStart": "2026-02-01"
+        }
       }
     },
     "content": "Test person not yet approved"

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,34 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "eksploruj-nowe-kolejnosc-najnowsi",
+    title: "„Eksploruj nowe” zaczyna od najnowszych zatrudnień",
+    description:
+      "Kolejka do sprawdzania miała dotąd jedną kolejność: najwyżej oceniani " +
+      "najpierw, niezależnie od tego, czy ktoś objął stanowisko w zeszłym " +
+      "miesiącu czy dziesięć lat temu. Doszedł przełącznik z drugą " +
+      "kolejnością - „Najnowsze zatrudnienia” - i to ona jest teraz " +
+      "domyślna: osoby, które najpóźniej zaczęły pracę, z sumą ocen co " +
+      "najmniej 3, żeby kolejka została krótką listą, a nie wszystkim, co " +
+      "kiedykolwiek trafiło do bazy. Próg da się zmienić w polu obok, a " +
+      "„Najwyżej oceniane” wraca do poprzedniego zachowania. W obu " +
+      "kolejnościach wciąż pokazują się tylko osoby, na które nikt jeszcze " +
+      "nie zagłosował. Wybór zapisuje się w adresie strony, więc link można " +
+      "komuś podać. Filtr typu podmiotu działa jak wcześniej.",
+    steps: [
+      "Wejdź na /eksploruj/nowe zalogowany. Przełącznik ma stać na „Najnowsze zatrudnienia”, a obok ma być pole „Min. suma głosów” z wartością 3.",
+      "Sprawdź w tabeli kolumnę „Ostatnie zatrudnienie” - klikając „Następna osoba” kilka razy, daty powinny iść od najnowszych w dół.",
+      "Kolumna „Głosy łącznie” ma pokazywać co najmniej 3 przy każdej osobie.",
+      "Zmień próg na 5. Adres ma dostać „minVotes=5”, a osoby z oceną 3 i 4 mają zniknąć.",
+      "Wyczyść pole - ma wrócić do 3, bo to wartość domyślna.",
+      "Przełącz na „Najwyżej oceniane”. Adres ma dostać „order=votes”, kolejność ma iść od najwyższej sumy ocen, a pole progu ma zniknąć.",
+      "Odśwież stronę z takim adresem - przełącznik i próg mają zostać tam, gdzie je ustawiłeś.",
+      "Ustaw „Typ podmiotu” na szpitale przy obu kolejnościach - lista ma się zawęzić, a licznik postępu u góry przeliczyć.",
+    ],
+    link: "/eksploruj/nowe",
+    area: "contributor",
+  },
+  {
     id: "wyszukiwarka-szersza-na-komputerze",
     title: "Wyszukiwarka na głównej znów szeroka na komputerze",
     description:

--- a/frontend/tests/e2e/explore_nowe.spec.ts
+++ b/frontend/tests/e2e/explore_nowe.spec.ts
@@ -40,5 +40,19 @@ test.describe("Eksploruj Nowe", () => {
     // Assert that it actually contains text
     const nameText = await firstRowName.innerText();
     expect(nameText.length).toBeGreaterThan(0);
+
+    // The queue opens on the most recent hires above the default threshold,
+    // which is the state nothing writes into the url.
+    await expect(page.getByLabel("Min. suma głosów")).toHaveValue("3");
+    expect(new URL(page.url()).search).toBe("");
+
+    // The other order is still reachable, and says so in the url so the choice
+    // survives a reload.
+    await page
+      .getByRole("button", { name: "Najwyżej oceniane" })
+      .click({ force: true });
+    await page.waitForURL(/order=votes/);
+    await expect(page.getByLabel("Min. suma głosów")).toHaveCount(0);
+    await expect(firstRowName).toBeVisible({ timeout: 15000 });
   });
 });

--- a/frontend/tests/pages/eksploruj/nowe.test.ts
+++ b/frontend/tests/pages/eksploruj/nowe.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { ref } from "vue";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import type { Query } from "~~/server/api/nodes/index.get";
+import NowePage from "../../../app/pages/eksploruj/nowe.vue";
+
+const vuetify = createVuetify({ components, directives });
+
+// The route query is what the filters read and write, so it is a live object
+// the tests rewrite between mounts rather than a fixed one.
+const { routeQuery, lastQuery } = vi.hoisted(() => ({
+  routeQuery: { value: {} as Record<string, string> },
+  lastQuery: { value: null as { value: Query } | null },
+}));
+
+vi.mock("vue-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-router")>();
+  return {
+    ...actual,
+    useRoute: () => ({
+      query: routeQuery.value,
+      name: "eksploruj-nowe",
+      path: "/eksploruj/nowe",
+      params: {},
+    }),
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn(), afterEach: vi.fn() }),
+  };
+});
+
+// Records the query the page built, and hands the page an empty result set.
+// Spelled out twice because `vi.mock` is hoisted above anything this file
+// defines, and Nuxt aliases the same composable under both prefixes.
+vi.mock("~/composables/entity/listWithStats", () => ({
+  useListWithStats: vi.fn((apiQuery: { value: Query }) => {
+    lastQuery.value = apiQuery;
+    return Promise.resolve({
+      tableItems: ref([]),
+      totalItems: ref(0),
+      pending: ref(false),
+    });
+  }),
+}));
+vi.mock("~~/app/composables/entity/listWithStats", () => ({
+  useListWithStats: vi.fn((apiQuery: { value: Query }) => {
+    lastQuery.value = apiQuery;
+    return Promise.resolve({
+      tableItems: ref([]),
+      totalItems: ref(0),
+      pending: ref(false),
+    });
+  }),
+}));
+
+vi.mock("~/composables/edges", () => ({
+  useEdges: vi.fn(() =>
+    Promise.resolve({ sources: ref([]), targets: ref([]) }),
+  ),
+}));
+
+// Auto-imported, so a `vi.stubGlobal` would not be consulted: the page reaches
+// them through the module Nuxt resolved at build time.
+vi.mock("~/composables/companyLocations", () => ({
+  useCompanyLocations: vi.fn(() => ({
+    companyRegions: ref({}),
+    companyLocations: ref({}),
+    regions: ref({}),
+  })),
+}));
+vi.mock("~/composables/personPlaces", () => ({
+  usePersonPlaces: vi.fn(() => ({
+    workLocations: ref([]),
+    mapLocations: ref([]),
+  })),
+}));
+
+// `useAuthState` names the database it wants rather than taking vuefire's
+// default-database handle, so the vuefire stub below is not enough on its own.
+vi.mock("firebase/firestore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("firebase/firestore")>();
+  return { ...actual, getFirestore: vi.fn(() => ({})) };
+});
+
+vi.mock("vuefire", () => ({
+  useCurrentUser: vi.fn(() => ref(null)),
+  useFirestore: vi.fn(() => ({})),
+  useFirebaseApp: vi.fn(() => ({ name: "[DEFAULT]" })),
+  useFirebaseAuth: vi.fn(() => ({})),
+  useDocument: vi.fn(() => ref(null)),
+}));
+
+async function mountPage(query: Record<string, string> = {}) {
+  routeQuery.value = query;
+  lastQuery.value = null;
+
+  vi.stubGlobal("definePageMeta", vi.fn());
+  vi.stubGlobal("useHead", vi.fn());
+  vi.stubGlobal("useCookie", (_key: string, opts: { default: () => boolean }) =>
+    ref(opts.default()),
+  );
+
+  const wrapper = mount(
+    { components: { NowePage }, template: "<Suspense><NowePage/></Suspense>" },
+    {
+      global: {
+        plugins: [vuetify],
+        stubs: {
+          ClientOnly: { template: "<div><slot></slot></div>" },
+          ExploreProgressBar: true,
+          ExploreNewButtons: true,
+          ExploreTable: true,
+          ExploreProposeChange: true,
+          CardExplorePerson: true,
+          CardEmploymentHistory: true,
+          ChartPersonLocations: true,
+          NoteEditor: true,
+        },
+      },
+    },
+  );
+  await flushPromises();
+  return wrapper;
+}
+
+function currentQuery(): Query {
+  if (!lastQuery.value) throw new Error("useListWithStats was never called");
+  return lastQuery.value.value;
+}
+
+describe("/eksploruj/nowe", () => {
+  beforeEach(() => {
+    lastQuery.value = null;
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("defaults to the most recently employed above the minimum score", async () => {
+    const wrapper = await mountPage();
+
+    expect(currentQuery()).toMatchObject({
+      sortBy: "latestEmploymentStart",
+      sortDesc: "true",
+      hideVoted: "no_votes",
+      minVotes: 3,
+    });
+    expect(wrapper.text()).toContain("Najnowsze zatrudnienia");
+    expect(
+      (wrapper.find('input[type="number"]').element as HTMLInputElement).value,
+    ).toBe("3");
+  });
+
+  it("takes the minimum score from the url", async () => {
+    await mountPage({ minVotes: "1" });
+
+    expect(currentQuery().minVotes).toBe(1);
+  });
+
+  it("sorts by the vote total and drops the minimum in the votes mode", async () => {
+    const wrapper = await mountPage({ order: "votes", minVotes: "1" });
+
+    const query = currentQuery();
+    expect(query.sortBy).toBe("stats.votes.interesting");
+    expect(query.minVotes).toBeUndefined();
+    // The threshold only means something for the recent queue, so its field
+    // goes away with it.
+    expect(wrapper.find('input[type="number"]').exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
The queue had a single order - highest aggregate score first - which said nothing about when somebody took the job. A person who started last month sat behind people the pipeline rated the same years ago, and there was no way to ask for the recent end of the list at all.

So there are two orders now, as a toggle, and "Najnowsze zatrudnienia" is the default: the latest employment start first, among people nobody has voted on yet, with an aggregate score of at least 3. Three is where the pipeline's own rating starts to mean something - 1,050 of the ~5,200 unpublished people clear it, against a maximum observed score of 5 - so the queue is a shortlist rather than everything ever ingested. The threshold is editable next to the toggle. "Najwyżej oceniane" is the old behaviour.

Both live in the url (`order`, `minVotes`), and both stay out of it while they hold their default, so an unadorned /eksploruj/nowe is the new default view and a link can carry any other.

The progress bar deliberately does not see the threshold. It counts who could be checked, and folding a queue-ordering knob into that would redefine "sprawdzono N z M" on load and move it again on every nudge.

Firestore serves the new default from a composite index that did not exist: isApproved, humanVoted, type, latestEmploymentStart desc, votes.interesting desc - the order-by field ahead of the inequality one, which is what keeps the sort by date rather than by score. Without it deployed the api falls back to sorting in memory over every unpublished person, so `firebase deploy --only firestore:indexes` has to run before this is worth much in production.

The seeded person the e2e spec finds now carries a score and an employment date, or the new default would leave that page empty in the emulator.