### PR TITLE
Drop the trailing blank line that reddened the format job

### DIFF
--- a/frontend/app/components/OmniSearch.vue
+++ b/frontend/app/components/OmniSearch.vue
@@ -308,4 +308,3 @@ watch(nodeGroupPicked, (value) => {
   transform: rotate(0deg) !important;
 }
 </style>
-


### PR DESCRIPTION
prettier 3.9.6 trims it; main has been failing Format and Typecheck (TS) since the edge-revisions-not-nodes merge, which went in red.