### PR TITLE
Give admins a view of the audit log, and a way to undo a removal

### DIFF
--- a/frontend/app/components/admin/PublishNodeDialog.vue
+++ b/frontend/app/components/admin/PublishNodeDialog.vue
@@ -117,7 +117,8 @@
 import { computed, ref, watch } from "vue";
 import { mdiEyeOffOutline } from "@mdi/js";
 import { authRequest } from "~/composables/auth";
-import { edgeTypeLabels, relationsPlural } from "~/composables/edges";
+import { relationsPlural } from "~/composables/edges";
+import { edgeTypeLabels } from "~~/shared/edges";
 import type {
   NodeRelation,
   NodeRelations,

--- a/frontend/app/components/article/CiteExistingEdgeDialog.vue
+++ b/frontend/app/components/article/CiteExistingEdgeDialog.vue
@@ -136,7 +136,7 @@ import {
 } from "@mdi/js";
 import type { Link, NodeType } from "~~/shared/model";
 import type { GraphLayout } from "~~/shared/graph/util";
-import { edgeTypeLabels } from "~/composables/edges";
+import { edgeTypeLabels } from "~~/shared/edges";
 import { authRequest } from "~/composables/auth";
 
 const props = defineProps<{

--- a/frontend/app/components/article/SourcedEdgeList.vue
+++ b/frontend/app/components/article/SourcedEdgeList.vue
@@ -76,7 +76,7 @@ import {
   mdiFileDocumentMultipleOutline,
   mdiSourceBranch,
 } from "@mdi/js";
-import { edgeTypeLabels } from "~/composables/edges";
+import { edgeTypeLabels } from "~~/shared/edges";
 import { polishCounting } from "~/composables/polish";
 import { generateEntityUrl } from "~/composables/slugs";
 import type { SourcedEdge } from "~~/server/api/edges/byReference.get";

--- a/frontend/app/components/dialog/RemoveEdge.vue
+++ b/frontend/app/components/dialog/RemoveEdge.vue
@@ -9,8 +9,10 @@
       <v-card-text class="pt-0">
         <p class="mb-4 text-body-2">
           Powiązanie zniknie ze strony i z grafu. Zostaje w bazie razem z
-          powodem, więc widać potem, kto i dlaczego je zdjął - ale nikt tej
-          decyzji nie zatwierdza po tobie i żaden ekran jej nie cofa.
+          powodem, więc widać potem, kto i dlaczego je zdjął - nikt jednak tej
+          decyzji nie zatwierdza po tobie. Cofnąć ją można w „Dzienniku
+          decyzji”, ale powiązanie wraca wtedy jako szkic i trzeba je jeszcze
+          raz opublikować.
         </p>
 
         <v-textarea

--- a/frontend/app/composables/edges.ts
+++ b/frontend/app/composables/edges.ts
@@ -1,4 +1,5 @@
 import type { Node, Edge, EdgeType, ElectionPosition } from "~~/shared/model";
+import { edgeTypeLabels } from "~~/shared/edges";
 import type { TraversePolicy } from "~~/shared/graph/model";
 
 export type EdgeNode = {
@@ -35,19 +36,6 @@ export function relationsPlural(count: number): string {
   if (units >= 2 && units <= 4 && (tens < 12 || tens > 14)) return "powiązania";
   return "powiązań";
 }
-
-/** What a relation is called on screen, when it has no name of its own. Shared
- * with the admin views, which list edges outside any graph. */
-export const edgeTypeLabels: Record<string, string> = {
-  employed: "Zatrudniony/a w",
-  owns: "Właściciel",
-  seat: "Siedziba",
-  connection: "Powiązanie z",
-  mentions: "Wspomina o",
-  comment: "Komentarz",
-  election: "Kandydował/a w",
-  tagged: "Dotyczy tematu",
-};
 
 export async function useEdges(nodeID: MaybeRefOrGetter<string | undefined>) {
   const { user } = useAuthState();

--- a/frontend/app/pages/admin/audyt.vue
+++ b/frontend/app/pages/admin/audyt.vue
@@ -1,0 +1,274 @@
+<template>
+  <div class="pa-4">
+    <div class="d-flex align-center mb-4">
+      <v-btn :icon="mdiArrowLeft" variant="text" class="mr-2" to="/admin" />
+      <div>
+        <h1 class="text-h5 text-sm-h4">Dziennik decyzji</h1>
+        <div class="text-caption text-grey-darken-1">
+          Co administratorzy zdecydowali o wpisach i powiązaniach - kto, kiedy,
+          czego to dotyczyło i dlaczego. Usunięte powiązania można stąd
+          przywrócić.
+        </div>
+      </div>
+    </div>
+
+    <v-alert
+      v-if="error"
+      type="error"
+      variant="tonal"
+      class="mb-4"
+      :text="error"
+      data-testid="audit-error"
+    />
+
+    <v-card class="mb-4 pa-3">
+      <div class="d-flex align-center flex-wrap ga-3">
+        <v-select
+          v-model="action"
+          :items="actionItems"
+          label="Rodzaj decyzji"
+          density="compact"
+          variant="outlined"
+          hide-details
+          clearable
+          style="max-width: 260px"
+          data-testid="audit-action-filter"
+          @update:model-value="load()"
+        />
+        <v-spacer />
+        <div class="text-caption text-grey-darken-1">Najnowsze na górze.</div>
+      </div>
+    </v-card>
+
+    <v-data-table
+      density="compact"
+      item-value="id"
+      :headers="headers"
+      :items="rows"
+      :loading="pending"
+      :no-data-text="noDataText"
+      loading-text="Ładowanie..."
+      items-per-page="-1"
+      data-testid="audit-table"
+    >
+      <template #[`item.at`]="{ item }">
+        <span class="text-caption">{{ formatAt(item.at) }}</span>
+      </template>
+
+      <template #[`item.user`]="{ item }">
+        <UserChip :uid="item.user" />
+      </template>
+
+      <template #[`item.action`]="{ item }">
+        <v-chip size="small" label :color="actionColor(item.action)">
+          {{ auditActionLabel(item.action, item.collection) }}
+        </v-chip>
+      </template>
+
+      <template #[`item.target`]="{ item }">
+        <div class="d-flex flex-column">
+          <nuxt-link
+            v-if="item.targetPath"
+            :to="item.targetPath"
+            class="text-decoration-none text-primary"
+          >
+            {{ item.targetName || item.target_id }}
+          </nuxt-link>
+          <span v-else>{{ item.targetName || item.target_id }}</span>
+          <span
+            v-if="item.targetDetail"
+            class="text-caption text-medium-emphasis"
+          >
+            {{ item.targetDetail }}
+          </span>
+        </div>
+      </template>
+
+      <template #[`item.reason`]="{ item }">
+        <span class="text-caption text-wrap">{{ item.reason || "-" }}</span>
+      </template>
+
+      <template #[`item.actions`]="{ item }">
+        <!-- Flat, not tonal. Tonal draws the label in the theme's pale sage on
+             a wash of the same sage, which is 1.73:1 - the combination
+             `EntityDetailView` and `card/EmploymentHistory` both call out. Flat
+             is black on sage, and this is the one control in the row. -->
+        <v-btn
+          v-if="item.restorable"
+          size="small"
+          variant="flat"
+          color="primary"
+          :prepend-icon="mdiRestore"
+          :loading="restoring === item.id"
+          :data-testid="`audit-restore-${item.id}`"
+          @click="restore(item)"
+        >
+          Przywróć
+        </v-btn>
+      </template>
+
+      <template #bottom>
+        <div class="d-flex justify-center pa-3">
+          <v-btn
+            v-if="nextCursor"
+            variant="text"
+            :loading="pending"
+            data-testid="audit-load-more"
+            @click="load(true)"
+          >
+            Wczytaj więcej
+          </v-btn>
+        </div>
+      </template>
+    </v-data-table>
+
+    <v-snackbar v-model="noticeShown" color="info" :timeout="8000">
+      {{ notice }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, onMounted } from "vue";
+import { mdiArrowLeft, mdiRestore } from "@mdi/js";
+import { authRequest } from "~/composables/auth";
+import {
+  auditActions,
+  auditActionLabel,
+  auditActionLabels,
+} from "~~/shared/audit";
+import type { AuditAction } from "~~/shared/audit";
+import type { AuditLog, AuditRow } from "~~/server/api/admin/audit.get";
+import type { EdgeRestored } from "~~/server/api/edges/restore.post";
+
+definePageMeta({
+  middleware: "admin",
+  fullWidth: true,
+});
+
+useHead({ title: "Dziennik decyzji (Admin) - koryta.pl" });
+
+const headers = [
+  { title: "Kiedy", key: "at", sortable: false, width: 150 },
+  { title: "Kto", key: "user", sortable: false, width: 200 },
+  { title: "Decyzja", key: "action", sortable: false, width: 190 },
+  { title: "Czego dotyczy", key: "target", sortable: false },
+  { title: "Powód", key: "reason", sortable: false },
+  { title: "", key: "actions", sortable: false, align: "end" as const },
+];
+
+const actionItems = auditActions.map((value) => ({
+  value,
+  title: auditActionLabels[value],
+}));
+
+const rows = ref<AuditRow[]>([]);
+const nextCursor = ref<string | null>(null);
+const action = ref<AuditAction | null>(null);
+const pending = ref(false);
+const restoring = ref<string | null>(null);
+const error = ref<string | null>(null);
+const notice = ref<string | null>(null);
+const noticeShown = ref(false);
+
+/** An empty page is not always an empty log. The action filter runs in memory
+ * over a bounded window, so a rare decision can leave a whole window with
+ * nothing in it while there is plenty further back - and "Nic tu jeszcze nie
+ * ma." next to a live "Wczytaj więcej" reads as a contradiction. */
+const noDataText = computed(() => {
+  if (nextCursor.value) {
+    return "W tej części dziennika nic nie pasuje - kliknij „Wczytaj więcej”.";
+  }
+  return action.value
+    ? "Nie ma decyzji tego rodzaju."
+    : "Nic tu jeszcze nie ma.";
+});
+
+/** Green for putting something back, red for taking it away, grey for the rest:
+ * the column is scanned rather than read, and those are the two a reader is
+ * usually looking for. */
+function actionColor(value: AuditAction): string | undefined {
+  if (value === "restore" || value === "publish") return "success";
+  if (value === "delete" || value === "reject") return "error";
+  return undefined;
+}
+
+/** `at` is ISO 8601 in UTC. Rendered in the reader's zone, because a log is
+ * read against "was I awake when this happened". */
+function formatAt(at: string): string {
+  const parsed = new Date(at);
+  if (Number.isNaN(parsed.getTime())) return at;
+  return parsed.toLocaleString("pl-PL", {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+/** @param more whether to append the next page rather than start over. */
+async function load(more = false) {
+  // The endpoint only answers a caller carrying an admin token, which the
+  // server render has no way to present - it would spend a request on a 401.
+  if (import.meta.server) return;
+
+  pending.value = true;
+  error.value = null;
+  try {
+    const data = await authRequest<AuditLog>("/api/admin/audit", {
+      method: "GET",
+      query: {
+        limit: 50,
+        ...(action.value ? { action: action.value } : {}),
+        ...(more && nextCursor.value ? { cursor: nextCursor.value } : {}),
+      },
+    });
+    // Deduplicated by id rather than concatenated: a page ends on a timestamp
+    // boundary, and the endpoint would rather serve one row twice than step
+    // over a decision taken in the same millisecond as the last one shown.
+    if (more) {
+      const seen = new Set(rows.value.map((row) => row.id));
+      rows.value = [
+        ...rows.value,
+        ...data.entries.filter((row) => !seen.has(row.id)),
+      ];
+    } else {
+      rows.value = data.entries;
+    }
+    nextCursor.value = data.nextCursor;
+  } catch (err) {
+    error.value =
+      (err as { data?: { message?: string } }).data?.message ||
+      "Nie udało się wczytać dziennika.";
+  } finally {
+    pending.value = false;
+  }
+}
+
+async function restore(row: AuditRow) {
+  restoring.value = row.id;
+  error.value = null;
+  try {
+    const result = await authRequest<EdgeRestored>("/api/edges/restore", {
+      body: { edge_id: row.target_id },
+    });
+    // The row keeps its place - it still records the removal, which happened -
+    // and only loses the button, because the relation is no longer removed.
+    rows.value = rows.value.map((entry) =>
+      entry.target_id === row.target_id && entry.action === "delete"
+        ? { ...entry, restorable: false }
+        : entry,
+    );
+    notice.value = result.published
+      ? "Powiązanie wróciło na stronę."
+      : "Powiązanie wróciło jako szkic - żeby było widoczne publicznie, opublikuj je w „Powiązaniach”.";
+    noticeShown.value = true;
+  } catch (err) {
+    error.value =
+      (err as { data?: { message?: string } }).data?.message ||
+      "Nie udało się przywrócić powiązania.";
+  } finally {
+    restoring.value = null;
+  }
+}
+
+onMounted(() => load());
+</script>

--- a/frontend/app/pages/admin/index.vue
+++ b/frontend/app/pages/admin/index.vue
@@ -364,19 +364,20 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 import {
+  mdiChartLine,
+  mdiCheckCircleOutline,
+  mdiChevronRight,
+  mdiClipboardCheckOutline,
+  mdiClipboardTextClockOutline,
+  mdiGestureTapButton,
   mdiGraphOutline,
   mdiHistory,
   mdiInboxArrowDown,
-  mdiVectorPolyline,
-  mdiNoteEditOutline,
-  mdiTextBoxSearchOutline,
-  mdiChartLine,
-  mdiClipboardCheckOutline,
-  mdiChevronRight,
-  mdiCheckCircleOutline,
-  mdiGestureTapButton,
-  mdiRefresh,
   mdiMessageAlertOutline,
+  mdiNoteEditOutline,
+  mdiRefresh,
+  mdiTextBoxSearchOutline,
+  mdiVectorPolyline,
 } from "@mdi/js";
 import { authRequest } from "~/composables/auth";
 import { noteAdminTypeLabel, noteKindConfig } from "~/composables/notes";
@@ -421,6 +422,12 @@ const subpages = [
     to: "/admin/notatki",
     icon: mdiNoteEditOutline,
     desc: "Zgłoszenia i źródła dodane przez użytkowników.",
+  },
+  {
+    title: "Dziennik decyzji",
+    to: "/admin/audyt",
+    icon: mdiClipboardTextClockOutline,
+    desc: "Co administratorzy zdecydowali i dlaczego - z przyciskiem cofnięcia usunięcia.",
   },
   {
     title: "Zgłoszenia",

--- a/frontend/app/pages/admin/krawedzie.vue
+++ b/frontend/app/pages/admin/krawedzie.vue
@@ -116,7 +116,8 @@
 import { computed, ref } from "vue";
 import { mdiArrowLeft, mdiEarth } from "@mdi/js";
 import { authRequest } from "~/composables/auth";
-import { edgeTypeLabels, relationsPlural } from "~/composables/edges";
+import { relationsPlural } from "~/composables/edges";
+import { edgeTypeLabels } from "~~/shared/edges";
 import type {
   UnpublishedEdgeRow,
   UnpublishedEdges,

--- a/frontend/server/api/admin/audit.get.ts
+++ b/frontend/server/api/admin/audit.get.ts
@@ -1,0 +1,259 @@
+import { FieldPath, getFirestore } from "firebase-admin/firestore";
+import { getApp } from "firebase-admin/app";
+import { requireAdmin } from "~~/server/utils/auth";
+import { auditActions, isRemovalAction } from "~~/shared/audit";
+import type { AuditAction } from "~~/shared/audit";
+import { generateEntityUrl } from "~/composables/slugs";
+import { edgeTypeLabels } from "~~/shared/edges";
+import { nodeTypes, type Edge, type NodeType } from "~~/shared/model";
+import { z } from "zod";
+
+/** One decision, as the log renders it. */
+export type AuditRow = {
+  id: string;
+  action: AuditAction;
+  collection: "nodes" | "edges";
+  target_id: string;
+  /** What the entry is called. Null when the target has since been hard
+   * deleted, or was never there - the row still stands, because the decision
+   * was still made. */
+  targetName: string | null;
+  /** Where to read it. Null for a relation, which has no page of its own, and
+   * for a target that is gone. */
+  targetPath: string | null;
+  /** A relation read as a sentence, since it has no name and no page. Null for
+   * a node. */
+  targetDetail: string | null;
+  revision_id: string | null;
+  /** The admin's uid. The page resolves it to a name through the batched
+   * lookup every other admin list uses. */
+  user: string;
+  at: string;
+  reason: string | null;
+  /** Whether this removal can still be undone - the relation is there and is
+   * still marked removed. False once somebody has put it back, so the button
+   * goes away rather than 404ing or writing a no-op revision. */
+  restorable: boolean;
+};
+
+export type AuditLog = {
+  entries: AuditRow[];
+  /** The `at` of the last row returned. Null when the log is exhausted. */
+  nextCursor: string | null;
+};
+
+const queryValidator = z.object({
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  cursor: z.string().optional(),
+  action: z.enum(auditActions).optional(),
+});
+
+/** The administrator decision log.
+ *
+ * Read only here and in `collectAdminDecisions`, which takes `user` and `at`
+ * and throws the rest away to count contributions. This is the other half: what
+ * was actually decided, about which entry, and why.
+ *
+ * Ordered by `at` alone. `audit` has no composite index and index deploys in
+ * this project are manual, so a filter combined with the ordering would pass
+ * every local test against the emulator - which creates indexes implicitly -
+ * and 500 in production. `action` is therefore filtered in memory, over a
+ * bounded scan, the way `deleted` is filtered everywhere else in this codebase.
+ */
+export default defineEventHandler(async (event): Promise<AuditLog> => {
+  const query = await getValidatedQuery(event, (q) => queryValidator.parse(q));
+  await requireAdmin(event);
+
+  const db = getFirestore(getApp(), "koryta-pl");
+
+  // One over the page when unfiltered, so a full read is distinguishable from
+  // the end of the log. Wider when filtering, because the filter runs in memory
+  // and a rare decision can sit behind any number of publications.
+  const scan = query.action ? SCAN_WITH_FILTER : query.limit + 1;
+
+  // Ordered by `at`, then by document id. Both descending, which is exactly the
+  // shape of the automatic single-field index Firestore keeps for every field -
+  // it terminates in `__name__` in the matching direction - so this needs no
+  // composite index, and `audit` has none declared. The second key is not
+  // cosmetic: `at` is stamped per `recordAudit` call, and publishing a hundred
+  // relations files up to two hundred rows inside one synchronous loop, tens of
+  // which land on the same millisecond. On `at` alone a cursor cannot address a
+  // position *inside* such a group, and `startAfter(at)` steps over all of it -
+  // so a page that ended mid-group silently lost the rest. The document id
+  // breaks every tie, so the cursor is exact and no row can be skipped.
+  let q = db
+    .collection("audit")
+    .orderBy("at", "desc")
+    .orderBy(FieldPath.documentId(), "desc")
+    .limit(scan);
+  if (query.cursor) {
+    const [at, id] = splitCursor(query.cursor);
+    q = q.startAfter(at, id);
+  }
+
+  const snap = await q.get();
+  const scanned = snap.docs.map((doc) => ({
+    id: doc.id,
+    ...(doc.data() as Omit<AuditRow, "id">),
+  }));
+
+  const matching = query.action
+    ? scanned.filter((row) => row.action === query.action)
+    : scanned;
+
+  const page = matching.slice(0, query.limit);
+  // Where the next page resumes. When the page was truncated it follows the
+  // last row *returned*; otherwise it follows the last row *examined*, so a
+  // filter for a rare decision keeps paging past the ones it skipped instead of
+  // reporting the log exhausted. A short read means there is nothing behind it.
+  const truncated = matching.length > query.limit;
+  const last = truncated ? page[page.length - 1] : scanned[scanned.length - 1];
+  const nextCursor =
+    (truncated || scanned.length >= scan) && last
+      ? `${last.at}|${last.id}`
+      : null;
+
+  // One read of the relations, shared: `resolveTargets` needs them to name the
+  // row and `restorable` needs them to know whether the removal still stands,
+  // and re-reading would double the cost of every page.
+  const edges = await readAll(
+    db,
+    "edges",
+    page
+      .filter((row) => row.collection === "edges")
+      .map((row) => row.target_id),
+  );
+  const targets = await resolveTargets(db, page, edges);
+
+  return {
+    entries: page.map((row) => {
+      const target = targets.get(`${row.collection}/${row.target_id}`);
+      return {
+        id: row.id,
+        action: row.action,
+        collection: row.collection,
+        target_id: row.target_id,
+        targetName: target?.name ?? null,
+        targetPath: target?.path ?? null,
+        targetDetail: target?.detail ?? null,
+        revision_id: row.revision_id ?? null,
+        user: row.user,
+        at: row.at,
+        reason: row.reason ?? null,
+        // Still undoable only while the relation is there and still marked
+        // removed - so the button goes away once somebody has put it back,
+        // rather than 404ing or writing a revision that changes nothing.
+        restorable:
+          isRemovalAction(row.action) &&
+          row.collection === "edges" &&
+          (edges.get(row.target_id) as unknown as Edge | undefined)?.deleted ===
+            true,
+      };
+    }),
+    nextCursor,
+  };
+});
+
+/** How many rows to read through when the caller asked for one kind of
+ * decision. Filtering in memory means a page of ten rejections can sit behind
+ * any number of publications; this bounds what that costs. */
+const SCAN_WITH_FILTER = 400;
+
+/** A cursor is `<at>|<document id>`, the two keys the query orders on.
+ *
+ * `at` is an ISO 8601 timestamp and carries no `|`, so the first one separates
+ * the keys. A cursor that has lost its id still positions correctly on the
+ * timestamp; it just cannot address a spot inside a same-millisecond group,
+ * which is the one thing the id is there for.
+ */
+function splitCursor(cursor: string): [string, string] {
+  const at = cursor.indexOf("|");
+  if (at === -1) return [cursor, ""];
+  return [cursor.slice(0, at), cursor.slice(at + 1)];
+}
+
+/** What each row is about, in one read per collection. */
+async function resolveTargets(
+  db: FirebaseFirestore.Firestore,
+  rows: { collection: string; target_id: string }[],
+  edges: Map<string, Record<string, unknown>>,
+): Promise<
+  Map<
+    string,
+    { name: string | null; path: string | null; detail: string | null }
+  >
+> {
+  const out = new Map<
+    string,
+    { name: string | null; path: string | null; detail: string | null }
+  >();
+  const nodeIds = new Set<string>();
+  for (const row of rows) {
+    if (row.collection !== "edges") nodeIds.add(row.target_id);
+  }
+
+  // A relation is named by its two ends, so their pages have to be read as
+  // well - including the ones this log's own rows took off the site.
+  for (const edge of edges.values()) {
+    const data = edge as unknown as Edge;
+    if (typeof data.source === "string") nodeIds.add(data.source);
+    if (typeof data.target === "string") nodeIds.add(data.target);
+  }
+  const nodes = await readAll(db, "nodes", [...nodeIds]);
+
+  const nameOf = (id: string) => {
+    const raw = nodes.get(id)?.name;
+    return typeof raw === "string" && raw ? raw : null;
+  };
+
+  for (const [id, data] of nodes) {
+    const type = nodeTypes.includes(data.type as NodeType)
+      ? (data.type as NodeType)
+      : null;
+    const name = nameOf(id);
+    out.set(`nodes/${id}`, {
+      name,
+      path: type ? generateEntityUrl(type, id, name ?? undefined) : null,
+      detail: null,
+    });
+  }
+
+  for (const [id, raw] of edges) {
+    const edge = raw as unknown as Edge;
+    const label = edge.name || edgeTypeLabels[edge.type] || edge.type;
+    const from = nameOf(edge.source) ?? edge.source;
+    const to = nameOf(edge.target) ?? edge.target;
+    const period = [edge.start_date, edge.end_date].filter(Boolean).join(" - ");
+    out.set(`edges/${id}`, {
+      name: `${from} - ${label} - ${to}`,
+      // A relation has no page. The end it starts from is the nearest thing,
+      // and it is where the reader would go to see the relation in context.
+      path: nodes.has(edge.source)
+        ? (out.get(`nodes/${edge.source}`)?.path ?? null)
+        : null,
+      detail: period || null,
+    });
+  }
+
+  return out;
+}
+
+/** `getAll` in chunks, the way `resolveEdgeEndpoints` reads its endpoints. */
+async function readAll(
+  db: FirebaseFirestore.Firestore,
+  collection: string,
+  ids: string[],
+): Promise<Map<string, Record<string, unknown>>> {
+  const found = new Map<string, Record<string, unknown>>();
+  for (let i = 0; i < ids.length; i += 100) {
+    const chunk = ids.slice(i, i + 100);
+    if (chunk.length === 0) continue;
+    const snaps = await db.getAll(
+      ...chunk.map((id) => db.collection(collection).doc(id)),
+    );
+    for (const snap of snaps) {
+      if (snap.exists) found.set(snap.id, snap.data() ?? {});
+    }
+  }
+  return found;
+}

--- a/frontend/server/api/edges/restore.post.ts
+++ b/frontend/server/api/edges/restore.post.ts
@@ -1,0 +1,133 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { getApp } from "firebase-admin/app";
+import { requireAdmin } from "~~/server/utils/auth";
+import {
+  createRevisionTransaction,
+  withoutInternalFields,
+} from "~~/server/utils/revisions";
+import { recordAudit } from "~~/server/utils/audit";
+import { z } from "zod";
+
+const bodyValidator = z.object({
+  edge_id: z.string().min(1),
+});
+
+export type EdgeRestored = {
+  edge_id: string;
+  restored: boolean;
+  /** The revision written for it, or null when the relation was not removed in
+   * the first place and nothing new was recorded. */
+  revision_id: string | null;
+  /** Whether the relation is back on the public site. Always false today, and
+   * said out loud because it is the surprising half of this: a removal hid the
+   * relation *and* unpublished it, and only the hiding is undone here. */
+  published: boolean;
+};
+
+/** Puts back a relation an admin removed.
+ *
+ * The exact mirror of /api/edges/delete, and it has to be: `deleted` and
+ * `delete_reason` are fields the document owns, so `createRevisionTransaction`
+ * layers whatever `stored` says for them back over the revision. Withholding
+ * both is what lets this write be the one that settles them - and because the
+ * target write is a full `set`, withholding them means the document comes back
+ * with neither key rather than with `deleted: false`.
+ *
+ * That distinction is not cosmetic. Every reader tests `deleted === true` or
+ * `!== true`, so `false` and absent look identical to all of them - but
+ * `applyRevision` layers the *stored* value over a revision it is applying, so
+ * a document carrying `deleted: false` would silently cancel the next removal
+ * somebody approved against it.
+ *
+ * `published` is deliberately not touched: the removal set it false, the value
+ * it had before that is recorded nowhere, and guessing would be the one way
+ * this endpoint could put something back in front of the public that nobody
+ * re-reviewed. The relation returns as a draft and re-enters the queue at
+ * /admin/krawedzie, which is where the decision to show it belongs.
+ *
+ * Edges only. A node is removed by approving a removal revision rather than
+ * through an endpoint, and its `published` is never lowered on the way out - so
+ * clearing `deleted` there would put the page and every relation around it back
+ * on the site in one write, with no review. That wants its own thought and its
+ * own endpoint.
+ */
+export default defineEventHandler(async (event): Promise<EdgeRestored> => {
+  const body = await readValidatedBody(event, (body) =>
+    bodyValidator.parse(body),
+  );
+
+  const user = await requireAdmin(event);
+  const db = getFirestore(getApp(), "koryta-pl");
+
+  const edgeRef = db.collection("edges").doc(body.edge_id);
+  const snapshot = await edgeRef.get();
+  if (!snapshot.exists) {
+    throw createError({
+      statusCode: 404,
+      message: `Nie ma powiązania o id: ${body.edge_id}`,
+    });
+  }
+
+  const data = snapshot.data() ?? {};
+  // Idempotent, like the removal it undoes: two admins clicking the same row,
+  // or one double-clicking, both mean the relation is back. Writing a second
+  // restore revision would only add a duplicate to its history and repoint
+  // `revision_id` at a revision that changed nothing.
+  if (data.deleted !== true) {
+    return {
+      edge_id: body.edge_id,
+      restored: true,
+      revision_id: null,
+      published: data.published === true,
+    };
+  }
+
+  const { deleted: _wasDeleted, delete_reason: _reason, ...stored } = data;
+
+  const batch = db.batch();
+  const { revisionRef } = createRevisionTransaction(
+    db,
+    batch,
+    user,
+    edgeRef,
+    // `withoutInternalFields` already drops `deleted` and `delete_reason`, so
+    // the revision states the relation as it was and says nothing about its
+    // removal - which is what retracting the removal looks like.
+    withoutInternalFields(data),
+    // No `published` option, so the stored `false` carries through. Approved as
+    // it is written, and that is the point of writing a revision at all rather
+    // than a bare update: `revision_id` has to stop pointing at the removal.
+    // Left where it was, re-approving it from /admin/rewizje would silently
+    // delete the relation again, and /api/revisions/reject refuses to retire
+    // the revision a document points at.
+    { stored, approve: true },
+  );
+
+  recordAudit(
+    db,
+    {
+      action: "restore",
+      collection: "edges",
+      target_id: edgeRef.id,
+      revision_id: revisionRef.id,
+      user: user.uid,
+    },
+    batch,
+  );
+
+  await batch.commit();
+
+  // Six hours of per-handler cache otherwise stands between the restored
+  // relation and the page it belongs on. Same clear as the removal.
+  await useStorage("cache").clear("nitro:handlers");
+
+  return {
+    edge_id: body.edge_id,
+    restored: true,
+    revision_id: revisionRef.id,
+    // What was actually written, not a constant: `published` is carried from
+    // the stored document rather than set here, so reporting a hardcoded false
+    // would be a guess about somebody else's write.
+    published: data.published === true,
+  };
+});

--- a/frontend/shared/audit.ts
+++ b/frontend/shared/audit.ts
@@ -18,6 +18,7 @@ export const auditActions = [
   "publish",
   "unpublish",
   "delete",
+  "restore",
 ] as const;
 
 export type AuditAction = (typeof auditActions)[number];
@@ -37,7 +38,8 @@ export type AuditEntry = {
    * plain range query on one field, the way votes and notes are read. */
   at: string;
   /** Why the suggestion was turned down, or why the entry was removed. Only a
-   * rejection and a removal carry one. */
+   * rejection and a removal carry one - a restore takes the removal's reason
+   * off the record rather than adding one of its own. */
   reason?: string;
 };
 
@@ -49,10 +51,47 @@ export function isVisibilityAction(action: AuditAction): boolean {
   return action === "publish" || action === "unpublish";
 }
 
+/** Whether the action took an entry off the site in a way `restore` undoes.
+ *
+ * Only `delete`. An `unpublish` is undone by publishing again, which is a
+ * different button on a different page, and a rejected proposal was never on
+ * the site to begin with.
+ */
+export function isRemovalAction(action: AuditAction): boolean {
+  return action === "delete";
+}
+
 export const auditActionLabels: Record<AuditAction, string> = {
   approve: "Zatwierdzenie rewizji",
   reject: "Odrzucenie rewizji",
   publish: "Opublikowanie strony",
   unpublish: "Ukrycie strony",
   delete: "Usunięcie wpisu",
+  restore: "Przywrócenie wpisu",
 };
+
+/** The same labels, for a decision about a relation rather than a page.
+ *
+ * `publish`/`unpublish` are filed against edges as well as nodes -
+ * `publishEdgeInBatch` and `cascadeUnpublishEdges` both do it - and the labels
+ * above were written when nothing rendered them, so they all say "strony". A
+ * log that calls publishing a relation "Opublikowanie strony" reads as if the
+ * admin had done something to a page they never touched.
+ */
+const relationActionLabels: Partial<Record<AuditAction, string>> = {
+  publish: "Opublikowanie powiązania",
+  unpublish: "Ukrycie powiązania",
+  delete: "Usunięcie powiązania",
+  restore: "Przywrócenie powiązania",
+};
+
+/** What a decision is called, given what it was about. */
+export function auditActionLabel(
+  action: AuditAction,
+  collection: "nodes" | "edges",
+): string {
+  if (collection === "edges") {
+    return relationActionLabels[action] ?? auditActionLabels[action];
+  }
+  return auditActionLabels[action];
+}

--- a/frontend/shared/edges.ts
+++ b/frontend/shared/edges.ts
@@ -1,0 +1,18 @@
+/** What a relation is called on screen, when it has no name of its own.
+ *
+ * In `shared/` rather than beside `useEdges`, because both sides need it: the
+ * entity pages and the admin dialogs render it, and so does the audit log,
+ * which describes a relation server-side. `app/composables/edges.ts` reaches
+ * for Nuxt's auto-imports, so importing this from there would have pulled
+ * `computed` and `useAuthState` into the server build.
+ */
+export const edgeTypeLabels: Record<string, string> = {
+  employed: "Zatrudniony/a w",
+  owns: "Właściciel",
+  seat: "Siedziba",
+  connection: "Powiązanie z",
+  mentions: "Wspomina o",
+  comment: "Komentarz",
+  election: "Kandydował/a w",
+  tagged: "Dotyczy tematu",
+};

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,36 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "admin-dziennik-decyzji",
+    title: "Dziennik decyzji administratorów, z przyciskiem „Przywróć”",
+    description:
+      "Nowa strona /admin/audyt pokazuje, co administratorzy zdecydowali o " +
+      "wpisach i powiązaniach: kto, kiedy, jakiego wpisu to dotyczyło i - " +
+      "przy usunięciach i odrzuceniach - dlaczego. Do tej pory te decyzje " +
+      "zapisywały się do bazy i nie było ich widać nigdzie poza licznikiem " +
+      "„Decyzja administratora” w statystykach, który mówi tylko, że ktoś coś " +
+      "zrobił. Przy usuniętych powiązaniach jest przycisk „Przywróć”, który " +
+      "cofa usunięcie - powiązanie wraca jako szkic, czyli widzą je zalogowani, " +
+      "ale nie widzi go publiczność; żeby wróciło na stronę dla wszystkich, " +
+      "trzeba je opublikować w „Powiązaniach”. Tak jest " +
+      "celowo: to, czy powiązanie było wcześniej publiczne, nie jest nigdzie " +
+      "zapisane, a zgadywanie oznaczałoby pokazanie czegoś, czego nikt " +
+      "ponownie nie sprawdził.",
+    steps: [
+      "Wejdź na /admin jako admin - w siatce kafelków jest „Dziennik decyzji”. Kliknij go (albo wejdź wprost na /admin/audyt).",
+      "Tabela ma kolumny: kiedy, kto, decyzja, czego dotyczy, powód. Najnowsze na górze. Nazwiska ładują się chwilę po tabeli - to jeden wspólny request na całą stronę.",
+      "Usuń jakieś powiązanie na stronie osoby (kosz w „Historii powiązań”), wróć na /admin/audyt i odśwież - na górze ma być wiersz „Usunięcie wpisu” z Twoim powodem i opisem powiązania („Osoba - rola - firma”).",
+      "Kliknij „Przywróć” w tym wierszu. Przycisk ma zniknąć, a na dole pojawić się komunikat, że powiązanie wróciło jako szkic.",
+      "Wróć na stronę osoby: powiązanie znów tam jest - zalogowani widzą szkice. Wyloguj się (albo otwórz okno prywatne) i sprawdź tę samą stronę: dla niezalogowanych powiązania nie ma, bo szkic nie jest publiczny.",
+      "Wejdź na /admin/krawedzie: przywrócone powiązanie ma tam czekać na opublikowanie. Opublikuj je - od tej pory widzą je też niezalogowani.",
+      "Odśwież /admin/audyt: są teraz dwa wiersze o tym powiązaniu - „Usunięcie wpisu” (już bez przycisku) i „Przywrócenie wpisu”.",
+      "Ustaw filtr „Rodzaj decyzji” na „Usunięcie wpisu” - w tabeli mają zostać same usunięcia. Wyczyść filtr i sprawdź, że wracają wszystkie.",
+      "Jeśli decyzji jest więcej niż 50, na dole jest „Wczytaj więcej”; kliknij i sprawdź, że dochodzą starsze wiersze, a żaden się nie dubluje.",
+    ],
+    link: "/admin/audyt",
+    area: "admin",
+  },
+  {
     id: "spolki-skarbu-panstwa-maja-wlasciciela",
     title: "Spółki Skarbu Państwa mają wreszcie wpisanego właściciela",
     description:
@@ -197,9 +227,9 @@ export const QA_ITEMS: QaItem[] = [
       "powiązań po źle scalonej osobie: zatrudnienia z niewłaściwej połowy " +
       "nie są niczyją tezą, tylko śmieciem po scaleniu. Powiązanie nie znika " +
       "z bazy - zostaje w niej razem z powodem i autorem usunięcia, więc " +
-      "widać, kto i dlaczego je zdjął. Cofnąć to można na razie tylko w " +
-      "bazie: żaden ekran w aplikacji nie przywraca usuniętego powiązania, " +
-      "więc pytaj o powód serio. Przy okazji: usunięte powiązanie znika też " +
+      "widać, kto i dlaczego je zdjął. Cofnąć usunięcie da się w „Dzienniku " +
+      "decyzji” (/admin/audyt) - patrz wpis o dzienniku. Przy okazji: " +
+      "usunięte powiązanie znika też " +
       "zalogowanym; wcześniej filtr omijał osoby oglądające wersje " +
       "niezatwierdzone, więc admin po usunięciu dalej widział je na stronie.",
     steps: [

--- a/frontend/tests/e2e/audit_log.spec.ts
+++ b/frontend/tests/e2e/audit_log.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect, type Locator } from "@playwright/test";
+import { initializeApp, getApps, getApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+import { logIn, USERS } from "./helpers/auth";
+
+process.env.FIRESTORE_EMULATOR_HOST = "127.0.0.1:8080";
+process.env.GCLOUD_PROJECT = "demo-koryta-pl";
+
+const app =
+  getApps().length === 0
+    ? initializeApp({ projectId: "demo-koryta-pl" })
+    : getApp();
+const db = getFirestore(app, "koryta-pl");
+
+const stamp = Date.now();
+
+/** No hyphens in a node id: a readable url is `/osoba/<slug>-<id>` and the page
+ * reads the id back as the last dash-separated segment. */
+const ids = {
+  worker: `audworker${stamp}`,
+  company: `audcompany${stamp}`,
+};
+const edgeId = `aud-edge-job-${stamp}`;
+
+/** One person, one company, one relation between them - this spec's own,
+ * because it removes what it reads and the seeded Jan Kowalski is asserted on
+ * by four other specs. */
+async function seed() {
+  const batch = db.batch();
+  const page = (name: string, type: "person" | "place") => ({
+    name,
+    type,
+    revision_id: `rev-${stamp}`,
+    published: true,
+    stats: { isApproved: true, nodeGroupSize: 1 },
+  });
+
+  batch.set(
+    db.collection("nodes").doc(ids.worker),
+    page(`Audytowany Pracownik ${stamp}`, "person"),
+  );
+  batch.set(
+    db.collection("nodes").doc(ids.company),
+    page(`Audytowana Spolka ${stamp}`, "place"),
+  );
+  // `set`, so a retry restores the fixture rather than finding it removed.
+  batch.set(db.collection("edges").doc(edgeId), {
+    source: ids.worker,
+    target: ids.company,
+    type: "employed",
+    name: "Zarzad",
+    start_date: "2019-03-01",
+    published: true,
+  });
+
+  await batch.commit();
+}
+
+test.describe("Decision log", () => {
+  // Per test, not per file: this spec removes a relation, so a retry or a
+  // second local run against a still-running dev server would otherwise start
+  // from a fixture the previous attempt already destroyed.
+  test.beforeEach(async () => {
+    await seed();
+  });
+
+  test("an admin reads back a removal and undoes it", async ({ page }) => {
+    test.setTimeout(240_000);
+    await logIn(page, USERS.admin, `/entity/person/${ids.worker}`);
+
+    // Remove the relation, so the log has a decision of this spec's own to
+    // find. The audit collection is never cleared by the seed, so the row has
+    // to be located by its own stamped text rather than by position.
+    const reason = `Blednie scalona osoba ${stamp}`;
+    await page
+      .getByTestId("relations-history")
+      .locator(".history-row")
+      .filter({ hasText: `Audytowana Spolka ${stamp}` })
+      .getByTestId(`edge-remove-${edgeId}`)
+      .click();
+    const removeDialog = page.getByTestId("remove-edge-dialog");
+    await expect(removeDialog).toBeVisible({ timeout: 30_000 });
+    await removeDialog
+      .getByTestId("remove-edge-reason")
+      .locator("textarea")
+      .first()
+      .fill(reason);
+    await removeDialog.getByTestId("remove-edge-confirm").click();
+    await expect(removeDialog).toBeHidden({ timeout: 30_000 });
+
+    // The log says who decided what, about which relation, and why.
+    await page.goto("/admin/audyt");
+    const row = page
+      .getByTestId("audit-table")
+      .locator("tr")
+      .filter({ hasText: reason });
+    await expect(row).toBeVisible({ timeout: 30_000 });
+    // "powiązania", not "wpisu": the label follows what the decision was about,
+    // and publishing a relation is not publishing a page.
+    await expect(row).toContainText("Usunięcie powiązania");
+    await expect(row).toContainText(`Audytowany Pracownik ${stamp}`);
+    await expect(row).toContainText(`Audytowana Spolka ${stamp}`);
+    // The uid is resolved to a name through the batched lookup.
+    await expect(row).toContainText("Admin User");
+
+    await row.getByTestId(`audit-restore-${await rowId(row)}`).click();
+
+    // The button goes, because the relation is no longer removed - but the row
+    // stays, because the removal still happened.
+    await expect(row.getByRole("button", { name: "Przywróć" })).toHaveCount(0, {
+      timeout: 30_000,
+    });
+    await expect(row).toBeVisible();
+    await expect(page.getByText("Powiązanie wróciło jako szkic")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Back as a draft, which is not the same as back on the site. A signed-in
+    // reader is shown drafts - `authFetch` asks for `latest` on every request,
+    // and `getLocalGraph` skips the visibility test when it does - so the
+    // relation returns to the admin's own view of the page immediately.
+    await page.goto(`/entity/person/${ids.worker}`);
+    await expect(page.getByTestId("relations-history")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(
+      page
+        .getByTestId("relations-history")
+        .getByText(`Audytowana Spolka ${stamp}`),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // The public still does not see it: that is what "as a draft" means, and it
+    // is why the relation is waiting in the publishing queue rather than live.
+    await page.goto("/admin/krawedzie");
+    await expect(
+      page
+        .getByTestId("edges-queue-table")
+        .getByText(`Audytowany Pracownik ${stamp}`),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // And the restoration is on the record too.
+    await page.goto("/admin/audyt");
+    await expect(
+      page
+        .getByTestId("audit-table")
+        .locator("tr")
+        .filter({ hasText: `Audytowany Pracownik ${stamp}` })
+        .filter({ hasText: "Przywrócenie powiązania" }),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("the log is closed to a reader who is not an admin", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    await logIn(page, USERS.normal);
+    await page.goto("/admin/audyt");
+
+    // The admin middleware aborts the navigation rather than rendering it.
+    await expect(page.getByTestId("audit-table")).toHaveCount(0);
+  });
+});
+
+/** The audit row's document id, read off the restore button's test hook. The
+ * page keys rows by the Firestore document id, which the spec cannot know up
+ * front - it only knows the reason it typed. */
+async function rowId(row: Locator): Promise<string> {
+  const testId = await row
+    .locator('[data-testid^="audit-restore-"]')
+    .getAttribute("data-testid");
+  return (testId ?? "").replace("audit-restore-", "");
+}

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -47,6 +47,9 @@ const LOGGED_IN_ROUTES = [
   // first few seconds.
   "/admin/krawedzie",
   "/admin/opinie",
+  // The decision log, whose spec looks for its own row and presses Przywróć
+  // within a few seconds of landing.
+  "/admin/audyt",
   // The id does not have to resolve; the route's own chunk is what we want
   // compiled before a spec follows a revision link into it.
   "/admin/rewizje/warmup",

--- a/frontend/tests/server/api/admin/audit.test.ts
+++ b/frontend/tests/server/api/admin/audit.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { requireAdmin } from "../../../../server/utils/auth";
+import handler from "../../../../server/api/admin/audit.get";
+
+let stored: Record<string, Record<string, unknown> | undefined> = {};
+
+/** What the audit query asked for, so a test can say the ordering is the one
+ * the automatic single-field index serves. */
+const mockOrderBy = vi.fn();
+
+/** Every audit document, newest first, honouring startAfter/limit for real.
+ * The endpoint's paging logic is the thing under test, so the fake has to
+ * page rather than hand back everything. */
+function auditQuery() {
+  let afterAt: string | null = null;
+  let afterId: string | null = null;
+  let cap = Infinity;
+  const query = {
+    orderBy: (field: string, dir: string) => {
+      mockOrderBy(field, dir);
+      return query;
+    },
+    // Two keys, the way the endpoint orders: `(at, __name__)` both descending.
+    startAfter: (at: string, id: string) => {
+      afterAt = at;
+      afterId = id;
+      return query;
+    },
+    limit: (n: number) => {
+      cap = n;
+      return query;
+    },
+    get: async () => {
+      const docs = Object.entries(stored)
+        .filter(([path]) => path.startsWith("audit/"))
+        .map(([path, data]) => ({
+          id: path.slice("audit/".length),
+          data: () => data as Record<string, unknown>,
+        }))
+        .sort((a, b) => {
+          const byAt = String(b.data().at).localeCompare(String(a.data().at));
+          return byAt !== 0 ? byAt : b.id.localeCompare(a.id);
+        })
+        .filter((doc) => {
+          if (afterAt === null) return true;
+          const at = String(doc.data().at);
+          if (at !== afterAt) return at < afterAt;
+          // Inside one timestamp the document id is what the cursor addresses.
+          return doc.id < (afterId ?? "");
+        })
+        .slice(0, cap);
+      return { docs, size: docs.length, empty: docs.length === 0 };
+    },
+  };
+  return query;
+}
+
+const mockDb = {
+  collection: vi.fn((name: string) => ({
+    doc: vi.fn((id: string) => ({ id, path: `${name}/${id}` })),
+    ...(name === "audit" ? auditQuery() : {}),
+  })),
+  getAll: vi.fn(async (...refs: { id: string; path: string }[]) =>
+    refs.map((ref) => ({
+      id: ref.id,
+      exists: stored[ref.path] !== undefined,
+      data: () => stored[ref.path],
+    })),
+  ),
+};
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: vi.fn(() => mockDb),
+  Timestamp: { now: () => ({}) },
+  FieldValue: { delete: () => "deleted" },
+  FieldPath: { documentId: () => "__name__" },
+}));
+
+vi.mock("firebase-admin/app", () => ({ getApp: vi.fn() }));
+
+vi.mock("../../../../server/utils/auth", () => ({
+  requireAdmin: vi.fn().mockResolvedValue({ uid: "admin-uid", admin: true }),
+}));
+
+const { mockGetValidatedQuery } = vi.hoisted(() => {
+  const mockGetValidatedQuery = vi.fn();
+  globalThis.getValidatedQuery = mockGetValidatedQuery;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.createError = (err: any) => err;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.defineEventHandler = (fn: any) => fn;
+  return { mockGetValidatedQuery };
+});
+
+function request(query: Record<string, unknown> = {}) {
+  mockGetValidatedQuery.mockImplementation(
+    async (_event: unknown, parse: (q: unknown) => unknown) => {
+      try {
+        return parse(query);
+      } catch {
+        throw { statusCode: 400, statusMessage: "Bad Request" };
+      }
+    },
+  );
+}
+
+function auditRow(
+  id: string,
+  at: string,
+  fields: Record<string, unknown> = {},
+) {
+  stored[`audit/${id}`] = {
+    action: "delete",
+    collection: "edges",
+    target_id: "e1",
+    user: "admin-uid",
+    at,
+    ...fields,
+  };
+}
+
+describe("api/admin/audit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stored = {};
+    request();
+  });
+
+  it("returns the newest decision first", async () => {
+    auditRow("old", "2026-01-01T00:00:00.000Z");
+    auditRow("new", "2026-06-01T00:00:00.000Z");
+
+    const result = await handler({} as never);
+
+    expect(result.entries.map((e) => e.id)).toEqual(["new", "old"]);
+  });
+
+  it("orders on `at` alone, which the automatic index serves", async () => {
+    // `audit` has no composite index and index deploys here are manual, so a
+    // filter combined with the ordering would pass against the emulator - which
+    // creates indexes implicitly - and 500 in production.
+    auditRow("a", "2026-01-01T00:00:00.000Z");
+
+    await handler({} as never);
+
+    // Both descending, which is the shape of the automatic single-field index
+    // (it terminates in `__name__` in the matching direction), so this needs no
+    // composite index - and `audit` has none declared.
+    expect(mockOrderBy.mock.calls).toEqual([
+      ["at", "desc"],
+      ["__name__", "desc"],
+    ]);
+  });
+
+  it("names a relation by its two ends", async () => {
+    auditRow("a", "2026-01-01T00:00:00.000Z", { reason: "Zły scalony" });
+    stored["edges/e1"] = {
+      source: "p1",
+      target: "c1",
+      type: "employed",
+      deleted: true,
+      start_date: "2019-03-01",
+      end_date: "2024-04-12",
+    };
+    stored["nodes/p1"] = { name: "Jan Kowalski", type: "person" };
+    stored["nodes/c1"] = { name: "Orlen", type: "place" };
+
+    const result = await handler({} as never);
+
+    expect(result.entries[0]).toMatchObject({
+      targetName: "Jan Kowalski - Zatrudniony/a w - Orlen",
+      targetDetail: "2019-03-01 - 2024-04-12",
+      reason: "Zły scalony",
+    });
+    // A relation has no page; the end it starts from is where a reader would go.
+    expect(result.entries[0]?.targetPath).toContain("p1");
+  });
+
+  it("offers a restore only while the relation is still removed", async () => {
+    auditRow("gone", "2026-02-01T00:00:00.000Z", { target_id: "e1" });
+    auditRow("back", "2026-01-01T00:00:00.000Z", { target_id: "e2" });
+    stored["edges/e1"] = {
+      source: "p1",
+      target: "c1",
+      type: "employed",
+      deleted: true,
+    };
+    // Already restored by somebody else - the row stands, the button does not.
+    stored["edges/e2"] = { source: "p1", target: "c1", type: "employed" };
+
+    const result = await handler({} as never);
+
+    expect(result.entries.find((e) => e.id === "gone")?.restorable).toBe(true);
+    expect(result.entries.find((e) => e.id === "back")?.restorable).toBe(false);
+  });
+
+  it("does not offer a restore on a decision that removed nothing", async () => {
+    auditRow("pub", "2026-01-01T00:00:00.000Z", { action: "publish" });
+    stored["edges/e1"] = {
+      source: "p1",
+      target: "c1",
+      type: "employed",
+      deleted: true,
+    };
+
+    const result = await handler({} as never);
+
+    expect(result.entries[0]?.restorable).toBe(false);
+  });
+
+  it("survives a target that is no longer there", async () => {
+    // The decision was still made, so the row still stands.
+    auditRow("a", "2026-01-01T00:00:00.000Z");
+
+    const result = await handler({} as never);
+
+    expect(result.entries[0]).toMatchObject({
+      targetName: null,
+      targetPath: null,
+      restorable: false,
+    });
+  });
+
+  it("filters to one kind of decision", async () => {
+    auditRow("d", "2026-03-01T00:00:00.000Z", { action: "delete" });
+    auditRow("p", "2026-02-01T00:00:00.000Z", { action: "publish" });
+    request({ action: "delete" });
+
+    const result = await handler({} as never);
+
+    expect(result.entries.map((e) => e.id)).toEqual(["d"]);
+  });
+
+  it("pages through a group that all shares one millisecond without losing a row", async () => {
+    // The reason the cursor carries a document id. `at` is stamped per
+    // `recordAudit` call, and publishing a hundred relations files up to two
+    // hundred rows inside one synchronous loop - tens of them on the same
+    // millisecond. On `at` alone a cursor cannot address a position inside such
+    // a group, so `startAfter(at)` stepped over whatever did not fit the page.
+    const at = "2026-02-01T00:00:00.000Z";
+    for (let i = 0; i < 7; i++) auditRow(`row${i}`, at);
+    request({ limit: 2 });
+
+    const seen: string[] = [];
+    let cursor: string | null | undefined;
+    for (let pageNo = 0; pageNo < 10; pageNo++) {
+      request({ limit: 2, ...(cursor ? { cursor } : {}) });
+      const result = await handler({} as never);
+      seen.push(...result.entries.map((e) => e.id));
+      cursor = result.nextCursor;
+      if (!cursor) break;
+    }
+
+    expect(seen.sort()).toEqual([
+      "row0",
+      "row1",
+      "row2",
+      "row3",
+      "row4",
+      "row5",
+      "row6",
+    ]);
+    // And each exactly once.
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+
+  it("does not repeat the last row of a page on the next one", async () => {
+    auditRow("a", "2026-03-01T00:00:00.000Z");
+    auditRow("b", "2026-02-01T00:00:00.000Z");
+    request({ limit: 1 });
+
+    const first = await handler({} as never);
+    request({ limit: 1, cursor: first.nextCursor! });
+    const second = await handler({} as never);
+
+    expect(first.entries.map((e) => e.id)).toEqual(["a"]);
+    expect(second.entries.map((e) => e.id)).toEqual(["b"]);
+  });
+
+  it("stops paging when the log runs out", async () => {
+    auditRow("a", "2026-01-01T00:00:00.000Z");
+
+    const result = await handler({} as never);
+
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("resumes after the cursor", async () => {
+    auditRow("a", "2026-03-01T00:00:00.000Z");
+    auditRow("b", "2026-02-01T00:00:00.000Z");
+    request({ cursor: "2026-03-01T00:00:00.000Z|a" });
+
+    const result = await handler({} as never);
+
+    expect(result.entries.map((e) => e.id)).toEqual(["b"]);
+  });
+
+  it("keeps paging when a filter matches nothing in the window it read", async () => {
+    // The filter runs in memory over a bounded scan, so a rare decision can sit
+    // behind any number of publications. Reporting the log exhausted the moment
+    // one window happens to hold none of them would hide it for good.
+    for (let i = 0; i < 3; i++) {
+      auditRow(`p${i}`, `2026-0${i + 1}-01T00:00:00.000Z`, {
+        action: "publish",
+      });
+    }
+    request({ action: "delete", limit: 2 });
+
+    const result = await handler({} as never);
+
+    expect(result.entries).toEqual([]);
+    // The cursor follows what was examined, not what was returned.
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("advances the cursor past rows it examined but did not return", async () => {
+    // Same rule, with the scan actually full: the next page has to resume after
+    // the publications rather than re-reading them forever.
+    auditRow("p1", "2026-03-01T00:00:00.000Z", { action: "publish" });
+    auditRow("p2", "2026-02-01T00:00:00.000Z", { action: "publish" });
+    auditRow("d1", "2026-01-01T00:00:00.000Z", { action: "delete" });
+    request({ action: "delete", limit: 2 });
+
+    const result = await handler({} as never);
+
+    expect(result.entries.map((e) => e.id)).toEqual(["d1"]);
+  });
+
+  it("refuses a caller who is not an admin", async () => {
+    vi.mocked(requireAdmin).mockRejectedValueOnce({ statusCode: 403 });
+
+    await expect(handler({} as never)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+});

--- a/frontend/tests/server/api/edges/restore.test.ts
+++ b/frontend/tests/server/api/edges/restore.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { requireAdmin } from "../../../../server/utils/auth";
+import handler from "../../../../server/api/edges/restore.post";
+
+const mockBatchSet = vi.fn();
+const mockCommit = vi.fn();
+const mockCacheClear = vi.fn();
+
+let stored: Record<string, Record<string, unknown> | undefined> = {};
+let generated = 0;
+
+function docRef(collection: string, id: string) {
+  return {
+    id,
+    path: `${collection}/${id}`,
+    parent: { id: collection },
+    get: vi.fn(async () => ({
+      id,
+      exists: stored[`${collection}/${id}`] !== undefined,
+      data: () => stored[`${collection}/${id}`],
+    })),
+  };
+}
+
+const mockDb = {
+  collection: vi.fn((collection: string) => ({
+    doc: vi.fn((id?: string) =>
+      docRef(collection, id ?? `generated-${++generated}`),
+    ),
+  })),
+  batch: vi.fn(() => ({
+    set: (ref: { path: string }, data: unknown) => mockBatchSet(ref.path, data),
+    update: vi.fn(),
+    commit: mockCommit,
+  })),
+};
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: vi.fn(() => mockDb),
+  // Only `now` is reached from here - nothing on this path reads the value
+  // back, so the mock does not have to be constructible.
+  Timestamp: { now: () => ({}) },
+  FieldValue: { delete: () => "deleted" },
+}));
+
+vi.mock("firebase-admin/app", () => ({ getApp: vi.fn() }));
+
+vi.mock("../../../../server/utils/auth", () => ({
+  requireAdmin: vi.fn().mockResolvedValue({ uid: "admin-uid", admin: true }),
+}));
+
+const { mockReadValidatedBody } = vi.hoisted(() => {
+  const mockReadValidatedBody = vi.fn();
+  globalThis.readValidatedBody = mockReadValidatedBody;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.createError = (err: any) => err;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.defineEventHandler = (fn: any) => fn;
+  return { mockReadValidatedBody };
+});
+
+function request(body: Record<string, unknown>) {
+  mockReadValidatedBody.mockImplementation(
+    async (_event: unknown, parse: (b: unknown) => unknown) => {
+      try {
+        return parse(body);
+      } catch {
+        throw { statusCode: 400, statusMessage: "Bad Request" };
+      }
+    },
+  );
+}
+
+function edgeWrite(id = "e1") {
+  return mockBatchSet.mock.calls.find((call) => call[0] === `edges/${id}`)?.[1];
+}
+
+function revisionWrite() {
+  return mockBatchSet.mock.calls.find((call) =>
+    String(call[0]).startsWith("revisions/"),
+  )?.[1] as Record<string, unknown> | undefined;
+}
+
+function auditEntry() {
+  return mockBatchSet.mock.calls.find((call) =>
+    String(call[0]).startsWith("audit/"),
+  )?.[1] as Record<string, unknown> | undefined;
+}
+
+/** A relation as `/api/edges/delete` leaves it. */
+function removedEdge(extra: Record<string, unknown> = {}) {
+  return {
+    source: "a",
+    target: "b",
+    type: "employed",
+    name: "Zarząd",
+    deleted: true,
+    delete_reason: "Błędnie scalona osoba",
+    published: false,
+    stats: { count: 3 },
+    revision_id: { path: "revisions/removal" },
+    ...extra,
+  };
+}
+
+describe("api/edges/restore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stored = {};
+    generated = 0;
+    globalThis.useStorage = () => ({ clear: mockCacheClear }) as never;
+    request({ edge_id: "e1" });
+    stored["edges/e1"] = removedEdge();
+  });
+
+  it("takes the removal off the relation", async () => {
+    const result = await handler({} as never);
+
+    const write = edgeWrite();
+    expect(write).toMatchObject({ source: "a", target: "b", name: "Zarząd" });
+    expect(mockCommit).toHaveBeenCalled();
+    expect(result).toMatchObject({ edge_id: "e1", restored: true });
+  });
+
+  it("leaves no `deleted` key at all rather than writing false", async () => {
+    // The sharpest hazard here. Every reader tests `=== true` / `!== true`, so
+    // `false` would look identical to them - but `applyRevision` layers the
+    // stored value over the revision it is applying, so a document carrying
+    // `deleted: false` would silently cancel the next approved removal.
+    await handler({} as never);
+
+    const write = edgeWrite() as Record<string, unknown>;
+    expect("deleted" in write).toBe(false);
+    expect("delete_reason" in write).toBe(false);
+  });
+
+  it("does not put the relation back on the public site", async () => {
+    // The removal set `published: false` and the value it had before that is
+    // recorded nowhere, so guessing would be the one way this could re-expose
+    // something nobody reviewed. It comes back as a draft.
+    const result = await handler({} as never);
+
+    expect(edgeWrite()).toMatchObject({ published: false });
+    expect(result.published).toBe(false);
+  });
+
+  it("repoints revision_id away from the removal revision", async () => {
+    // Left where it was, re-approving it from /admin/rewizje would delete the
+    // relation again, and /api/revisions/reject refuses to retire the revision
+    // a document points at.
+    const result = await handler({} as never);
+
+    expect(revisionWrite()).toMatchObject({
+      node_id: "e1",
+      collection: "edges",
+      status: "approved",
+      update_user: "admin-uid",
+    });
+    expect(edgeWrite()).toMatchObject({
+      revision_id: expect.objectContaining({ id: result.revision_id }),
+    });
+  });
+
+  it("does not carry the removal's reason into the new revision", async () => {
+    // The revision states the relation as it was and says nothing about the
+    // removal - which is what retracting one looks like in a history somebody
+    // reads back later.
+    await handler({} as never);
+
+    const data = revisionWrite()?.data as Record<string, unknown>;
+    expect(data).toMatchObject({ source: "a", target: "b" });
+    expect("delete_reason" in data).toBe(false);
+    expect("deleted" in data).toBe(false);
+  });
+
+  it("keeps the counters the document owns", async () => {
+    await handler({} as never);
+
+    expect(edgeWrite()).toMatchObject({ stats: { count: 3 } });
+  });
+
+  it("files the restoration in the audit log, with no reason of its own", async () => {
+    await handler({} as never);
+
+    const entry = auditEntry() as Record<string, unknown>;
+    expect(entry).toMatchObject({
+      action: "restore",
+      collection: "edges",
+      target_id: "e1",
+      user: "admin-uid",
+    });
+    expect("reason" in entry).toBe(false);
+  });
+
+  it("clears the handler cache so the page draws it again", async () => {
+    await handler({} as never);
+
+    expect(mockCacheClear).toHaveBeenCalledWith("nitro:handlers");
+  });
+
+  it("is idempotent on a relation that was never removed", async () => {
+    stored["edges/e1"] = { source: "a", target: "b", published: true };
+
+    const result = await handler({} as never);
+
+    expect(result).toEqual({
+      edge_id: "e1",
+      restored: true,
+      revision_id: null,
+      published: true,
+    });
+    expect(mockCommit).not.toHaveBeenCalled();
+  });
+
+  it("refuses an id that names no relation", async () => {
+    stored = {};
+
+    await expect(handler({} as never)).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("refuses a caller who is not an admin", async () => {
+    vi.mocked(requireAdmin).mockRejectedValueOnce({ statusCode: 403 });
+
+    await expect(handler({} as never)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+});


### PR DESCRIPTION
Every administrator decision has been filed to `audit` since the collection was invented, and exactly one thing read it back: `collectAdminDecisions`, which selects `user` and `at` and throws the rest away to count contributions. So the log recorded who did something and when, and nothing anywhere said what. That was tolerable while approving and publishing were the only decisions; a removal that cannot be seen or undone is not.

/admin/audyt is the other half - what was decided, about which entry, and why - and a Przywróć button on the removals.

The restore is the exact mirror of the removal, and has to be: `deleted` and `delete_reason` are fields the document owns, so `createRevisionTransaction` layers whatever `stored` says for them back over the revision. Withholding both lets this write settle them, and because the target write is a full `set` the document comes back with neither key rather than with `deleted: false` - which would read identically to every current reader and then silently cancel the next removal somebody approved, since `applyRevision` layers the stored value over the revision it is applying.

It comes back as a draft. The removal set `published: false` and what it was before that is recorded nowhere, so republishing would be a guess about whether the public should see it again; the relation re-enters the queue at /admin/krawedzie instead, where that decision already lives. Note a draft is not invisible - signed-in readers are shown drafts - so the relation returns to an admin's own view of the page at once. The dialog, the notice and the QA entry all say so; the previous version of the removal dialog said no screen could undo a removal, which this makes false.

The log pages on `(at, __name__)` rather than on `at`. Both keys descending is the shape of the automatic single-field index, so it needs no composite index - `audit` has none and index deploys here are manual - and the second key is what makes the cursor exact. `at` is stamped per `recordAudit` call and publishing a hundred relations files up to two hundred rows inside one synchronous loop, tens of them on the same millisecond; a cursor that could only name a timestamp stepped over whatever did not fit the page, and the rows were unreachable afterwards. The `action` filter runs in memory over a bounded scan for the same index reason, and the cursor follows what was examined rather than what was returned, so filtering for a rare decision keeps paging instead of reporting the log empty.

`edgeTypeLabels` moved to `shared/edges.ts`. The log names a relation server-side, and importing it from `app/composables/edges.ts` pulled that module's Nuxt auto-imports into the server build.