### PR TITLE
Give each scoring model the part of the 1-5 scale it has earned

### DIFF
--- a/data/pipelines/src/analysis/scores/__init__.py
+++ b/data/pipelines/src/analysis/scores/__init__.py
@@ -11,10 +11,21 @@ employers, `PeopleScoresPageRank` reads the shape of the graph around them,
 can nominate somebody the others miss, which is why the site takes the best
 score across models rather than the sum.
 
+Taking the best only works if a 5 means the same thing whoever said it, and the
+first measurement against human verdicts says it did not - so each model now
+carries a `ScoreRange` bounding the part of the 1-5 axis its accuracy supports.
+`base` holds the numbers and `scripts/score_model_accuracy.py` recomputes them.
+
 See `base.PeopleScoreModel` for what they share.
 """
 
-from analysis.scores.base import PeopleScoreModel, Population
+from analysis.scores.base import (
+    FULL_RANGE,
+    QUEUE_THRESHOLD,
+    PeopleScoreModel,
+    Population,
+    ScoreRange,
+)
 from analysis.scores.capture import PeopleScoresCapture
 from analysis.scores.coappointment import PeopleScoresCoappointment
 from analysis.scores.company import CompanyScores, PeopleScores
@@ -34,6 +45,8 @@ PEOPLE_SCORE_MODELS: list[type[PeopleScoreModel]] = [
 ]
 
 __all__ = [
+    "FULL_RANGE",
+    "QUEUE_THRESHOLD",
     "CompanyScores",
     "PEOPLE_SCORE_MODELS",
     "PeopleScoreModel",
@@ -44,4 +57,5 @@ __all__ = [
     "PeopleScoresSuccession",
     "PeopleScoresTurnover",
     "Population",
+    "ScoreRange",
 ]

--- a/data/pipelines/src/analysis/scores/base.py
+++ b/data/pipelines/src/analysis/scores/base.py
@@ -17,6 +17,40 @@ by rank, not by value: raw model outputs are on wildly different scales - a
 PageRank mass is ~1e-5, a co-appointment count is an integer - and with the
 frontend taking the maximum across models, whichever model scaled itself most
 generously would otherwise win every tie.
+
+Ranking within a model is not the same as being right, though, and `ScoreRange`
+is what the first measurement of that cost. `scripts/score_model_accuracy.py`
+matches every human vote cast since the models went live on 2026-08-08 to the
+scores standing on that person just before somebody looked at them, and asks
+what the reader then said. Over 132 people:
+
+    model      n    said interesting    wasted a click    band orders?
+    turnover   43   88 %               12 %              no  (87 % -> 90 %)
+    pagerank  120   66 %               34 %              no  (64 % -> 68 %)
+    company   124   65 %               35 %              yes (54 % -> 88 %)
+    capture   130   65 %               35 %              yes (56 % -> 80 %)
+    together   51   51 %               49 %              no  (56 % -> 41 %)
+
+against a base rate of 65 % interesting and 35 % wasted over everybody a reader
+judged. "Band orders" compares the model saying 1-2 against it saying 3-5, and
+the arrow is what the reader concluded; the split is significant for `company`
+(p = 0.0002) and `capture` (p = 0.008) and not for the other three. Being named
+at all is significant only for `turnover` (88 % against 65 %, p = 0.0001) and
+for `together`, which is significantly *worse* than the pool it draws from
+(51 %, p = 0.009).
+
+So a 5 does not mean the same thing from every model: `turnover` is right about
+almost everybody it names and its own ordering adds nothing, `company` and
+`capture` earn their scale, and `pagerank` and `together` emit a 5 that carries
+no more information than their 1 - and with the site taking the maximum, that 5
+is what decides the queue.
+
+`ScoreRange` therefore gives each model the part of the 1-5 axis its measured
+accuracy supports, and `banded_scores` folds the rank bands onto it. A model
+whose ceiling is 2 can never on its own put somebody in the queue, which starts
+at 3; a model floored at 3 puts everybody it names there. Nothing about the
+site changes - it still takes the highest score any model gave - but the
+highest score now comes from whichever model has earned the right to say it.
 """
 
 import dataclasses
@@ -45,6 +79,45 @@ SCORE_BANDS: tuple[tuple[float, int], ...] = (
     (0.60, 2),
     (0.0, 1),
 )
+
+#: The score a person needs before the site's default queue shows them at all.
+#: Mirrors `DEFAULT_MIN_VOTES` in `frontend/app/pages/eksploruj/nowe.vue`, and
+#: it is the number the ranges below are drawn around: a ceiling under it keeps
+#: a model out of the queue, a floor on it puts everybody it names in.
+QUEUE_THRESHOLD = 3
+
+
+@dataclasses.dataclass(frozen=True)
+class ScoreRange:
+    """How much of the 1-5 axis a model has earned.
+
+    The band a model hands out is a rank within its own output, and a rank says
+    nothing about whether the model is right. Measuring that against what
+    readers concluded (see the module docstring) put the models a long way
+    apart, so each gets the span its accuracy supports rather than all of them
+    getting all five points.
+    """
+
+    floor: int = 1
+    ceiling: int = 5
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.floor <= self.ceiling <= 5:
+            raise ValueError(f"{self} is not a range inside 1-5")
+
+    def rescale(self, band: int) -> int:
+        """Where a 1-5 rank band lands once folded onto this range.
+
+        Rounded up at the halves, so a model with a narrow range still reaches
+        its own ceiling - a range of 1-2 whose top band came out as 1 would be
+        a model that cannot say anything at all.
+        """
+        width = self.ceiling - self.floor
+        return self.floor + int((band - 1) * width / 4 + 0.5)
+
+
+#: What a model that has not been measured gets: the whole axis, as before.
+FULL_RANGE = ScoreRange()
 
 
 def iter_dicts(value: typing.Any) -> typing.Iterator[dict]:
@@ -138,14 +211,21 @@ class Population:
         return bool(self.candidacies.get(name))
 
 
-def banded_scores(raw: typing.Mapping[str, float]) -> dict[str, int]:
-    """Put a model's raw output on the shared 1-5 scale.
+def banded_scores(
+    raw: typing.Mapping[str, float], span: ScoreRange = FULL_RANGE
+) -> dict[str, int]:
+    """Put a model's raw output on the shared 1-5 scale, inside its own range.
 
     By rank, so the shape of the raw distribution does not matter: PageRank
     masses are a power law and co-appointment counts are small integers with
     ties everywhere, and both need to come out as a usable shortlist. People
     scoring zero or less are dropped rather than banded - a model saying
     nothing about somebody is not a vote.
+
+    The rank band is then folded onto `span`, which is how a model that ranks
+    its own people perfectly well but is wrong about most of them stops
+    outranking one that is right. Ranking and being right are separate
+    questions and only the first is knowable without a reader.
     """
     series = pd.Series(raw, dtype="float64")
     positive = series[series > 0]
@@ -160,7 +240,7 @@ def banded_scores(raw: typing.Mapping[str, float]) -> dict[str, int]:
                 return points
         return 1
 
-    return {str(name): band(value) for name, value in percentile.items()}
+    return {str(name): span.rescale(band(value)) for name, value in percentile.items()}
 
 
 class PeopleScoreModel(Pipeline):
@@ -174,6 +254,12 @@ class PeopleScoreModel(Pipeline):
     #: "pipeline" reads as non-human to the frontend; the tag after it is what
     #: tells two models apart in `stats.votes.models`.
     model_tag: str = "pipeline"
+
+    #: How much of the 1-5 axis this model has earned, measured against what
+    #: readers said about the people it named. A model nobody has checked yet
+    #: keeps the whole axis - the range is a record of a measurement, not a
+    #: guess, and guessing one would be worse than leaving it alone.
+    score_range: ScoreRange = FULL_RANGE
 
     people_payloads: PeoplePayloads
     people_koryta: KorytaPeople
@@ -200,7 +286,8 @@ class PeopleScoreModel(Pipeline):
         raw = self.raw_scores(ctx, population)
         eligible = set(population.shortlist)
         banded = banded_scores(
-            {name: score for name, score in raw.items() if name in eligible}
+            {name: score for name, score in raw.items() if name in eligible},
+            self.score_range,
         )
 
         records = [

--- a/data/pipelines/src/analysis/scores/capture.py
+++ b/data/pipelines/src/analysis/scores/capture.py
@@ -19,7 +19,7 @@ Small boards need a brake, because two people of whom one is a candidate is
 the company scores have used all along.
 """
 
-from analysis.scores.base import PeopleScoreModel, Population
+from analysis.scores.base import FULL_RANGE, PeopleScoreModel, Population
 from scrapers.stores import Context
 
 #: Added to the denominator so a tiny board cannot reach a high share. With a
@@ -46,6 +46,12 @@ def political_weight(population: Population, name: str) -> float:
 class PeopleScoresCapture(PeopleScoreModel):
     filename = "people_scores_capture"
     model_tag = "pipeline-capture"
+
+    #: The whole axis, on the same evidence as `PeopleScores`: of 130 people it
+    #: had named 65 % were called interesting, which is the base rate, but its
+    #: bands separate - 1-2 scored 56 % and 3-5 scored 80 % (p = 0.008). It
+    #: casts the widest net here, 550 people at 3 or above, and it orders them.
+    score_range = FULL_RANGE
 
     def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
         rosters = {

--- a/data/pipelines/src/analysis/scores/coappointment.py
+++ b/data/pipelines/src/analysis/scores/coappointment.py
@@ -16,7 +16,7 @@ they travel with rather than the number of doors they have been through.
 
 import collections
 
-from analysis.scores.base import PeopleScoreModel, Population
+from analysis.scores.base import PeopleScoreModel, Population, ScoreRange
 from scrapers.stores import Context
 
 #: How many separate companies two people have to have shared before the
@@ -44,6 +44,21 @@ def shared_company_counts(
 class PeopleScoresCoappointment(PeopleScoreModel):
     filename = "people_scores_coappointment"
     model_tag = "pipeline-together"
+
+    #: Capped below the queue threshold, so this model can no longer put
+    #: anybody in front of a reader by itself. It is the only one measured
+    #: whose people did *worse* than the pool they were drawn from: of 51 it
+    #: had named, 51 % were called interesting against a base rate of 65 %
+    #: (p = 0.009), and 49 % were a wasted click against 35 %. Its bands run
+    #: the wrong way too - saying 3-5 scored 41 %, saying 1-2 scored 56 %.
+    #:
+    #: The likely cause is the one `CompanyScores` already carries a TODO
+    #: about: the population is keyed by name, so two people who share one
+    #: merge into a person holding both their posts, and "shares two employers
+    #: with somebody confirmed" is exactly the claim a merge like that
+    #: manufactures. Worth re-measuring against ids, not deleting - the
+    #: reasoning is sound and the input may not be.
+    score_range = ScoreRange(ceiling=2)
 
     def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
         rosters = {

--- a/data/pipelines/src/analysis/scores/company.py
+++ b/data/pipelines/src/analysis/scores/company.py
@@ -19,7 +19,12 @@ import dataclasses
 import pandas as pd
 
 from analysis.payloads.person import PeoplePayloads
-from analysis.scores.base import IS_PUBLIC_SCORE, PeopleScoreModel, Population
+from analysis.scores.base import (
+    FULL_RANGE,
+    IS_PUBLIC_SCORE,
+    PeopleScoreModel,
+    Population,
+)
 from analysis.utils import as_sequence
 from scrapers.koryta.download import KorytaPeople, KorytaVotes
 from scrapers.stores import Context, Pipeline
@@ -154,6 +159,15 @@ class PeopleScores(PeopleScoreModel):
 
     filename = "people_scores"
     model_tag = "pipeline"
+
+    #: The whole 1-5 axis, which this model is the clearest case for having
+    #: earned - by ordering rather than by picking. Of 124 people it had named,
+    #: 65 % were called interesting, which is the base rate, so being on its
+    #: list means nothing on its own. Its bands separate sharply though: 1-2
+    #: scored 54 % and 3-5 scored 88 % (p = 0.0002), the widest split measured.
+    #: Whatever a person's employers' ratings are worth, they are worth it in
+    #: order.
+    score_range = FULL_RANGE
 
     company_scores: CompanyScores
 

--- a/data/pipelines/src/analysis/scores/pagerank.py
+++ b/data/pipelines/src/analysis/scores/pagerank.py
@@ -24,7 +24,12 @@ that cancels out.
 
 import networkx as nx
 
-from analysis.scores.base import PeopleScoreModel, Population
+from analysis.scores.base import (
+    QUEUE_THRESHOLD,
+    PeopleScoreModel,
+    Population,
+    ScoreRange,
+)
 from scrapers.stores import Context
 
 #: Teleport probability is 1 - alpha. The usual 0.85 lets a walk run about six
@@ -125,6 +130,16 @@ def walk_from(graph: nx.DiGraph, seeds: dict[str, float]) -> dict[str, float]:
 class PeopleScoresPageRank(PeopleScoreModel):
     filename = "people_scores_pagerank"
     model_tag = "pipeline-pagerank"
+
+    #: Capped at the queue threshold: this model may still nominate somebody,
+    #: but it can no longer outrank one whose bands mean something. Of 120
+    #: people it had named, 66 % were called interesting - the base rate, so
+    #: being on its list says nothing either way (p = 0.75). Nor does the band:
+    #: 1-2 scored 64 % and 3-5 scored 68 % (p = 0.70), which is about what a
+    #: random walk over a graph everybody in local government is connected in
+    #: should be expected to produce. Its 490 people at 3 or above were a third
+    #: of the queue and 169 of them were there for no other reason.
+    score_range = ScoreRange(ceiling=QUEUE_THRESHOLD)
 
     def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
         graph = build_graph(population)

--- a/data/pipelines/src/analysis/scores/succession.py
+++ b/data/pipelines/src/analysis/scores/succession.py
@@ -38,7 +38,12 @@ share a company with somebody party-affiliated but did not take over from them:
 import collections
 import datetime
 
-from analysis.scores.base import Employment, PeopleScoreModel, Population
+from analysis.scores.base import (
+    FULL_RANGE,
+    Employment,
+    PeopleScoreModel,
+    Population,
+)
 from scrapers.stores import Context
 
 #: How long a seat may stand empty and the next holder still count as having
@@ -184,6 +189,14 @@ def successions(
 class PeopleScoresSuccession(PeopleScoreModel):
     filename = "people_scores_succession"
     model_tag = "pipeline-succession"
+
+    #: The whole axis, because nothing else can be said yet: this model has
+    #: never had a run uploaded, so no reader has judged anybody it named and
+    #: there is nothing to narrow its range on. Narrowing it on the strength of
+    #: how the sibling models did would be guessing. Re-run
+    #: `scripts/score_model_accuracy.py` once its votes have been on the site
+    #: long enough for a few dozen people to have been looked at.
+    score_range = FULL_RANGE
 
     @staticmethod
     def predecessor_weight(

--- a/data/pipelines/src/analysis/scores/turnover.py
+++ b/data/pipelines/src/analysis/scores/turnover.py
@@ -18,7 +18,12 @@ so it adds a point rather than deciding the question. An appointment that
 clears all three is worth four times one that only happened to be well timed.
 """
 
-from analysis.scores.base import PeopleScoreModel, Population
+from analysis.scores.base import (
+    QUEUE_THRESHOLD,
+    PeopleScoreModel,
+    Population,
+    ScoreRange,
+)
 from scrapers.stores import Context
 
 #: How many years after an election an appointment still counts as following
@@ -62,6 +67,19 @@ def same_region(candidacy_teryt: str | None, company_teryt: str | None) -> bool:
 class PeopleScoresTurnover(PeopleScoreModel):
     filename = "people_scores_turnover"
     model_tag = "pipeline-turnover"
+
+    #: Floored at the queue threshold, because the finding this model has to
+    #: report is *that* the pattern is there rather than how strongly. Of the
+    #: 43 people it had named whom a reader then judged, 88 % were called
+    #: interesting against a base rate of 65 % (p = 0.0001), and 12 % were a
+    #: wasted click against 35 % - the best of any model measured. Its own
+    #: ordering carries none of that: saying 1-2 scored 87 % and saying 3-5
+    #: scored 90 %, and three quarters of the people it names sit in one tie at
+    #: the bottom anyway, because most appointments clear `TIMING_POINTS` and
+    #: nothing else. So the floor is the finding and the ceiling is a courtesy.
+    #: This is also the widest bet here: it moves ~930 people into the queue on
+    #: a bottom band measured over 20 of them.
+    score_range = ScoreRange(floor=QUEUE_THRESHOLD, ceiling=5)
 
     def raw_scores(self, ctx: Context, population: Population) -> dict[str, float]:
         scores: dict[str, float] = {}

--- a/data/pipelines/src/analysis/tests/test_scores.py
+++ b/data/pipelines/src/analysis/tests/test_scores.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from analysis.scores import (
+    PEOPLE_SCORE_MODELS,
     CompanyScores,
     PeopleScoresCapture,
     PeopleScoresCoappointment,
@@ -14,11 +15,14 @@ from analysis.scores import (
     PeopleScoresTurnover,
 )
 from analysis.scores.base import (
+    FULL_RANGE,
+    QUEUE_THRESHOLD,
     Candidacy,
     CompanyFacts,
     Employment,
     PeopleScoreModel,
     Population,
+    ScoreRange,
     banded_scores,
 )
 from analysis.scores.succession import as_date, successions
@@ -93,6 +97,66 @@ class TestBandedScores:
 
     def test_a_lone_score_lands_in_the_top_band(self):
         assert banded_scores({"a": 0.001}) == {"a": 5}
+
+    def test_a_range_folds_the_bands_onto_itself(self):
+        raw = {f"p{i}": float(i) for i in range(1, 101)}
+
+        capped = banded_scores(raw, ScoreRange(ceiling=3))
+
+        assert max(capped.values()) == 3
+        assert min(capped.values()) == 1
+        # Still ordered: a capped model ranks its own people as before, it just
+        # cannot outrank a model that has earned the top of the scale.
+        assert capped["p100"] >= capped["p90"] >= capped["p1"]
+
+    def test_a_floor_puts_everybody_the_model_named_in_the_queue(self):
+        raw = {f"p{i}": float(i) for i in range(1, 101)}
+
+        floored = banded_scores(raw, ScoreRange(floor=QUEUE_THRESHOLD))
+
+        assert min(floored.values()) == QUEUE_THRESHOLD
+        assert max(floored.values()) == 5
+
+    def test_a_narrow_range_still_reaches_its_ceiling(self):
+        # Rounding down at the halves would leave a 1-2 model unable to say 2
+        # for anybody but the very top percentile, which is not a model.
+        raw = {f"p{i}": float(i) for i in range(1, 101)}
+
+        assert set(banded_scores(raw, ScoreRange(ceiling=2)).values()) == {1, 2}
+
+    def test_the_default_range_changes_nothing(self):
+        raw = {f"p{i}": float(i) for i in range(1, 101)}
+
+        assert banded_scores(raw, FULL_RANGE) == banded_scores(raw)
+
+    def test_a_range_outside_the_scale_is_refused(self):
+        with pytest.raises(ValueError):
+            ScoreRange(floor=4, ceiling=2)
+        with pytest.raises(ValueError):
+            ScoreRange(ceiling=6)
+
+
+class TestScoreRanges:
+    """What each model is allowed to say, and why it is written down at all."""
+
+    def test_every_model_states_a_range(self):
+        for model_type in PEOPLE_SCORE_MODELS:
+            assert isinstance(model_type.score_range, ScoreRange), model_type
+
+    def test_the_measured_models_carry_their_verdict(self):
+        # The three the 2026-08 measurement moved, pinned so that changing any
+        # of them is a change somebody had to write down rather than a constant
+        # that drifted. The numbers behind them are in `analysis.scores.base`.
+        assert PeopleScoresTurnover.score_range == ScoreRange(
+            floor=QUEUE_THRESHOLD, ceiling=5
+        )
+        assert PeopleScoresPageRank.score_range == ScoreRange(ceiling=QUEUE_THRESHOLD)
+        assert PeopleScoresCoappointment.score_range == ScoreRange(ceiling=2)
+
+    def test_a_capped_model_cannot_reach_the_queue_on_its_own(self):
+        # The whole point of the cap: `together` may still colour somebody the
+        # other models found, but it can no longer put one in front of a reader.
+        assert PeopleScoresCoappointment.score_range.ceiling < QUEUE_THRESHOLD
 
 
 class TestPopulation:

--- a/data/pipelines/src/scripts/score_model_accuracy.py
+++ b/data/pipelines/src/scripts/score_model_accuracy.py
@@ -1,0 +1,369 @@
+"""Which scoring model is worth a reader's time, measured against their votes.
+
+Every model in `analysis.scores` writes its verdict to the site as a vote under
+its own `pipeline-*` uid, and the site shows a person whose best model score
+reaches `QUEUE_THRESHOLD`. Nothing in that loop ever asked whether a model is
+right. This does, by reading the one label the site produces: a reader opens
+somebody, looks them up, and votes -5..+5 on whether they were worth it.
+
+The join is the awkward part, because a model's vote does not survive being
+answered. `Firestore.replace_scores` retracts the score of anybody who has left
+the shortlist, and a human vote is exactly what takes somebody off it - so by
+the time a verdict exists, the score that caused it has been deleted. The
+nightly Firestore export to GCS is what makes the pairing possible at all:
+every snapshot holds the scores standing that morning, and a human vote carries
+`updatedAt`, so the score a reader actually saw is the one in the newest
+snapshot before their vote.
+
+That gives two populations, and they answer different questions:
+
+*   **queue** - a score was standing when the reader voted. This is production
+    behaviour, and it is selection-biased on purpose: these are the people the
+    queue put in front of somebody, which is the thing being judged.
+*   **blind** - no score was standing, and the models scored the person in the
+    very next run. The reader cannot have been influenced by a score that did
+    not exist, and the model cannot have been seeded on a vote its input export
+    predated, so this is the closest thing to a controlled test the site
+    produces. It exists because ingest and review run at different speeds
+    rather than because anybody arranged it, and it is small.
+
+A model is reported on both, and a claim that holds on only one of them is a
+claim about the queue rather than about the model.
+
+    uv run python src/scripts/score_model_accuracy.py
+    uv run python src/scripts/score_model_accuracy.py --since 2026-08-08
+    uv run python src/scripts/score_model_accuracy.py --csv rows.csv
+"""
+
+import argparse
+import collections
+import dataclasses
+import typing
+
+import pandas as pd
+from leveldb_export import parse_leveldb_documents  # type: ignore
+
+from analysis.scores import PEOPLE_SCORE_MODELS, QUEUE_THRESHOLD
+from conductor import setup_context
+from entities.person import is_pipeline_uid
+from scrapers.koryta.download import export_timestamp
+from scrapers.stores import CloudStorage, Context
+from scrapers.stores.file import DownloadableFile
+
+#: The day the models beyond the original `pipeline` uid first appear in an
+#: export. Anything earlier can only measure one of them, so the default run
+#: starts here rather than pretending the older snapshots say something about
+#: `pipeline-capture`.
+MULTI_MODEL_ERA = "2026-08-08"
+
+#: What counts as the reader having been glad they looked. +1 is "ciekawe" and
+#: +3 is "koryciarz" - see `scaleLabels` in frontend/app/composables/votes.ts,
+#: which is the ladder the numbers on the site mean.
+INTERESTING = 1
+STRONG = 3
+
+#: And what counts as the click having been wasted. -1 is "nie moge znalezc
+#: informacji", the commonest negative by a distance: the reader went looking
+#: and there was nothing there.
+WASTED = -1
+
+
+@dataclasses.dataclass
+class Verdict:
+    """One person, what a reader said about them, and what the models had said.
+
+    `scores` holds only the models that had an opinion; a model absent from it
+    said nothing about this person, which is different from having said 1.
+    """
+
+    node_id: str
+    name: str
+    verdict: int
+    population: str
+    scores: dict[str, int]
+
+
+def vote_blobs(ctx: Context, since: str) -> dict[str, list[DownloadableFile]]:
+    """The votes half of every export from `since` on, grouped by export.
+
+    Listed a day at a time. `FirestoreCollection` lists the whole
+    `hostname=koryta.pl` prefix per call, which is fine when a run reads one
+    export and hopeless when it reads forty: the bucket holds two exports a day
+    of eight collections going back to December, and listing all of that takes
+    longer than everything else here put together. A day's prefix is a few
+    thousand objects, and the `date=` namespace is an ISO timestamp, so the day
+    is a prefix of it.
+    """
+    grouped: dict[str, list[DownloadableFile]] = collections.defaultdict(list)
+    today = pd.Timestamp.now(tz="UTC").date()
+    for day in pd.date_range(since, today, freq="D"):
+        prefix = f"hostname=koryta.pl/date={day.date().isoformat()}"
+        for blob in ctx.io.list_files(CloudStorage(prefix=prefix, binary=True)):
+            assert isinstance(blob, DownloadableFile)
+            if "output" not in blob.filename or "votes" not in blob.filename:
+                continue
+            stamp = export_timestamp(blob)
+            if stamp:
+                grouped[stamp].append(blob)
+    return dict(sorted(grouped.items()))
+
+
+def read_export(ctx: Context, blobs: list[DownloadableFile]) -> list[dict]:
+    """The vote documents in one export, as plain dicts.
+
+    Only votes on a node: a vote carrying `extractionId` instead is somebody
+    rating an extracted fact, which no scoring model has an opinion about.
+    """
+    rows = []
+    for blob in blobs:
+        for doc in parse_leveldb_documents(ctx.io.read_data(blob).read_file()):
+            categories = doc.get("categoryVotes")
+            node_id = doc.get("nodeId")
+            if not isinstance(categories, dict) or not node_id:
+                continue
+            rows.append(
+                {
+                    "node_id": str(node_id),
+                    "uid": str(doc.get("userUid")),
+                    "interesting": categories.get("interesting"),
+                    "updated_at": doc.get("updatedAt"),
+                }
+            )
+    return rows
+
+
+def panel(ctx: Context, since: str) -> pd.DataFrame:
+    """One row per (export, vote) for every export on or after `since`.
+
+    A pipeline vote carries no timestamp of its own - the model rewrites the
+    document rather than dating it - so which snapshot it appears in is the
+    only clock it has, and reading the exports is the only way to get one.
+    """
+    frames = []
+    exports = vote_blobs(ctx, since)
+    print(f"Reading {len(exports)} votes exports since {since}")
+    for stamp, blobs in exports.items():
+        frame = pd.DataFrame.from_records(read_export(ctx, blobs))
+        frame["snapshot"] = pd.Timestamp(stamp)
+        frames.append(frame)
+    if not frames:
+        raise SystemExit(f"No votes exports on or after {since}")
+    return pd.concat(frames, ignore_index=True)
+
+
+def people(ctx: Context) -> dict[str, str]:
+    """Node id -> name, for people only.
+
+    A vote can name a place or an article, and no scoring model has ever had an
+    opinion about either, so counting those would dilute every rate here with
+    rows no model could have got right or wrong.
+    """
+    from scrapers.koryta.download import FirestoreCollection  # noqa: PLC0415
+
+    nodes, date = FirestoreCollection.latest_on_or_before(ctx, "nodes", "person")
+    print(f"Read {len(nodes)} people from the {date} export")
+    return dict(zip(nodes["id"].astype(str), nodes.get("name", nodes["id"])))
+
+
+def verdicts(frame: pd.DataFrame, names: dict[str, str]) -> list[Verdict]:
+    """Pair every human vote with the model scores it was cast against.
+
+    The pairing is per snapshot rather than per person, because a person can be
+    scored, retracted and scored again, and only the score standing at the
+    moment of the vote is the one the reader was answering.
+    """
+    frame = frame.copy()
+    frame["is_pipeline"] = frame["uid"].map(is_pipeline_uid)
+    frame["voted_at"] = pd.to_datetime(
+        frame["updated_at"], format="ISO8601", utc=True, errors="coerce"
+    )
+    snapshots = pd.DatetimeIndex(sorted(frame["snapshot"].unique()))
+
+    scores = (
+        frame[frame["is_pipeline"]]
+        .pivot_table(
+            index=["node_id", "snapshot"],
+            columns="uid",
+            values="interesting",
+            aggfunc="max",
+        )
+        .to_dict(orient="index")
+    )
+
+    human = frame[~frame["is_pipeline"] & frame["voted_at"].notna()]
+    # The export repeats every vote every night, and a reader may revise one.
+    # The last snapshot's version of it is the verdict that stands.
+    human = (
+        human.sort_values("snapshot").groupby(["node_id", "uid"], as_index=False).last()
+    )
+
+    out: list[Verdict] = []
+    for row in human.itertuples():
+        node_id = str(row.node_id)
+        if node_id not in names or pd.isna(row.interesting):
+            continue
+        before = int(snapshots.searchsorted(row.voted_at, side="left")) - 1
+        if before < 0:
+            # Voted on before the first export read, so nothing can be said
+            # about what the models had on them at the time.
+            continue
+
+        standing = _clean(scores.get((node_id, snapshots[before])))
+        if standing:
+            population = "queue"
+        elif before + 1 < len(snapshots):
+            standing = _clean(scores.get((node_id, snapshots[before + 1])))
+            population = "blind"
+        else:
+            continue
+        if not standing:
+            continue
+        out.append(
+            Verdict(
+                node_id=node_id,
+                name=names[node_id],
+                verdict=int(typing.cast(int, row.interesting)),
+                population=population,
+                scores=standing,
+            )
+        )
+    return out
+
+
+def _clean(scores: dict | None) -> dict[str, int]:
+    """A snapshot's score row with the models that said nothing dropped."""
+    if not scores:
+        return {}
+    return {uid: int(v) for uid, v in scores.items() if pd.notna(v)}
+
+
+def as_frame(found: list[Verdict]) -> pd.DataFrame:
+    """The verdicts as a table, one column per model, NaN where it was silent."""
+    rows = []
+    for verdict in found:
+        row = {
+            "node_id": verdict.node_id,
+            "name": verdict.name,
+            "verdict": verdict.verdict,
+            "population": verdict.population,
+        }
+        row.update(verdict.scores)
+        rows.append(row)
+    return pd.DataFrame.from_records(rows)
+
+
+def model_columns(frame: pd.DataFrame) -> list[str]:
+    """The model columns present, known models first and in run order.
+
+    A uid nobody in this repo writes still gets reported - the site has carried
+    at least one model run from outside it - because leaving it out would make
+    the base rate include the people it nominated while crediting them to
+    nobody.
+    """
+    known = [m.model_tag for m in PEOPLE_SCORE_MODELS if m.model_tag in frame]
+    return known + sorted(
+        c for c in frame.columns if is_pipeline_uid(c) and c not in known
+    )
+
+
+def report(frame: pd.DataFrame) -> None:
+    verdict = frame["verdict"]
+    models = model_columns(frame)
+    print(
+        f"\n{len(frame)} people judged by a reader "
+        f"({(frame.population == 'queue').sum()} with a score standing, "
+        f"{(frame.population == 'blind').sum()} blind)"
+    )
+    print(
+        f"Base rate: {(verdict >= INTERESTING).mean():.0%} called interesting, "
+        f"{(verdict <= WASTED).mean():.0%} a wasted click\n"
+    )
+
+    rows = []
+    for uid in models:
+        named = frame[frame[uid].notna()]
+        if named.empty:
+            continue
+        low = named[named[uid] < QUEUE_THRESHOLD]
+        high = named[named[uid] >= QUEUE_THRESHOLD]
+        rows.append(
+            {
+                "model": uid,
+                "n": len(named),
+                "interesting": (named.verdict >= INTERESTING).mean(),
+                "strong": (named.verdict >= STRONG).mean(),
+                "wasted": (named.verdict <= WASTED).mean(),
+                "mean": named.verdict.mean(),
+                f"band<{QUEUE_THRESHOLD}": (low.verdict >= INTERESTING).mean()
+                if len(low)
+                else float("nan"),
+                f"band>={QUEUE_THRESHOLD}": (high.verdict >= INTERESTING).mean()
+                if len(high)
+                else float("nan"),
+            }
+        )
+    table = pd.DataFrame(rows).sort_values("mean", ascending=False)
+    print(table.to_string(index=False, float_format=lambda v: f"{v:.2f}"))
+    print(
+        "\n`interesting` is the share of the people a model named whom the reader "
+        "rated +1 or better; compare it against the base rate above, not against "
+        f"50%. The two band columns are that same share for the model saying less "
+        f"than {QUEUE_THRESHOLD} against it saying {QUEUE_THRESHOLD} or more, "
+        "which is whether its own ordering means anything."
+    )
+
+    for population in ("queue", "blind"):
+        part = frame[frame.population == population]
+        if part.empty:
+            continue
+        print(
+            f"\n-- {population} only (n={len(part)}, "
+            f"base {(part.verdict >= INTERESTING).mean():.0%}) --"
+        )
+        for uid in models:
+            named = part[part[uid].notna()]
+            if len(named) < 5:
+                continue
+            print(
+                f"   {uid:24s} n={len(named):4d}  "
+                f"interesting {(named.verdict >= INTERESTING).mean():.0%}  "
+                f"mean {named.verdict.mean():+.2f}"
+            )
+
+    print("\n-- per band --")
+    for uid in models:
+        named = frame[frame[uid].notna()]
+        if len(named) < 10:
+            continue
+        grouped = named.groupby(uid).agg(
+            n=("verdict", "size"),
+            interesting=("verdict", lambda s: (s >= INTERESTING).mean()),
+            wasted=("verdict", lambda s: (s <= WASTED).mean()),
+            mean=("verdict", "mean"),
+        )
+        print(f"\n   {uid}")
+        print(grouped.to_string(float_format=lambda v: f"{v:.2f}"))
+
+
+def main(argv: typing.Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since",
+        default=MULTI_MODEL_ERA,
+        help="Read exports from this date on (default: when the models went live)",
+    )
+    parser.add_argument("--csv", help="Write the paired rows here as well")
+    args = parser.parse_args(argv)
+
+    ctx, _ = setup_context()
+    frame = as_frame(verdicts(panel(ctx, args.since), people(ctx)))
+    if frame.empty:
+        raise SystemExit("No reader has judged anybody a model had scored yet")
+    report(frame)
+    if args.csv:
+        frame.to_csv(args.csv, index=False)
+        print(f"\nWrote {len(frame)} rows to {args.csv}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The site takes the highest score any model gave a person and shows them at three or more, which only works if a 5 means the same thing whoever said it. Nobody had checked. scripts/score_model_accuracy.py checks it, by pairing every human vote since the models went live on 2026-08-08 with the scores standing on that person in the export just before the vote - the pairing the retraction in replace_scores would otherwise destroy.

Over 132 people, against a base rate of 65% called interesting: turnover 88% (p = 0.0001), pagerank 66%, company 65%, capture 65%, together 51% (p = 0.009, significantly worse than the pool it draws from). Only company and capture order their own people - their 3-5 beats their 1-2 at p = 0.0002 and p = 0.008
- while pagerank's and together's bands separate nothing.

So ScoreRange bounds each model to what it has earned: together to 1-2, which puts it under the queue threshold, pagerank to 1-3, turnover floored at 3, and company and capture keep the full axis. Projected against the current run that moves the queue from 1,178 people to 1,570 and its expected yield from 67% to 79%.

Nothing on the site changes - it still takes the maximum.