### PR TITLE
Stop counting a migration script as a contributor

### DIFF
--- a/frontend/server/utils/activityRollup.ts
+++ b/frontend/server/utils/activityRollup.ts
@@ -37,8 +37,8 @@ export type DailyRollup = {
   /** `YYYY-MM-DD`, UTC. Also the document id. */
   date: string;
   totals: ActivityCounts;
-  /** Per contributor, for the day. Pipeline uids are already filtered out by
-   * `aggregateActivity`, so nothing in here is a robot. */
+  /** Per contributor, for the day. Pipeline and migration uids are already
+   * filtered out by `aggregateActivity`, so nothing in here is a robot. */
   contributors: Record<
     string,
     { counts: ActivityCounts; lastActiveAt: string }
@@ -56,8 +56,9 @@ export type DailyRollup = {
  * different version is recomputed and overwritten.
  *
  * 1: excludes automatic revisions and article-node bookkeeping.
+ * 2: excludes the `migration:*` scripts as well as the pipeline.
  */
-const ROLLUP_VERSION = 1;
+const ROLLUP_VERSION = 2;
 
 const COLLECTION = "activityDaily";
 
@@ -122,7 +123,7 @@ export function dayEndIso(day: string): string {
  *
  * Goes through `aggregateActivity` rather than counting here, so a stored day
  * and a live one are produced by the same code - including which uids are
- * dropped as pipelines and how a note's several sources are counted.
+ * dropped as robots and how a note's several sources are counted.
  */
 export function rollupForDay(
   date: string,

--- a/frontend/server/utils/activityStats.ts
+++ b/frontend/server/utils/activityStats.ts
@@ -4,7 +4,7 @@ import {
   type ActivityCounts,
   type ActivityKind,
 } from "~~/shared/activity";
-import { isPipelineUid } from "~~/shared/stats";
+import { isAutomatedUid, isPipelineUid } from "~~/shared/stats";
 
 /** One thing a human did, normalized out of whichever collection recorded it.
  *
@@ -44,12 +44,15 @@ export type ActivityAggregate = {
   contributors: ContributorAggregate[];
 };
 
-/** Writes the pipeline makes on a person's behalf. They dwarf everything a
- * human does and would turn the page into a chart of one robot's day.
+/** Writes the site makes on a person's behalf - the scoring pipeline's, and a
+ * migration script's. They dwarf everything a human does and would turn the
+ * page into a chart of one robot's day: `migration:merge-duplicate-people` filed
+ * 1,081 revisions on 2026-08-31 in the minutes one run took, more than every
+ * human revision in the export bar the owner's.
  *
  * Defined next to the vote aggregate that has to draw the same line, and
  * re-exported here because the activity page drew it first. */
-export { isPipelineUid };
+export { isAutomatedUid, isPipelineUid };
 
 /** The UTC day an instant falls on, or null if it cannot be read as one. */
 export function utcDay(at: string | null | undefined): string | null {
@@ -96,7 +99,7 @@ export function aggregateActivity(
   const totals = emptyActivityCounts();
 
   for (const event of events) {
-    if (isPipelineUid(event.uid)) continue;
+    if (isAutomatedUid(event.uid)) continue;
     const day = utcDay(event.at);
     if (!day || !inWindow.has(day)) continue;
 

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,28 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "statystyki-bez-migracji",
+    title: "Statystyki nie liczą migracji jako czyjejś pracy",
+    description:
+      "Skrypty migracyjne podpisują swoje zapisy własną nazwą, żeby dało się " +
+      "sprawdzić, który przebieg co zmienił. Na wykresie aktywności wyglądało " +
+      "to jak dzień pracy jednego człowieka: scalanie duplikatów osób zapisało " +
+      "31 sierpnia 1081 propozycji zmian w kilka minut i przykryło sobą " +
+      "wszystko, co zrobili ludzie. Teraz zapisy skryptów nie liczą się wcale " +
+      "- tak samo jak od dawna nie liczą się oceny wystawione przez modele. " +
+      "Same zmiany zostają w bazie i w historii strony, znikają tylko z " +
+      "rankingu i z wykresu.",
+    steps: [
+      "Otwórz /eksploruj/statystyki z zakresem 30 dni. W „Kto tworzy koryta.pl” nikt nie powinien mieć kilkuset zmian z jednego dnia.",
+      "Popatrz na wykres dzienny: 31 sierpnia ma być zwykłym dniem, a nie słupkiem kilkadziesiąt razy wyższym od pozostałych.",
+      "Sprawdź kafelek „Propozycja zmiany”: liczba ma być porównywalna z tym, co widać przy zakresie 7 dni, a nie o rząd wielkości większa.",
+      "Sprawdź, że Twój własny wiersz i Twoja pozycja w rankingu się nie zmieniły.",
+      "Wejdź na stronę scaloną (taką z przekierowaniem do drugiej osoby) i sprawdź, że historia zmian nadal pokazuje, co zrobiła migracja.",
+    ],
+    link: "/eksploruj/statystyki",
+    area: "public",
+  },
+  {
     id: "osoba-rozpoznawana-po-rejestrze",
     title: "Upload rozpoznaje osobę po wpisie w rejestrze, nie po imieniu",
     description:

--- a/frontend/shared/stats.ts
+++ b/frontend/shared/stats.ts
@@ -104,6 +104,38 @@ export function isPipelineUid(uid: string | undefined | null): boolean {
   return !!uid && uid.includes("pipeline");
 }
 
+/** Whether a write was made by a one-time migration script rather than by a
+ * person.
+ *
+ * Every script under `scripts/migrate/` that files revisions or audit entries
+ * signs them `migration:<script-name>` - see `AUTHOR` in
+ * `merge-duplicate-people.ts` and its neighbours. Matching on the prefix is
+ * safe for the same reason `isPipelineUid` matches on a substring: a Firebase
+ * uid is 28 random alphanumerics and cannot contain a colon.
+ *
+ * The signature is deliberate and worth keeping. A merge, a category backfill
+ * or a date repair is a change somebody has to be able to trace, and the uid is
+ * what says which run made it - so these writes are attributed, not anonymous.
+ * What they are not is somebody's afternoon: one run of
+ * `merge-duplicate-people` files a revision per collapsed relation and an audit
+ * entry per merged page, all inside a few minutes - 1,081 revisions on
+ * 2026-08-31, against 160 for the second-busiest human in the whole export.
+ */
+export function isMigrationUid(uid: string | undefined | null): boolean {
+  return !!uid && uid.startsWith("migration:");
+}
+
+/** Whether a uid is one the site writes under itself, rather than a person.
+ *
+ * The union of the two, for the places that are counting *work people did* and
+ * have no reason to tell one kind of robot from the other. The vote aggregate
+ * is not one of them: it needs the pipeline's verdicts specifically, which is
+ * why it still asks `isPipelineUid`.
+ */
+export function isAutomatedUid(uid: string | undefined | null): boolean {
+  return isPipelineUid(uid) || isMigrationUid(uid);
+}
+
 /**
  * The vote aggregate stored on a node: what people said, plus the pipeline's
  * best guess.

--- a/frontend/tests/server/utils/activityRollup.test.ts
+++ b/frontend/tests/server/utils/activityRollup.test.ts
@@ -260,7 +260,7 @@ describe("ensureDailyRollups", () => {
   it("reads a stored day instead of counting it again", async () => {
     const db = fakeDb({
       "activityDaily/2026-08-19": {
-        version: 1,
+        version: 2,
         date: "2026-08-19",
         totals: { nodeVote: 4 },
         truncated: [],
@@ -327,7 +327,7 @@ describe("ensureDailyRollups", () => {
     // 20th for nothing.
     const db = fakeDb({
       "activityDaily/2026-08-20": {
-        version: 1,
+        version: 2,
         date: "2026-08-20",
         totals: {},
         contributors: {},
@@ -355,12 +355,13 @@ describe("ensureDailyRollups", () => {
   });
 
   it("recounts a day that was stored under an older counting rule", async () => {
-    // The rule changed - article nodes and bulk edge publications stopped
-    // counting - so a day counted under the old one has to be thrown away, or
-    // the fix would only ever apply to days nobody had looked at yet.
+    // The rule changed - article nodes, bulk edge publications and the
+    // migration scripts stopped counting - so a day counted under the old one
+    // has to be thrown away, or the fix would only ever apply to days nobody
+    // had looked at yet.
     const db = fakeDb({
       "activityDaily/2026-08-19": {
-        version: 0,
+        version: 1,
         date: "2026-08-19",
         totals: { revision: 999 },
         contributors: {},

--- a/frontend/tests/server/utils/activityStats.test.ts
+++ b/frontend/tests/server/utils/activityStats.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   aggregateActivity,
   daysBetween,
+  isAutomatedUid,
   isPipelineUid,
   utcDay,
   type ActivityEvent,
 } from "../../../server/utils/activityStats";
+import { isMigrationUid } from "../../../shared/stats";
 
 const WINDOW = { since: "2026-07-30", until: "2026-08-01" };
 
@@ -61,6 +63,29 @@ describe("isPipelineUid", () => {
   it("leaves people alone", () => {
     expect(isPipelineUid("aB3xYz")).toBe(false);
     expect(isPipelineUid(null)).toBe(false);
+  });
+});
+
+describe("isMigrationUid", () => {
+  it("matches what a migration script signs its writes with", () => {
+    expect(isMigrationUid("migration:merge-duplicate-people")).toBe(true);
+    expect(isMigrationUid("migration:apply-company-categories")).toBe(true);
+  });
+
+  it("leaves people alone", () => {
+    // A Firebase uid is 28 alphanumerics; the colon is what makes the prefix
+    // unambiguous, so a name that merely starts with the word is not one.
+    expect(isMigrationUid("migrationHelper")).toBe(false);
+    expect(isMigrationUid("aB3xYz")).toBe(false);
+    expect(isMigrationUid(null)).toBe(false);
+  });
+});
+
+describe("isAutomatedUid", () => {
+  it("covers both kinds of robot", () => {
+    expect(isAutomatedUid("pipeline-pagerank")).toBe(true);
+    expect(isAutomatedUid("migration:merge-duplicate-people")).toBe(true);
+    expect(isAutomatedUid("aB3xYz")).toBe(false);
   });
 });
 
@@ -154,6 +179,32 @@ describe("aggregateActivity", () => {
 
     expect(result.totals.revision).toBe(1);
     expect(result.contributors).toHaveLength(1);
+  });
+
+  it("drops a migration script's writes", () => {
+    // `merge-duplicate-people` files a revision per collapsed relation and an
+    // audit entry per merged page, all in one run - 1,081 revisions on
+    // 2026-08-31 in production. None of it is a day somebody had.
+    const result = aggregateActivity(
+      [
+        event(
+          "migration:merge-duplicate-people",
+          "revision",
+          "2026-07-31T08:00:00.000Z",
+        ),
+        event(
+          "migration:merge-duplicate-people",
+          "adminDecision",
+          "2026-07-31T08:00:01.000Z",
+        ),
+        event("u1", "revision", "2026-07-31T08:00:00.000Z"),
+      ],
+      WINDOW,
+    );
+
+    expect(result.totals.revision).toBe(1);
+    expect(result.totals.adminDecision).toBe(0);
+    expect(result.contributors.map((c) => c.uid)).toEqual(["u1"]);
   });
 
   it("drops events outside the window instead of clamping them in", () => {


### PR DESCRIPTION
The activity section of /eksploruj/statystyki dropped uids containing "pipeline" and nothing else, so the migration scripts under scripts/migrate/ counted as people. They sign their writes migration:<script-name> on purpose - a merge or a backfill is a change somebody has to be able to trace back to the run that made it - but the signature is not somebody's afternoon.

merge-duplicate-people filed 1,081 revisions on 2026-08-31 in the few minutes one run took, against 160 for the second-busiest human in the whole export, plus an audit entry per merged page. Measured against the 2026-08-31 export: the 31st read 1,147 events with a 1,081-event contributor at the top of the ranking, and reads 66 without it.

The other two migrations in the export happened to write update_automatic: true and were already dropped; merge-duplicate-people writes false, because what it files is an approved change and not bookkeeping. So the automatic flag was never the line to draw - the author is.

isAutomatedUid is the union of the two robots, for the places counting work people did. computeVoteStats keeps asking isPipelineUid: it needs the models' verdicts specifically.

ROLLUP_VERSION goes to 2 so the days already stored under the old rule are recounted rather than carrying the spike forever.