### PR TITLE
Leave the revision preview behind when the search navigates away

### DIFF
--- a/frontend/app/components/OmniSearch.vue
+++ b/frontend/app/components/OmniSearch.vue
@@ -83,6 +83,7 @@ import {
 } from "@mdi/js";
 import { parties } from "~~/shared/misc";
 import { generateEntityUrl } from "~/composables/slugs";
+import { omniSearchTarget } from "~/composables/omniSearch";
 import type { NodeType } from "~~/shared/model";
 import type { ProposableNodeType } from "~~/shared/api";
 import { refDebounced } from "@vueuse/core";
@@ -275,28 +276,7 @@ watch(nodeGroupPicked, (value) => {
     return;
   }
 
-  let path = value?.path ?? currentRoute.value.path;
-  const allowedPath =
-    path == "/graf" ||
-    path.startsWith("/eksploruj/tabela") ||
-    path.startsWith("/entity/person/") ||
-    path.startsWith("/entity/region/teryt1261") ||
-    path.startsWith("/region/krakow-teryt1261") ||
-    path.startsWith("/osoba/") ||
-    path.startsWith("/instytucja/") ||
-    path.startsWith("/region/") ||
-    path.startsWith("/artykul/") ||
-    path.startsWith("/edit/");
-  if (!allowedPath) {
-    path = "/eksploruj/tabela";
-  }
-  push({
-    path: path,
-    query: {
-      ...currentRoute.value.query,
-      ...value.query,
-    },
-  });
+  push(omniSearchTarget(currentRoute.value, value));
   autocompleteFocus.value = false;
 });
 </script>

--- a/frontend/app/composables/omniSearch.ts
+++ b/frontend/app/composables/omniSearch.ts
@@ -1,0 +1,59 @@
+/** What picking an OmniSearch result means for the url.
+ *
+ * Kept out of the component so the rule below - which query survives a pick -
+ * can be tested without a router: the component reaches for Nuxt's own router,
+ * not the one a component test installs, so anything decided inside the watcher
+ * is only observable through a real navigation.
+ */
+
+import type { LocationQueryRaw } from "vue-router";
+
+export type OmniSearchPick = {
+  /** Where the entry leads. Absent for an entry that only narrows the current
+   * page, which then stays where it is. */
+  path?: string;
+  query?: Record<string, string>;
+};
+
+type RouteLike = {
+  path: string;
+  query: LocationQueryRaw;
+};
+
+/** Pages a result may open. Anything else - an admin screen, a profile - is not
+ * a place to show a search hit, so the pick falls back to the table. */
+function isAllowedPath(path: string): boolean {
+  return (
+    path == "/graf" ||
+    path.startsWith("/eksploruj/tabela") ||
+    path.startsWith("/entity/person/") ||
+    path.startsWith("/entity/region/teryt1261") ||
+    path.startsWith("/region/krakow-teryt1261") ||
+    path.startsWith("/osoba/") ||
+    path.startsWith("/instytucja/") ||
+    path.startsWith("/region/") ||
+    path.startsWith("/artykul/") ||
+    path.startsWith("/edit/")
+  );
+}
+
+/** Where picking `pick` takes a visitor currently at `current`. */
+export function omniSearchTarget(
+  current: RouteLike,
+  pick: OmniSearchPick,
+): { path: string; query: LocationQueryRaw } {
+  const path = pick.path ?? current.path;
+  // The filters in the url only survive a pick that keeps us on the same page -
+  // picking a party while the table is open. Carrying them across meant the
+  // `revisionId` of a profile opened from the revision queue followed a search
+  // to the next profile, which then rendered the previous person's proposal on
+  // top of it, so the search looked like it had not navigated at all.
+  const staysOnPage = !pick.path || pick.path === current.path;
+
+  return {
+    path: isAllowedPath(path) ? path : "/eksploruj/tabela",
+    query: staysOnPage
+      ? { ...current.query, ...pick.query }
+      : { ...pick.query },
+  };
+}

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,26 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "omnisearch-opuszcza-podglad-rewizji",
+    title: "Wyszukiwarka wychodzi z podglądu rewizji",
+    description:
+      "Profil otwarty z kolejki rewizji albo z „Moich propozycji” ma w adresie " +
+      "parametr rewizji i pokazuje proponowane zmiany nałożone na dane osoby. " +
+      "Wyszukanie kogoś innego przenosiło ten parametr na nowy adres, więc na " +
+      "profilu kolejnej osoby dalej widać było poprzednią rewizję - wyglądało " +
+      "to tak, jakby wyszukiwarka w ogóle nie przeszła dalej. Filtry z adresu " +
+      "zostają teraz tylko wtedy, gdy wybór z listy nie zmienia strony, na " +
+      "przykład przy wyborze partii w tabeli.",
+    steps: [
+      "Otwórz profil dowolnej osoby w podglądzie rewizji - z panelu rewizji albo z „Moich propozycji” w swoim profilu. U góry strony jest wtedy niebieska informacja o podglądzie propozycji.",
+      "W wyszukiwarce na górze wpisz nazwisko innej osoby i wybierz ją z listy.",
+      "Sprawdź, że otworzył się profil wybranej osoby, bez paska podglądu rewizji, i że w adresie nie ma już parametru revisionId.",
+      "Wejdź na /eksploruj/tabela, ustaw dowolny filtr, a potem wybierz partię z wyszukiwarki - poprzedni filtr ma zostać.",
+    ],
+    link: "/profil",
+    area: "contributor",
+  },
+  {
     id: "szpitale-jeden-wykres-trzy-podzialy",
     title:
       "Szpitale: jeden wykres zamiast trzech, przełączany na partie, województwa albo szpitale",

--- a/frontend/tests/composables/omniSearch.test.ts
+++ b/frontend/tests/composables/omniSearch.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { omniSearchTarget } from "../../app/composables/omniSearch";
+
+describe("omniSearchTarget", () => {
+  // A profile opened from the revision queue carries `?revisionId=`, and the
+  // view renders that revision on top of the node. A search made from there has
+  // to leave it behind, or the next profile shows the previous person's
+  // proposal and the search looks like it never navigated.
+  it("drops the current query when the pick leads to another page", () => {
+    expect(
+      omniSearchTarget(
+        { path: "/osoba/jan-kowalski-1", query: { revisionId: "rev1" } },
+        { path: "/osoba/anna-nowak-2" },
+      ),
+    ).toEqual({ path: "/osoba/anna-nowak-2", query: {} });
+  });
+
+  it("keeps the current query when the pick refines the same page", () => {
+    expect(
+      omniSearchTarget(
+        { path: "/eksploruj/tabela", query: { miejsce: "krakow" } },
+        { path: "/eksploruj/tabela", query: { party: "PiS" } },
+      ),
+    ).toEqual({
+      path: "/eksploruj/tabela",
+      query: { miejsce: "krakow", party: "PiS" },
+    });
+  });
+
+  it("stays put, filters and all, for a pick with no path of its own", () => {
+    expect(
+      omniSearchTarget(
+        { path: "/graf", query: { partia: "PiS" } },
+        { query: { miejsce: "krakow" } },
+      ),
+    ).toEqual({ path: "/graf", query: { partia: "PiS", miejsce: "krakow" } });
+  });
+
+  it("sends a pick the site cannot show to the table", () => {
+    expect(
+      omniSearchTarget(
+        { path: "/admin/rewizje/node1", query: { revisionId: "rev1" } },
+        { path: "/admin/rewizje/node2" },
+      ),
+    ).toEqual({ path: "/eksploruj/tabela", query: {} });
+  });
+});


### PR DESCRIPTION
A profile opened from the revision queue carries `?revisionId=` and renders that proposal on top of the node. OmniSearch merged the current query into every push, so searching for somebody else from there took the parameter along: the next profile came up with the previous person's revision laid over it, and the search looked like it had not navigated at all.

The merge is there for the picks that only narrow the page you are on - a party while the table is open - so keep it for those and drop it when the pick leads somewhere else. The rule moved into `omniSearchTarget`, because the component reaches for Nuxt's own router rather than the one a component test installs, which is why the existing navigation test is skipped.