### PR TITLE
Count untriaged corrections and reported gaps as notes needing action

### DIFF
--- a/frontend/app/pages/admin/index.vue
+++ b/frontend/app/pages/admin/index.vue
@@ -150,7 +150,8 @@
 
           <v-card-text>
             <div class="text-caption text-medium-emphasis mb-2">
-              Źródła oznaczone jako „Nierozwiązane”.
+              Zgłoszone poprawki i braki oraz wpisy oznaczone jako
+              „Nierozwiązane”.
             </div>
 
             <template v-if="pending">
@@ -175,8 +176,18 @@
                   lines="two"
                 >
                   <template #append>
+                    <!-- An untriaged correction has no type yet, and it is
+                         what it is on the list for, so its kind stands in. -->
                     <v-chip v-if="item.adminType" size="x-small" label>
                       {{ noteAdminTypeLabel(item.adminType) }}
+                    </v-chip>
+                    <v-chip
+                      v-else
+                      size="x-small"
+                      label
+                      :color="noteKindConfig[item.kind].color"
+                    >
+                      {{ noteKindConfig[item.kind].title }}
                     </v-chip>
                   </template>
                 </v-list-item>
@@ -193,10 +204,15 @@
           </v-card-text>
 
           <v-card-actions>
+            <!-- Filtered to the same set the number above counts, so the
+                 page it opens is the list it promised. -->
             <v-btn
               variant="text"
               color="primary"
-              to="/admin/notatki"
+              :to="{
+                path: '/admin/notatki',
+                query: { status: 'needs_action' },
+              }"
               :append-icon="mdiChevronRight"
             >
               Przejdź do notatek
@@ -363,7 +379,7 @@ import {
   mdiMessageAlertOutline,
 } from "@mdi/js";
 import { authRequest } from "~/composables/auth";
-import { noteAdminTypeLabel } from "~/composables/notes";
+import { noteAdminTypeLabel, noteKindConfig } from "~/composables/notes";
 import type { AdminSummary } from "~~/server/api/admin/summary.get";
 import type { ActivityStats } from "~~/server/api/stats/activity.get";
 

--- a/frontend/app/pages/admin/notatki/index.vue
+++ b/frontend/app/pages/admin/notatki/index.vue
@@ -367,6 +367,9 @@ const kindFilterOptions = Object.entries(noteKindConfig).map(
 );
 
 const statusFilterOptions = [
+  // Not a stored status but the one the dashboard counts, so the number on it
+  // has a page that shows exactly those rows.
+  { title: "Wymagające działania", value: "needs_action" },
   { title: "Bez statusu", value: "none" },
   { title: "Nierozwiązane", value: "unresolved" },
   { title: "Rozwiązane", value: "resolved" },

--- a/frontend/server/api/admin/summary.get.ts
+++ b/frontend/server/api/admin/summary.get.ts
@@ -2,6 +2,7 @@ import { getFirestore, FieldPath } from "firebase-admin/firestore";
 import type { Firestore } from "firebase-admin/firestore";
 import { defineEventHandler } from "h3";
 import { getUser } from "~~/server/utils/auth";
+import { noteNeedsAction } from "~~/shared/model";
 import type {
   Feedback,
   FeedbackKind,
@@ -29,7 +30,8 @@ export type AdminSummary = {
     }[];
   };
   notes: {
-    // Sources an admin has explicitly flagged as unresolved.
+    // Entries waiting on an admin: the ones flagged unresolved by hand, plus
+    // every correction nobody has settled yet. See `noteNeedsAction`.
     needsAction: number;
     // Sources nobody has given a type yet, minus the ones a reviewer handed
     // back to the table view - i.e. the length of the phone queue at
@@ -86,7 +88,7 @@ export default defineEventHandler(async (event): Promise<AdminSummary> => {
 
   // --- Notes needing action -------------------------------------------------
   // Firestore can't query into an array of source objects, so read the notes
-  // (only the fields we need) and count sources flagged unresolved.
+  // (only the fields we need) and count the entries waiting on somebody.
   const notesSnap = await db
     .collection("notes")
     .select("sources", "nodeId")
@@ -107,7 +109,7 @@ export default defineEventHandler(async (event): Promise<AdminSummary> => {
     const data = doc.data() as Note;
     for (const source of data.sources || []) {
       if (!source.adminType && !source.adminTypeDeferred) uncategorized++;
-      if (source.adminStatus === "unresolved") {
+      if (noteNeedsAction(source)) {
         needsAction++;
         if (noteSampleRaw.length < SAMPLE_SIZE) {
           noteSampleRaw.push({

--- a/frontend/server/api/notes/admin.get.ts
+++ b/frontend/server/api/notes/admin.get.ts
@@ -3,7 +3,7 @@ import { getFirestore } from "firebase-admin/firestore";
 import { defineEventHandler, getValidatedQuery } from "h3";
 import { getUser } from "~~/server/utils/auth";
 import { getNoteRows } from "~~/server/utils/notes";
-import { nodeTypes } from "~~/shared/model";
+import { nodeTypes, noteNeedsAction } from "~~/shared/model";
 import type { NoteRow } from "~~/shared/model";
 
 const queryValidator = z.object({
@@ -11,8 +11,10 @@ const queryValidator = z.object({
   page: z.coerce.number().int().min(1).default(1),
 
   kind: z.enum(["source", "change_request", "missing"]).optional(),
-  /** "none" selects the entries nobody has triaged yet. */
-  status: z.enum(["resolved", "unresolved", "none"]).optional(),
+  /** "none" selects the entries nobody has triaged yet; "needs_action" the
+   * ones the dashboard counts as waiting on somebody, which is a status of its
+   * own rather than a stored one - see `noteNeedsAction`. */
+  status: z.enum(["resolved", "unresolved", "none", "needs_action"]).optional(),
   /** A stored type, or "none" for the entries nobody has classified - which is
    * the queue /admin/notatki/kategoryzacja works through. */
   adminType: z.string().min(1).optional(),
@@ -65,10 +67,12 @@ export default defineEventHandler(async (event) => {
   const needle = query.q?.toLowerCase();
   const matching = rows.filter((row) => {
     if (query.kind && row.kind !== query.kind) return false;
+    if (query.status === "needs_action" && !noteNeedsAction(row)) return false;
     if (query.status === "none" && row.adminStatus) return false;
     if (
       query.status &&
       query.status !== "none" &&
+      query.status !== "needs_action" &&
       row.adminStatus !== query.status
     ) {
       return false;

--- a/frontend/shared/model.ts
+++ b/frontend/shared/model.ts
@@ -501,6 +501,26 @@ export type NoteSource = {
   adminTypeDeferred?: boolean;
 };
 
+/** Whether an entry is still waiting on an admin, which is what the dashboard
+ * counts under "Notatki wymagające działania".
+ *
+ * Two ways in. A reviewer can flag any entry "Nierozwiązane" by hand, and a
+ * correction ("Do poprawy") or a gap somebody reported ("Brakuje danych") is
+ * one the moment it is written - its author is saying the data is wrong or
+ * absent, so it needs acting on before anybody has triaged it. A source is
+ * not: it is something to read, and only a reviewer can say it is more.
+ *
+ * Either way it is the reviewer marking it "Rozwiązane" that takes it off the
+ * list; an explicit status always wins over the kind.
+ */
+export function noteNeedsAction(entry: {
+  kind?: NoteEntryKind | null;
+  adminStatus?: NoteAdminStatus | null;
+}): boolean {
+  if (entry.adminStatus) return entry.adminStatus === "unresolved";
+  return (entry.kind ?? "source") !== "source";
+}
+
 /** Note allows users to collaborate on a node content without accessing the node itself.
  * A node can have multiple notes but one per user.
  * User can view/edit their own note and admins can view all notes.

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,29 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "notatki-do-poprawy-wymagaja-dzialania",
+    title: "Zgłoszone poprawki i braki od razu trafiają na listę do zrobienia",
+    description:
+      "Notatka dodana jako „Do poprawy” albo „Brakuje danych” od razu liczy " +
+      "się jako wymagająca działania w panelu admina - wcześniej pojawiała " +
+      "się tam dopiero, gdy ktoś ręcznie oznaczył ją jako „Nierozwiązaną”, " +
+      "więc zgłoszenia czytelników przepadały. Same źródła nadal wchodzą na " +
+      "tę listę tylko z ręki admina, a oznaczenie „Rozwiązane” zdejmuje z " +
+      "niej każdy wpis.",
+    steps: [
+      "Na dowolnej stronie osoby lub instytucji dodaj notatkę przyciskiem " +
+        "„Zgłoś poprawkę” (albo „Zgłoś brak”) i zapisz ją.",
+      "Wejdź na /admin - kafelek „Notatki wymagające działania” liczy nowe " +
+        "zgłoszenie i pokazuje je na liście z chipem „Do poprawy”.",
+      "Kliknij „Przejdź do notatek” - tabela otwiera się z filtrem " +
+        "„Wymagające działania” i tym samym zestawem wierszy.",
+      "Ustaw status wiersza na „Rozwiązane” i odśwież /admin - zgłoszenie " +
+        "znika z kafelka.",
+    ],
+    link: "/admin",
+    area: "admin",
+  },
+  {
     id: "eksploruj-nowe-uporzadkowana-strona",
     title:
       "„Eksploruj nowe” czytelniejsze: trzy kroki i powiązania na wierzchu",

--- a/frontend/tests/server/api/admin/summary.test.ts
+++ b/frontend/tests/server/api/admin/summary.test.ts
@@ -144,6 +144,46 @@ describe("GET /api/admin/summary", () => {
     });
   });
 
+  it("counts an untriaged correction or reported gap as needing action", async () => {
+    results.notes = [
+      doc("note-1", {
+        nodeId: "node-1",
+        sources: [
+          // "Do poprawy" - somebody saying the data is wrong, which is work
+          // waiting on an admin before anybody has triaged it.
+          { note: "zła data urodzenia", kind: "change_request" },
+          // "Brakuje danych" - the same, reported as an absence rather than
+          // as a mistake.
+          { note: "brakuje zarządu", kind: "missing" },
+          // Settled, so it is off the list even though it is a correction.
+          {
+            note: "poprawione",
+            kind: "change_request",
+            adminStatus: "resolved",
+          },
+          // A source only counts once a reviewer flags it.
+          { note: "ciekawy artykuł", url: "https://example.com" },
+          { note: "do sprawdzenia", adminStatus: "unresolved" },
+        ],
+      }),
+    ];
+    results.namedNodes = [doc("node-1", { name: "Jan Kowalski" })];
+
+    const summary = await handler({} as never);
+
+    expect(summary.notes.needsAction).toBe(3);
+    expect(summary.notes.sample.map((item) => item.note)).toEqual([
+      "zła data urodzenia",
+      "brakuje zarządu",
+      "do sprawdzenia",
+    ]);
+    expect(summary.notes.sample[0]).toMatchObject({
+      name: "Jan Kowalski",
+      kind: "change_request",
+      adminType: null,
+    });
+  });
+
   it("counts unsettled edge revisions alongside unapproved nodes", async () => {
     results.unapprovedNodes = {
       count: 3,

--- a/frontend/tests/server/api/notes-admin.test.ts
+++ b/frontend/tests/server/api/notes-admin.test.ts
@@ -280,6 +280,44 @@ describe("/api/notes/admin", () => {
     expect(byAdminType.notes.map((n) => n.note)).toEqual(["załatwione"]);
   });
 
+  it("selects the entries the dashboard counts as needing action", async () => {
+    mockNotesGet.mockResolvedValue({
+      docs: [
+        noteDoc("note-1", {
+          nodeId: "node-1",
+          userUid: "user-a",
+          sources: [
+            // A correction nobody has triaged: waiting on somebody by virtue
+            // of being one. A reported gap counts the same way.
+            { note: "poprawka", kind: "change_request" },
+            { note: "brak zarządu", kind: "missing" },
+            // The same, once a reviewer has settled it.
+            {
+              note: "załatwiona poprawka",
+              kind: "change_request",
+              adminStatus: "resolved",
+            },
+            // A source is only on the list if a reviewer put it there.
+            { note: "źródło" },
+            { note: "źródło do sprawdzenia", adminStatus: "unresolved" },
+          ],
+        }),
+      ],
+    });
+    mockGetAll.mockResolvedValue([nodeDoc("node-1", "Jan Testowy", "person")]);
+
+    const needsAction = (await callHandler({
+      status: "needs_action",
+    })) as Result;
+
+    expect(needsAction.notes.map((n) => n.note)).toEqual([
+      "poprawka",
+      "brak zarządu",
+      "źródło do sprawdzenia",
+    ]);
+    expect(needsAction.total).toBe(3);
+  });
+
   it("answers a permalink with the one entry it names", async () => {
     mockNotesGet.mockResolvedValue({
       docs: [

--- a/frontend/tests/shared/model.test.ts
+++ b/frontend/tests/shared/model.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   approvedRevisionId,
+  noteNeedsAction,
   pageIsPublic,
   revisionCollection,
   revisionIsPending,
@@ -74,5 +75,31 @@ describe("approvedRevisionId", () => {
     expect(approvedRevisionId({ id: "r1" })).toBe("r1");
     expect(approvedRevisionId(undefined)).toBeUndefined();
     expect(approvedRevisionId(null)).toBeUndefined();
+  });
+});
+
+describe("noteNeedsAction", () => {
+  it("takes a correction or a reported gap as waiting on somebody the moment it is written", () => {
+    expect(noteNeedsAction({ kind: "change_request" })).toBe(true);
+    expect(noteNeedsAction({ kind: "missing" })).toBe(true);
+  });
+
+  it("leaves a source to a reviewer to flag", () => {
+    expect(noteNeedsAction({ kind: "source" })).toBe(false);
+    // Entries written before kinds existed are sources.
+    expect(noteNeedsAction({})).toBe(false);
+    expect(noteNeedsAction({ kind: null, adminStatus: null })).toBe(false);
+  });
+
+  it("lets an explicit status win over the kind, either way", () => {
+    expect(
+      noteNeedsAction({ kind: "change_request", adminStatus: "resolved" }),
+    ).toBe(false);
+    expect(noteNeedsAction({ kind: "missing", adminStatus: "resolved" })).toBe(
+      false,
+    );
+    expect(noteNeedsAction({ kind: "source", adminStatus: "unresolved" })).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
The admin dashboard's "Notatki wymagające działania" counted only entries an admin had flagged "Nierozwiązane" by hand, so a reader's "Do poprawy" or "Brakuje danych" note never reached it - the one queue that exists to catch those reports was the one place they did not appear.

noteNeedsAction decides it in a single place now: an explicit status wins, and with none, anything that is not a plain source is waiting on somebody. /api/notes/admin gains a matching status=needs_action filter, so the number on the dashboard links to a table holding exactly the rows it counts.