### PR TITLE
Ask for the scopes the storage client would have asked for

### DIFF
--- a/.github/workflows/gcp-auth-probe.yml
+++ b/.github/workflows/gcp-auth-probe.yml
@@ -72,8 +72,11 @@ jobs:
       - name: gcloud, same credentials
         continue-on-error: true
         run: |
-          gcloud auth list
-          gcloud storage ls gs://koryta-pl-crawled --limit 3
+          # `gcloud auth list` reads gcloud's own credential store, which
+          # ADC is not part of -- it says "No credentialed accounts" even when
+          # the calls below work. Not a signal either way.
+          gcloud storage ls gs://koryta-pl-crawled > /tmp/ls.txt
+          head -3 /tmp/ls.txt
 
       # google-auth builds the generateAccessToken body as
       #   {"delegates": [], "scope": <scopes>, "lifetime": "<n>s"}

--- a/data/pipelines/src/stores/storage.py
+++ b/data/pipelines/src/stores/storage.py
@@ -36,7 +36,21 @@ _GCS_POOL_SIZE = 256  # generous cap; pool is lazy so unused slots cost nothing
 
 
 def _make_gcs_client() -> storage.Client:
-    credentials, project = google.auth.default()
+    # Scopes have to be named here. Passing `credentials=` and `_http=` to
+    # storage.Client skips the with_scopes_if_required() it would otherwise do
+    # for itself, so whatever google.auth.default() returns is what gets used.
+    #
+    # Unscoped is harmless for a service-account key or a gcloud user login --
+    # neither needs a scope to mint a token, which is why this only ever broke
+    # on CI. Under Workload Identity Federation the credentials are impersonated,
+    # and google-auth sends the scopes as the `scope` field of the
+    # generateAccessToken body; empty, IAM rejects the call as
+    #
+    #   RefreshError: ('Unable to acquire impersonated credentials',
+    #     {"code": 400, "message": "Request contains an invalid argument."})
+    #
+    # which is what every nightly run did from the first one on 2026-07-31.
+    credentials, project = google.auth.default(scopes=storage.Client.SCOPE)
     session = google.auth.transport.requests.AuthorizedSession(credentials)
     adapter = requests.adapters.HTTPAdapter(
         pool_connections=_GCS_POOL_SIZE, pool_maxsize=_GCS_POOL_SIZE

--- a/data/pipelines/src/stores/test_storage.py
+++ b/data/pipelines/src/stores/test_storage.py
@@ -1,0 +1,46 @@
+import pytest
+from google.cloud import storage
+
+from stores.storage import _make_gcs_client
+
+
+def test_the_gcs_client_asks_for_scopes(monkeypatch: pytest.MonkeyPatch):
+    """Credentials with no scopes cannot be impersonated.
+
+    Passing `credentials=` and `_http=` to storage.Client skips the
+    with_scopes_if_required() it does for itself, so google.auth.default() has
+    to be asked for the scopes directly. Nothing local notices -- a
+    service-account key and a gcloud login both mint tokens without a scope --
+    but under Workload Identity Federation google-auth puts the scopes in the
+    `scope` field of the generateAccessToken body, and IAM rejects an empty one
+    with a 400. Every nightly run between 2026-07-31 and 2026-09-01 died there.
+    """
+    asked: dict[str, object] = {}
+    expected = storage.Client.SCOPE
+
+    class FakeSession:
+        def mount(self, prefix: str, adapter: object) -> None:
+            pass
+
+    class FakeClient:
+        # The real one carries it, and the code under test reads it.
+        SCOPE = expected
+
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+    def fake_default(*args: object, **kwargs: object):
+        asked.update(kwargs)
+        return object(), "koryta-pl"
+
+    monkeypatch.setattr("stores.storage.google.auth.default", fake_default)
+    monkeypatch.setattr(
+        "stores.storage.google.auth.transport.requests.AuthorizedSession",
+        lambda credentials: FakeSession(),
+    )
+    monkeypatch.setattr("stores.storage.storage.Client", FakeClient)
+
+    _make_gcs_client()
+
+    assert asked.get("scopes"), "google.auth.default() was called without scopes"
+    assert set(asked["scopes"]) == set(expected)  # type: ignore[arg-type]


### PR DESCRIPTION
The nightly has never once been green: all 32 scheduled runs since 2026-07-31 died on

  RefreshError: ('Unable to acquire impersonated credentials',
    {"code": 400, "message": "Request contains an invalid argument."})

which is IAM rejecting a generateAccessToken whose `scope` is empty. Not a missing role -- that answers 403 -- and not the pool, which the probe run on 33452044648 showed working: with cloud-platform named, the same credentials refresh and list the bucket.

_make_gcs_client passes credentials= and _http= to storage.Client, which skips the with_scopes_if_required() it would otherwise do for itself, so the unscoped result of google.auth.default() was what reached IAM. Locally nothing notices, because neither a service-account key nor a gcloud login needs a scope to mint a token -- only impersonation does, which is why this was invisible outside CI.

storage.Client.SCOPE rather than a literal: those are the scopes the client would have requested, and the probe listed blobs with exactly them.

The probe's gcloud step was wrong in two ways and proved nothing -- `gcloud storage ls` has no --limit, and `gcloud auth list` does not see ADC. Corrected so it is worth running if this recurs.