### PR TITLE
Count what people do on the site, and leave room to A/B the home page

### DIFF
--- a/frontend/app/components/OmniSearch.vue
+++ b/frontend/app/components/OmniSearch.vue
@@ -88,8 +88,7 @@ import { generateEntityUrl } from "~/composables/slugs";
 import { omniSearchTarget } from "~/composables/omniSearch";
 import { trackGoal } from "~/composables/analytics";
 import {
-  SEARCH_PICK_GOALS,
-  SEARCH_PROPOSE_GOALS,
+  resultBucket,
   searchPickKind,
   type SearchPickKind,
 } from "~~/shared/analytics";
@@ -155,9 +154,9 @@ const createType = ref<ProposableNodeType>("person");
 const openCreate = async (type: CreatableFromSearch) => {
   // Recorded before the dialog opens, because this is the interesting event on
   // its own: it says the search could not answer, and what the reader was
-  // willing to add instead. Whether they went on to submit is a different
-  // question, and one the revision queue already answers.
-  trackGoal(SEARCH_PROPOSE_GOALS[type], { query: createName.value });
+  // willing to add instead. The typed name is not recorded - it is somebody's
+  // name, and `kind` is the part that is about the site.
+  trackGoal("search:propose", { kind: type });
   pendingCreateName.value = createName.value;
   createType.value = type;
   // The dialog is keyed by type, so it is a different component instance once
@@ -238,12 +237,10 @@ async function performSearch(searchTerm: string) {
     searchData.value = response;
     // Counted here rather than on every keystroke: `debouncedSearch` is what
     // reaches the server, so this is one event per query a reader actually
-    // waited for, and the two goals are directly comparable - the gap between
-    // them is the share of searches the index cannot answer.
-    trackGoal("search:performed");
-    if (response.length === 0) {
-      trackGoal("search:no-results", { query: searchTerm });
-    }
+    // waited for. The count is bucketed and the query itself is not sent -
+    // `results: none` against the total is the share of searches the index
+    // cannot answer, which is the whole question.
+    trackGoal("search:performed", { results: resultBucket(response.length) });
   } catch (error) {
     // A search that fails should offer nothing rather than spin forever.
     console.error("Search failed", error);
@@ -326,9 +323,7 @@ watch(nodeGroupPicked, (value) => {
   // reader with something in mind, the other is a reader giving up on typing.
   // Defaulted, because the value arrives from VAutocomplete's model and a test
   // may hand over a partial entry.
-  trackGoal(SEARCH_PICK_GOALS[value.analyticsKind ?? "place"], {
-    title: value.title,
-  });
+  trackGoal("search:pick", { kind: value.analyticsKind ?? "place" });
   push(omniSearchTarget(currentRoute.value, value));
   autocompleteFocus.value = false;
 });

--- a/frontend/app/components/OmniSearch.vue
+++ b/frontend/app/components/OmniSearch.vue
@@ -86,6 +86,13 @@ import { parties } from "~~/shared/misc";
 import { nameMatchesTokens, searchTokens } from "~~/shared/search";
 import { generateEntityUrl } from "~/composables/slugs";
 import { omniSearchTarget } from "~/composables/omniSearch";
+import { trackGoal } from "~/composables/analytics";
+import {
+  SEARCH_PICK_GOALS,
+  SEARCH_PROPOSE_GOALS,
+  searchPickKind,
+  type SearchPickKind,
+} from "~~/shared/analytics";
 import type { NodeType } from "~~/shared/model";
 import type { ProposableNodeType } from "~~/shared/api";
 import { refDebounced } from "@vueuse/core";
@@ -135,12 +142,22 @@ const createOptions = [
   { type: "article" as const, label: "Dodaj źródło", icon: mdiFilePlusOutline },
 ];
 
+/** The subset of ProposableNodeType the search box actually offers. Narrower
+ * than the dialog's own type on purpose: a goal exists for each of these three,
+ * and a fourth added to `createOptions` should not compile until it has one. */
+type CreatableFromSearch = (typeof createOptions)[number]["type"];
+
 // Captured on click, because opening the dialog blurs the autocomplete, which
 // can reset `search` before the dialog reads the name to prefill.
 const pendingCreateName = ref("");
 const createType = ref<ProposableNodeType>("person");
 
-const openCreate = async (type: ProposableNodeType) => {
+const openCreate = async (type: CreatableFromSearch) => {
+  // Recorded before the dialog opens, because this is the interesting event on
+  // its own: it says the search could not answer, and what the reader was
+  // willing to add instead. Whether they went on to submit is a different
+  // question, and one the revision queue already answers.
+  trackGoal(SEARCH_PROPOSE_GOALS[type], { query: createName.value });
   pendingCreateName.value = createName.value;
   createType.value = type;
   // The dialog is keyed by type, so it is a different component instance once
@@ -181,7 +198,11 @@ type ListItem = {
   title: string;
   subtitle?: string;
   icon: string;
-  logEventKey: { content_id: string; content_type: string };
+  /** Which search:pick-* goal this entry converts, set where the entry is
+   * built. It replaces a `logEventKey` that carried content_id/content_type for
+   * an analytics call that no longer existed - nothing read it, so every hit
+   * was describing itself to nobody. */
+  analyticsKind: SearchPickKind;
   path?: string;
   query?: Record<string, string>;
 };
@@ -215,6 +236,14 @@ async function performSearch(searchTerm: string) {
       },
     });
     searchData.value = response;
+    // Counted here rather than on every keystroke: `debouncedSearch` is what
+    // reaches the server, so this is one event per query a reader actually
+    // waited for, and the two goals are directly comparable - the gap between
+    // them is the share of searches the index cannot answer.
+    trackGoal("search:performed");
+    if (response.length === 0) {
+      trackGoal("search:no-results", { query: searchTerm });
+    }
   } catch (error) {
     // A search that fails should offer nothing rather than spin forever.
     console.error("Search failed", error);
@@ -238,10 +267,7 @@ const items = computed<ListItem[]>(() => {
     title: "Lista wszystkich osób",
     icon: mdiFormatListBulletedType,
     path: "/eksploruj/tabela",
-    logEventKey: {
-      content_id: "",
-      content_type: "nodeGroup",
-    },
+    analyticsKind: "list",
   });
 
   parties.forEach((item) => {
@@ -254,10 +280,7 @@ const items = computed<ListItem[]>(() => {
       query: {
         party: item,
       },
-      logEventKey: {
-        content_id: item,
-        content_type: "party",
-      },
+      analyticsKind: "party",
     });
   });
 
@@ -281,10 +304,9 @@ const items = computed<ListItem[]>(() => {
         id: `entity-${item.id}`,
         title: item.name,
         icon,
-        logEventKey: {
-          content_id: item.id!,
-          content_type: "nodeGroup",
-        },
+        // The type /api/search returned, not the url it produced: a company
+        // with a krs filter and a company page both mean "place".
+        analyticsKind: searchPickKind(itemType),
         ...routing,
       });
     });
@@ -298,6 +320,15 @@ watch(nodeGroupPicked, (value) => {
     return;
   }
 
+  // `analyticsKind` rather than the destination, because several entries lead
+  // to the same place: a party and „Lista wszystkich osób” both open
+  // /eksploruj/tabela, and telling those apart is most of the point - one is a
+  // reader with something in mind, the other is a reader giving up on typing.
+  // Defaulted, because the value arrives from VAutocomplete's model and a test
+  // may hand over a partial entry.
+  trackGoal(SEARCH_PICK_GOALS[value.analyticsKind ?? "place"], {
+    title: value.title,
+  });
   push(omniSearchTarget(currentRoute.value, value));
   autocompleteFocus.value = false;
 });

--- a/frontend/app/components/card/CallToAction.vue
+++ b/frontend/app/components/card/CallToAction.vue
@@ -19,6 +19,7 @@
           class="ma-2"
           href="https://docs.google.com/forms/d/e/1FAIpQLSfZX4ekzLEhX60f6Frn3JMKkYwbqG2tE1NNNN0Eu_Ozr814FQ/viewform"
           target="_blank"
+          @click="trackGoal('cta:volunteer-form', { from: 'home' })"
         >
           <v-icon :icon="mdiPencilPlus" /> Chcę pomóc! (ankieta)
         </v-btn>
@@ -27,7 +28,13 @@
            that both ask for the same thing, and /pomoc is already one tap away
            from the top of the home page. -->
       <v-col cols="12" md="6" class="text-center d-none d-md-block">
-        <v-btn variant="elevated" color="primary" class="ma-2" to="/pomoc">
+        <v-btn
+          variant="elevated"
+          color="primary"
+          class="ma-2"
+          to="/pomoc"
+          @click="trackGoal('cta:pomoc', { from: 'home-cta' })"
+        >
           Albo zacznij działać
         </v-btn>
       </v-col>
@@ -38,6 +45,7 @@
 <script setup lang="ts">
 import { mdiPencilPlus } from "@mdi/js";
 import { useStats } from "~/composables/stats/useStats";
+import { trackGoal } from "~/composables/analytics";
 
 const { reviewed } = useStats();
 </script>

--- a/frontend/app/components/chart/TreemapParty.vue
+++ b/frontend/app/components/chart/TreemapParty.vue
@@ -19,6 +19,13 @@ import {
 const { results: resultsUnfiltered } = await usePartyStatistics();
 const router = useRouter();
 
+/** Emitted alongside the navigation, not instead of it - the chart keeps
+ * deciding where a party leads, and the parent gets told that a party was
+ * picked. It exists so the home page can record the treemap's only conversion
+ * under a name that says where the click happened, rather than this component
+ * naming a surface it does not know it is on. Mirrors PolandMap's `click`. */
+const emit = defineEmits<{ select: [party: string] }>();
+
 const nonZeroIndices = computed(() =>
   resultsUnfiltered.value.map((x, i) => (x > 0 ? i : -1)).filter((i) => i >= 0),
 );
@@ -49,9 +56,12 @@ const chartOptions = computed(() => ({
         _chartContext: unknown,
         opts: { dataPointIndex: number },
       ) {
+        const party = parties.value[opts.dataPointIndex];
+        if (!party) return;
+        emit("select", party);
         router.push({
           path: "/eksploruj/tabela",
-          query: { party: parties.value[opts.dataPointIndex] },
+          query: { party },
         });
       },
     },

--- a/frontend/app/components/explore/ShareQuery.vue
+++ b/frontend/app/components/explore/ShareQuery.vue
@@ -208,6 +208,9 @@ const selectUrl = () => {
   }
 };
 
+/** A link or a description+link actually reached the clipboard. */
+const emit = defineEmits<{ copied: [] }>();
+
 const copy = async (text: string, done: string) => {
   try {
     // Inside the try on purpose: on an insecure origin `navigator.clipboard`
@@ -235,8 +238,13 @@ const copy = async (text: string, done: string) => {
   }
 
   announce(done);
-  // Only on success. Closing on the failure path would take away the field the
-  // fallback just selected.
+  // Only on success, and for the same reason the dialog only closes here: the
+  // fallback path put the address in front of the reader to copy by hand, and
+  // nobody has shared anything yet. Emitted rather than counted here, so the
+  // page that shows this card is the one that names the goal.
+  emit("copied");
+  // Closing on the failure path would take away the field the fallback just
+  // selected.
   open.value = false;
 };
 </script>

--- a/frontend/app/components/form/EksplorujTabelaFilters.vue
+++ b/frontend/app/components/form/EksplorujTabelaFilters.vue
@@ -245,7 +245,12 @@
         </v-list>
       </v-menu>
 
-      <ExploreShareQuery v-if="showShare" :query="query" :lookup="lookup" />
+      <ExploreShareQuery
+        v-if="showShare"
+        :query="query"
+        :lookup="lookup"
+        @copied="emit('share')"
+      />
     </div>
 
     <!-- Band 2: the work row, for a reader who is signed in and can act on it.
@@ -457,7 +462,13 @@ const props = withDefaults(
  * The page owns the url, so the page drops them in one write - which is also
  * one history entry for the back button rather than ten.
  */
-const emit = defineEmits<{ clear: [] }>();
+const emit = defineEmits<{
+  clear: [];
+  /** The reader copied a link to the query this bar describes. Passed up rather
+   * than counted here for the same reason `clear` is: the page owns what its
+   * surface is called. */
+  share: [];
+}>();
 
 const visibility = defineModel<"all" | "public" | "private">("visibility");
 const party = defineModel<string[] | null>("party");

--- a/frontend/app/components/home/Explorer.vue
+++ b/frontend/app/components/home/Explorer.vue
@@ -42,7 +42,12 @@
               <v-card-text>
                 <ClientOnly>
                   <LazyChartTreemapParty
-                    @select="trackGoal('home-parties:party', { party: $event })"
+                    @select="
+                      trackGoal('home-explorer:pick', {
+                        panel: 'parties',
+                        value: $event,
+                      })
+                    "
                   />
                 </ClientOnly>
               </v-card-text>
@@ -115,17 +120,17 @@ watch(arm, (value) => {
 function selectTab(value: unknown) {
   if (!isPanel(value) || value === tab.value) return;
   tab.value = value;
-  trackGoal(
-    value === "parties" ? "home-explorer:tab-parties" : "home-explorer:tab-map",
-  );
+  trackGoal("home-explorer:tab", { tab: value });
 }
 
-/** The map's only conversion. The powiat goes in a property rather than the
- * goal name - there are 380 of them, and on a Growth plan the property is
- * dropped, which is the right trade: one readable goal beats 380 unusable
- * ones. Keyed by teryt rather than name, which is optional on a Powiat. */
+/** The map's conversion, under the same goal as the treemap's so that `panel`
+ * compares the two directly - which is the question the tab strip poses.
+ *
+ * Keyed by teryt rather than name, which is optional on a Powiat. 380 values is
+ * a long breakdown but a legitimate one, and it is the only place the site
+ * would learn which parts of the country people look for. */
 function pickRegion(picked: Powiat) {
   region.value = picked;
-  trackGoal("home-map:region", { region: picked.teryt });
+  trackGoal("home-explorer:pick", { panel: "map", value: picked.teryt });
 }
 </script>

--- a/frontend/app/components/home/Explorer.vue
+++ b/frontend/app/components/home/Explorer.vue
@@ -2,16 +2,21 @@
   <v-container :style="{ background: 'white' }">
     <v-row>
       <v-col cols="12" class="d-md-none pb-0">
-        <v-tabs v-model="search" color="primary" grow>
+        <v-tabs
+          :model-value="tab"
+          color="primary"
+          grow
+          @update:model-value="selectTab"
+        >
           <v-tab value="map">Mapa</v-tab>
           <v-tab value="parties">Partie</v-tab>
         </v-tabs>
       </v-col>
       <v-col cols="12" md="8">
-        <v-tabs-window v-model="search">
+        <v-tabs-window :model-value="tab">
           <v-tabs-window-item value="map">
             <HomeHeading title="Mapa koryciarstwa" center />
-            <ChartPolandMap @click="region = $event" />
+            <ChartPolandMap @click="pickRegion" />
           </v-tabs-window-item>
           <v-tabs-window-item value="parties">
             <HomeHeading title="Podział na partie" center />
@@ -36,7 +41,9 @@
               </v-card-title>
               <v-card-text>
                 <ClientOnly>
-                  <LazyChartTreemapParty />
+                  <LazyChartTreemapParty
+                    @select="trackGoal('home-parties:party', { party: $event })"
+                  />
                 </ClientOnly>
               </v-card-text>
             </v-card>
@@ -44,7 +51,13 @@
         </v-tabs-window>
       </v-col>
       <v-col cols="12" md="4">
-        <v-tabs v-model="search" color="primary" grow class="d-none d-md-flex">
+        <v-tabs
+          :model-value="tab"
+          color="primary"
+          grow
+          class="d-none d-md-flex"
+          @update:model-value="selectTab"
+        >
           <v-tab value="map">Mapa</v-tab>
           <v-tab value="parties">Partie</v-tab>
         </v-tabs>
@@ -58,11 +71,61 @@
 <script lang="ts" setup>
 import { polishCounting } from "@/composables/polish";
 import { useStats } from "~/composables/stats/useStats";
+import { trackGoal } from "~/composables/analytics";
+import { useExperimentArm } from "~/composables/experiments";
+import { HOME_DEFAULT_EXPERIMENT } from "~~/shared/experiments";
 
 import type { Powiat } from "@/composables/entity/regions";
 
 const { approved } = useStats();
 
-const search = ref("map");
+/** The panels this component actually renders.
+ *
+ * `home-default` also declares a `gry` arm, for the games hub that lives on
+ * another branch - so an arm can name a panel that is not here. It carries no
+ * weight today and cannot be assigned, but a weight is one number in a registry
+ * and a blank window on the home page is a worse failure than an unhonoured
+ * experiment. Anything unrecognised stays on the map. */
+const PANELS = ["map", "parties"] as const;
+type Panel = (typeof PANELS)[number];
+
+function isPanel(value: unknown): value is Panel {
+  return PANELS.includes(value as Panel);
+}
+
+const tab = ref<Panel>("map");
 const region = ref<Powiat | undefined>(undefined);
+
+/** Dormant: every reader is on the `map` arm until the weights in
+ * `shared/experiments.ts` move, so this resolves to what the page already did.
+ * What it does today is record the arm, which is what makes the split readable
+ * on a Growth plan when it is switched on. */
+const arm = useExperimentArm(HOME_DEFAULT_EXPERIMENT);
+watch(arm, (value) => {
+  if (isPanel(value)) tab.value = value;
+});
+
+/** Explicitly controlled rather than `v-model`, so that a switch made by the
+ * reader is distinguishable from one made by the experiment.
+ *
+ * With `v-model` the bound ref is already updated by the time a sibling
+ * `@update:model-value` listener runs, so there is nothing left to compare
+ * against and no way to tell an echo from a click - and there are two tab
+ * strips here, one per breakpoint, bound to the same value. */
+function selectTab(value: unknown) {
+  if (!isPanel(value) || value === tab.value) return;
+  tab.value = value;
+  trackGoal(
+    value === "parties" ? "home-explorer:tab-parties" : "home-explorer:tab-map",
+  );
+}
+
+/** The map's only conversion. The powiat goes in a property rather than the
+ * goal name - there are 380 of them, and on a Growth plan the property is
+ * dropped, which is the right trade: one readable goal beats 380 unusable
+ * ones. Keyed by teryt rather than name, which is optional on a Powiat. */
+function pickRegion(picked: Powiat) {
+  region.value = picked;
+  trackGoal("home-map:region", { region: picked.teryt });
+}
 </script>

--- a/frontend/app/composables/analytics.ts
+++ b/frontend/app/composables/analytics.ts
@@ -1,46 +1,73 @@
 /** The one way the app sends a custom event to Plausible.
  *
- * `useTrackEvent` takes any string, which is how a goal ends up misspelled,
- * recorded, and invisible on a dashboard that was only ever told about the
- * correct spelling. Going through here types the name against the vocabulary in
- * `shared/analytics.ts`, so a goal that is not registered does not compile.
+ * `useTrackEvent` takes any string and any properties, which is how a goal ends
+ * up misspelled - recorded, and invisible on a dashboard that was only told
+ * about the correct spelling - and how one call site ends up sending `kind`
+ * where another sends `type`. Going through here types both against
+ * `shared/analytics.ts`, so a goal that is not registered, or a property set
+ * that does not match the goal's, does not compile.
  */
 
-import type { AnalyticsGoal } from "~~/shared/analytics";
+import {
+  isPassiveGoal,
+  type AnalyticsGoal,
+  type GoalPropKeys,
+} from "~~/shared/analytics";
 
-/** Values Plausible accepts for a property.
- *
- * Strings only, which is the tracker's own `CustomProperties` type rather than
- * a restriction added here: the API stores properties as strings and a number
- * would be coerced on the way out, so a caller with a count should decide how
- * it wants to be bucketed rather than leave that to the serializer. */
+/** Plausible stores properties as strings; the tracker's own type says so too.
+ * A caller with a count decides how it wants to be bucketed rather than leaving
+ * that to a serializer - see `resultBucket`. */
 export type AnalyticsProps = Record<string, string>;
+
+/** Properties attached to every event, keyed by property name.
+ *
+ * Today this is only the experiment arms: `shared/experiments.ts` needs the arm
+ * on each goal so the dashboard can be filtered to one arm and every number
+ * compared across them, and a property is the only way to do that without a
+ * goal per arm.
+ *
+ * It lives here rather than in the experiments composable to keep the imports
+ * pointing one way - experiments knows about analytics, not the reverse.
+ *
+ * What this deliberately does *not* cover is pageviews. `@nuxtjs/plausible`
+ * calls the tracker's `init` itself and passes no `customProperties`, so the
+ * pageview it fires on load carries nothing from here. Segmenting bounce rate
+ * or visit duration by arm would mean replacing that plugin with one of our
+ * own - worth doing if an experiment ever runs on something whose effect is
+ * about staying on the page rather than about clicking something.
+ */
+const globalProps: AnalyticsProps = {};
+
+/** Attach `value` to every event from now on. Idempotent. */
+export function setGlobalProp(key: string, value: string): void {
+  globalProps[key] = value;
+}
+
+/** Goals that carry no properties take one argument; the rest must pass exactly
+ * the keys the goal declares. `[…] extends [never]` rather than a bare
+ * conditional, because a naked `never` distributes and every goal would look
+ * like it takes none. */
+type TrackArgs<G extends AnalyticsGoal> = [GoalPropKeys<G>] extends [never]
+  ? []
+  : [props: Record<GoalPropKeys<G>, string>];
 
 /** Record `goal`.
  *
  * Safe to call from an event handler, and a no-op during SSR - `useTrackEvent`
  * guards on `import.meta.client` itself, and the tracker only exists in the
  * client plugin.
- *
- * `props` are sent even though the site's Growth plan discards them. They cost
- * nothing, they document at the call site what the interesting dimension was,
- * and if the plan ever changes the breakdowns start appearing without another
- * pass over every caller. Do not use one in place of a goal name: on Growth a
- * property is not a thing you can filter or group by, so a dimension that
- * matters belongs in the name. See `shared/analytics.ts`.
  */
-export function trackGoal(goal: AnalyticsGoal, props?: AnalyticsProps): void {
-  useTrackEvent(goal, props ? { props } : undefined);
-}
-
-/** Record an arm-marker goal.
- *
- * Separate from `trackGoal` because the name is built from the experiment
- * registry rather than taken from the fixed vocabulary, so it cannot be typed
- * as an `AnalyticsGoal`. Only `useExperimentArm` should call it. */
-export function trackExperimentGoal(
-  goal: string,
-  props?: AnalyticsProps,
+export function trackGoal<G extends AnalyticsGoal>(
+  goal: G,
+  ...args: TrackArgs<G>
 ): void {
-  useTrackEvent(goal, props ? { props } : undefined);
+  const props = { ...globalProps, ...(args[0] ?? {}) };
+  useTrackEvent(goal, {
+    props,
+    // Only sent for the passive ones. A custom event counts towards the bounce
+    // rate unless it says otherwise, which is right for a click and wrong for
+    // an event that fires because a page loaded - see the note in
+    // shared/analytics.ts.
+    ...(isPassiveGoal(goal) ? { interactive: false as const } : {}),
+  });
 }

--- a/frontend/app/composables/analytics.ts
+++ b/frontend/app/composables/analytics.ts
@@ -1,0 +1,46 @@
+/** The one way the app sends a custom event to Plausible.
+ *
+ * `useTrackEvent` takes any string, which is how a goal ends up misspelled,
+ * recorded, and invisible on a dashboard that was only ever told about the
+ * correct spelling. Going through here types the name against the vocabulary in
+ * `shared/analytics.ts`, so a goal that is not registered does not compile.
+ */
+
+import type { AnalyticsGoal } from "~~/shared/analytics";
+
+/** Values Plausible accepts for a property.
+ *
+ * Strings only, which is the tracker's own `CustomProperties` type rather than
+ * a restriction added here: the API stores properties as strings and a number
+ * would be coerced on the way out, so a caller with a count should decide how
+ * it wants to be bucketed rather than leave that to the serializer. */
+export type AnalyticsProps = Record<string, string>;
+
+/** Record `goal`.
+ *
+ * Safe to call from an event handler, and a no-op during SSR - `useTrackEvent`
+ * guards on `import.meta.client` itself, and the tracker only exists in the
+ * client plugin.
+ *
+ * `props` are sent even though the site's Growth plan discards them. They cost
+ * nothing, they document at the call site what the interesting dimension was,
+ * and if the plan ever changes the breakdowns start appearing without another
+ * pass over every caller. Do not use one in place of a goal name: on Growth a
+ * property is not a thing you can filter or group by, so a dimension that
+ * matters belongs in the name. See `shared/analytics.ts`.
+ */
+export function trackGoal(goal: AnalyticsGoal, props?: AnalyticsProps): void {
+  useTrackEvent(goal, props ? { props } : undefined);
+}
+
+/** Record an arm-marker goal.
+ *
+ * Separate from `trackGoal` because the name is built from the experiment
+ * registry rather than taken from the fixed vocabulary, so it cannot be typed
+ * as an `AnalyticsGoal`. Only `useExperimentArm` should call it. */
+export function trackExperimentGoal(
+  goal: string,
+  props?: AnalyticsProps,
+): void {
+  useTrackEvent(goal, props ? { props } : undefined);
+}

--- a/frontend/app/composables/experiments.ts
+++ b/frontend/app/composables/experiments.ts
@@ -6,11 +6,11 @@
  */
 
 import {
+  armPropertyName,
   assignArm,
-  experimentGoal,
   type Experiment,
 } from "~~/shared/experiments";
-import { trackExperimentGoal } from "~/composables/analytics";
+import { setGlobalProp, trackGoal } from "~/composables/analytics";
 
 /** Where the per-session id lives. One key for the whole site: the id
  * identifies the session, not the experiment, so two experiments running at
@@ -64,7 +64,7 @@ function claimReport(experimentId: string): boolean {
   }
 }
 
-/** The arm this reader is in, and a record of it in Plausible.
+/** The arm this reader is in, registered so every later event carries it.
  *
  * Starts on the control arm and stays there through SSR, because `/` is served
  * from a shared `swr` cache and cannot vary per reader - the arm is resolved on
@@ -72,11 +72,16 @@ function claimReport(experimentId: string): boolean {
  * asymmetry `shared/experiments.ts` says to fix before activating a split, and
  * it is invisible while every experiment is dormant.
  *
- * The marker goal is sent once per session per experiment, on assignment. Once,
- * because the dashboard reading is "filter to visitors who converted this goal"
- * - a per-pageview marker would still segment correctly but would report an arm
- * size that is really a pageview count, which is the number one is trying not
- * to confuse it with.
+ * Two things happen on assignment. The arm becomes a property on every
+ * subsequent event, which is what makes the comparison readable; and
+ * `experiment:assigned` is sent once per session, which is what gives the arm a
+ * denominator to compare against. Once rather than per pageview, because an arm
+ * size that is really a pageview count is the number one is trying not to
+ * confuse it with.
+ *
+ * The ordering matters: `setGlobalProp` runs before the goal, so
+ * `experiment:assigned` carries the arm too and the denominator sits inside the
+ * same filter as everything it is a denominator for.
  */
 export function useExperimentArm<Id extends string>(
   experiment: Experiment<Id>,
@@ -89,9 +94,10 @@ export function useExperimentArm<Id extends string>(
     if (!id) return;
 
     arm.value = assignArm(experiment, id);
+    setGlobalProp(armPropertyName(experiment.id), arm.value);
 
     if (claimReport(experiment.id)) {
-      trackExperimentGoal(experimentGoal(experiment.id, arm.value), {
+      trackGoal("experiment:assigned", {
         experiment: experiment.id,
         arm: arm.value,
       });

--- a/frontend/app/composables/experiments.ts
+++ b/frontend/app/composables/experiments.ts
@@ -1,0 +1,102 @@
+/** Reading which experiment arm the current reader is in.
+ *
+ * The registry, the assignment rule and the reasoning about traffic and
+ * stickiness all live in `shared/experiments.ts`; this is only the part that
+ * needs a browser.
+ */
+
+import {
+  assignArm,
+  experimentGoal,
+  type Experiment,
+} from "~~/shared/experiments";
+import { trackExperimentGoal } from "~/composables/analytics";
+
+/** Where the per-session id lives. One key for the whole site: the id
+ * identifies the session, not the experiment, so two experiments running at
+ * once assign independently (the experiment id is hashed in with it) while
+ * still describing the same reader. */
+const SESSION_KEY = "koryta:session";
+
+/** Prefix for the "already reported this arm" flag, one per experiment. */
+const REPORTED_PREFIX = "koryta:exp-reported:";
+
+/** The current session's id, creating one if this is the first call.
+ *
+ * `sessionStorage` rather than a cookie, and rather than `localStorage`: see
+ * the stickiness note in `shared/experiments.ts`. Returns null when storage is
+ * unavailable - Safari in private mode has historically thrown on write, and an
+ * analytics detail is not worth an exception on the home page. Every caller
+ * treats null as "control".
+ */
+function sessionId(): string | null {
+  try {
+    const existing = sessionStorage.getItem(SESSION_KEY);
+    if (existing) return existing;
+    // Math.random rather than crypto.randomUUID: this is not a secret, it
+    // never leaves the browser, and randomUUID is undefined on an insecure
+    // origin - which is every local build. Two random suffixes and a timestamp
+    // is far more than enough to keep a few thousand concurrent sessions in
+    // different buckets, and a collision would cost one misassigned arm.
+    const created = [
+      Date.now().toString(36),
+      Math.random().toString(36).slice(2),
+      Math.random().toString(36).slice(2),
+    ].join("-");
+    sessionStorage.setItem(SESSION_KEY, created);
+    return created;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether this session has already reported `experimentId`, marking it as
+ * reported if not. Storage failures report every time rather than never: a
+ * duplicated marker inflates one number, a suppressed one loses the arm. */
+function claimReport(experimentId: string): boolean {
+  try {
+    const key = `${REPORTED_PREFIX}${experimentId}`;
+    if (sessionStorage.getItem(key)) return false;
+    sessionStorage.setItem(key, "1");
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+/** The arm this reader is in, and a record of it in Plausible.
+ *
+ * Starts on the control arm and stays there through SSR, because `/` is served
+ * from a shared `swr` cache and cannot vary per reader - the arm is resolved on
+ * mount. A non-control arm therefore paints control for a frame; that is the
+ * asymmetry `shared/experiments.ts` says to fix before activating a split, and
+ * it is invisible while every experiment is dormant.
+ *
+ * The marker goal is sent once per session per experiment, on assignment. Once,
+ * because the dashboard reading is "filter to visitors who converted this goal"
+ * - a per-pageview marker would still segment correctly but would report an arm
+ * size that is really a pageview count, which is the number one is trying not
+ * to confuse it with.
+ */
+export function useExperimentArm<Id extends string>(
+  experiment: Experiment<Id>,
+): Ref<Id> {
+  const control = experiment.arms[0]!.id;
+  const arm = ref(control) as Ref<Id>;
+
+  onMounted(() => {
+    const id = sessionId();
+    if (!id) return;
+
+    arm.value = assignArm(experiment, id);
+
+    if (claimReport(experiment.id)) {
+      trackExperimentGoal(experimentGoal(experiment.id, arm.value), {
+        experiment: experiment.id,
+        arm: arm.value,
+      });
+    }
+  });
+
+  return arm;
+}

--- a/frontend/app/pages/eksploruj/tabela.vue
+++ b/frontend/app/pages/eksploruj/tabela.vue
@@ -49,6 +49,7 @@
         :show-progress="!!user"
         show-share
         @clear="clearFilters"
+        @share="trackGoal('tabela:shared')"
       />
 
       <v-card class="table-card">
@@ -139,6 +140,8 @@ import type { Query } from "~~/server/api/nodes/index.get";
 import { useCurrentUser } from "vuefire";
 
 import { useEdges } from "~/composables/edges";
+import { trackGoal } from "~/composables/analytics";
+import { activeTabelaFilters, tabelaFiltersChanged } from "~~/shared/analytics";
 
 definePageMeta({ fullWidth: true, affineLink: "BYOEeL1iG0mvIR3yz2pOs" });
 useHead({
@@ -158,18 +161,39 @@ const { setQuery, stringFilter, arrayFilter, choiceFilter, numberFilter } =
 
 // Paging and sorting are the table's own state rather than filters, so they do
 // not reset the page - they set it.
+//
+// The parameters are read once into a ref each rather than inside the getter:
+// the setters compare against the current value before counting the change,
+// and `numberFilter` builds a fresh computed per call, so reading it there
+// would allocate one on every write.
+const pageParam = numberFilter("page");
 const page = computed<number>({
-  get: () => numberFilter("page").value ?? 1,
-  set: (val) => void setQuery({ page: val > 1 ? String(val) : undefined }),
+  get: () => pageParam.value ?? 1,
+  set: (val) => {
+    // Only a move off the first page, and only one the reader made. Vuetify's
+    // table writes the page back on mount and whenever the row count changes,
+    // and neither is somebody reaching row 11.
+    if (val > 1 && val !== (pageParam.value ?? 1)) {
+      trackGoal("tabela:paged", { kind: "page", to: String(val) });
+    }
+    void setQuery({ page: val > 1 ? String(val) : undefined });
+  },
 });
 
+const itemsPerPageParam = numberFilter("itemsPerPage");
 const itemsPerPage = computed<number>({
-  get: () => numberFilter("itemsPerPage").value ?? DEFAULT_ITEMS_PER_PAGE,
-  set: (val) =>
+  get: () => itemsPerPageParam.value ?? DEFAULT_ITEMS_PER_PAGE,
+  set: (val) => {
+    // Asking for more rows is the same intent as turning the page, so it is the
+    // same goal - what matters is that the reader wanted past the tenth row.
+    if (val !== (itemsPerPageParam.value ?? DEFAULT_ITEMS_PER_PAGE)) {
+      trackGoal("tabela:paged", { kind: "rows", to: String(val) });
+    }
     void setQuery({
       itemsPerPage: val === DEFAULT_ITEMS_PER_PAGE ? undefined : String(val),
       page: undefined,
-    }),
+    });
+  },
 });
 
 type SortEntry = { key: string; order: "asc" | "desc" };
@@ -184,6 +208,19 @@ const sortBy = computed<SortEntry[]>({
   },
   set: (val: SortEntry[]) => {
     const sort = val[0];
+    // Compared against what is already in the url, because the table hands its
+    // sort back on mount as well as on a click.
+    const current = route.query.sortBy as string | undefined;
+    const currentDesc = route.query.sortDesc === "true";
+    if (
+      sort?.key !== current ||
+      (sort ? sort.order === "desc" : false) !== currentDesc
+    ) {
+      trackGoal("tabela:sorted", {
+        by: sort?.key ?? "none",
+        order: sort?.order ?? "none",
+      });
+    }
     void setQuery({
       sortBy: sort?.key,
       sortDesc: sort ? String(sort.order === "desc") : undefined,
@@ -370,7 +407,19 @@ const filterMinVotes = numberFilter("minVotes");
  * `parties` and `krs` are in the list without a control of their own: they are
  * the spellings older links use for `party` and `place`, and a „Wyczyść” that
  * left them behind would clear the chips and none of the filtering. */
-const clearFilters = () =>
+/** Set by `clearFilters`, read once by the query watcher below.
+ *
+ * Only ever armed when the clear will actually change the url, so the watcher
+ * it is waiting for is guaranteed to run and take it down again. Armed on a
+ * no-op it would swallow the reader's next real filter change. */
+let clearInFlight = false;
+
+const clearFilters = () => {
+  const dropped = activeTabelaFilters(route.query);
+  if (dropped.length > 0) {
+    clearInFlight = true;
+    trackGoal("tabela:filter-cleared", { dropped: String(dropped.length) });
+  }
   void setQuery({
     category: undefined,
     teryt: undefined,
@@ -386,6 +435,7 @@ const clearFilters = () =>
     minVotes: undefined,
     page: undefined,
   });
+};
 
 const availableRegions = computed(() =>
   regionFilterOptions(Object.values(regions.value ?? {})),
@@ -462,9 +512,53 @@ const focusedEdges = computed(() => [
 ]);
 
 const focusPerson = (item: PersonRich) => {
+  // The table's conversion: everything else on the page exists to get a reader
+  // to open one of these.
+  trackGoal("tabela:row-opened");
   focusedPerson.value = item;
   openDrawer.value = true;
 };
+
+// How the reader got here. 73% of the site's entrances land on `/`, and this is
+// where the home map, the party treemap and most of the search results send
+// them - so whether an arrival carries a filter is the difference between "came
+// looking for something" and "was handed the raw list of everybody".
+onMounted(() => {
+  const arrived = activeTabelaFilters(route.query);
+  trackGoal("tabela:open", {
+    filtered: arrived.length > 0 ? "true" : "false",
+    filters: arrived.join(",") || "none",
+  });
+});
+
+// Every filter on this page is a writable computed over the query string, so
+// the url is the one place that sees all of them - including the close button
+// on each chip and the spellings older links still use. Watching it beats
+// threading a callback through the filter bar and its eleven controls.
+watch(
+  () => route.query,
+  (after, before) => {
+    if (clearInFlight) {
+      // „Wyczyść” already reported itself as one event. Without this the same
+      // click would also report each of the filters it dropped as used.
+      clearInFlight = false;
+      return;
+    }
+    for (const filter of tabelaFiltersChanged(before, after)) {
+      trackGoal("tabela:filter", { filter });
+    }
+  },
+);
+
+// Once per settled fetch that came back empty, which is once per filter change
+// that found nobody. It does not fire while `pending` is still true, so the
+// empty table shown during a load is not counted as a dead end.
+watch(pending, (isPending, was) => {
+  if (isPending || !was || totalItems.value !== 0) return;
+  trackGoal("tabela:no-results", {
+    filters: activeTabelaFilters(route.query).join(",") || "none",
+  });
+});
 </script>
 
 <style scoped>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -78,6 +78,7 @@
           text="Działaj z nami"
           to="/pomoc"
           data-testid="home-cta"
+          @click="trackGoal('cta:pomoc', { from: 'home-hero' })"
         />
       </v-col>
     </v-row>
@@ -152,6 +153,7 @@
 <script setup lang="ts">
 import { mdiChevronRight, mdiLayersSearchOutline, mdiTable } from "@mdi/js";
 import { useStats } from "~/composables/stats/useStats";
+import { trackGoal } from "~/composables/analytics";
 import { SOCIAL_CARD } from "~/composables/entitySeo";
 
 useSeoMeta({

--- a/frontend/app/pages/pomoc.vue
+++ b/frontend/app/pages/pomoc.vue
@@ -34,6 +34,7 @@
         height="100%"
         variant="outlined"
         hover
+        @click="action.href && trackGoal('cta:community', { to: action.title })"
       >
         <v-card-item>
           <template #prepend>
@@ -58,6 +59,7 @@
         height="100%"
         variant="outlined"
         hover
+        @click="trackGoal('cta:volunteer-form', { from: 'pomoc' })"
       >
         <v-card-item>
           <template #prepend>
@@ -83,6 +85,7 @@
         height="100%"
         variant="outlined"
         hover
+        @click="trackGoal('cta:donate', { to: 'patronite' })"
       >
         <v-card-item>
           <template #prepend>
@@ -125,6 +128,7 @@
         height="100%"
         variant="outlined"
         hover
+        @click="trackGoal('cta:community', { to: link.title })"
       >
         <v-card-item>
           <template #prepend>
@@ -161,6 +165,7 @@ import {
 } from "@mdi/js";
 import { useAuthState } from "@/composables/auth";
 import { useStats } from "~/composables/stats/useStats";
+import { trackGoal } from "~/composables/analytics";
 
 // Discord brand icon from simple-icons; @mdi/js no longer ships brand icons.
 const discordIcon =

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -167,12 +167,16 @@ export default defineNuxtConfig({
     // to what rendering a page costs, and the handler does no rendering.
     proxy: true,
 
-    // Counts clicks that leave the site - the volunteer form, Patronite, the
-    // Slack invite - as one "Outbound Link: Click" goal. The url is a property,
-    // so on a Growth plan this cannot say *which* link, which is why the links
-    // that matter also fire a named goal of their own (shared/analytics.ts).
-    // Kept anyway: it is the only thing that sees the source links on an
-    // article page, and those are not worth a goal each.
+    // Counts clicks that leave the site as one "Outbound Link: Click" goal,
+    // with the url as a property - which on a Business plan is a breakdown
+    // rather than a single number, so this alone covers every source link on
+    // every article page without a goal for any of them.
+    //
+    // The handful that carry a decision - the volunteer form, Patronite, the
+    // Slack invite - still fire a named goal of their own
+    // (shared/analytics.ts), because a conversion worth putting in a funnel
+    // should be one thing to point at rather than a url filter somebody has to
+    // remember to apply.
     autoOutboundTracking: true,
   },
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -154,6 +154,26 @@ export default defineNuxtConfig({
   plausible: {
     // Prevent tracking on localhost
     ignoredHostnames: ["localhost"],
+
+    // Send events to our own origin, which nitro forwards to plausible.io. The
+    // tracker itself is already first-party - @nuxtjs/plausible bundles
+    // @plausible-analytics/tracker rather than loading a remote script - so the
+    // event endpoint was the only thing left for a blocklist to match, and the
+    // audience is 69% mobile and Polish, where blocking is common. Every number
+    // the dashboard has ever shown is a floor because of it.
+    //
+    // The cost is that each event becomes a request to the Cloud Run container
+    // instead of to plausible.io. At 15k pageviews a quarter that is noise next
+    // to what rendering a page costs, and the handler does no rendering.
+    proxy: true,
+
+    // Counts clicks that leave the site - the volunteer form, Patronite, the
+    // Slack invite - as one "Outbound Link: Click" goal. The url is a property,
+    // so on a Growth plan this cannot say *which* link, which is why the links
+    // that matter also fire a named goal of their own (shared/analytics.ts).
+    // Kept anyway: it is the only thing that sees the source links on an
+    // article page, and those are not worth a goal each.
+    autoOutboundTracking: true,
   },
 
   eslint: {

--- a/frontend/shared/analytics.ts
+++ b/frontend/shared/analytics.ts
@@ -1,144 +1,240 @@
 /** Every custom event the site is allowed to send to Plausible, in one place.
  *
- * Two reasons this is a closed vocabulary rather than string literals at the
- * call sites.
+ * ## Why a closed vocabulary
  *
- * The first is that Plausible only *counts* an event it has been told about:
- * an event whose name is not registered as a goal on the dashboard is accepted,
- * stored and then invisible. So the set has to be enumerable to be set up at
- * all - `ALL_GOALS` below is the list to paste into Settings -> Goals, and
- * `analytics.test.ts` fails if a name is added here without a description, so
- * the list stays the documentation of what each goal means.
+ * Plausible only *counts* an event it has been told about: an event whose name
+ * is not registered as a goal on the dashboard is accepted, stored and then
+ * invisible. So the set has to be enumerable to be set up at all - `ALL_GOALS`
+ * is the list to paste into Settings -> Goals, and the descriptions here are
+ * what the goal means to somebody reading the dashboard in six months.
  *
- * The second is that koryta.pl is on a Growth plan, where **custom properties
- * do not exist**. On Business you would send `track("search", { props: { kind:
- * "person" }})` and break the goal down by `kind` in the dashboard; on Growth
- * that property is accepted by the API and then dropped. Any dimension worth
- * having therefore has to be part of the goal *name*, which is why the names
- * below read `search:pick-person` rather than `search:pick`. That trades a
- * longer goal list for being able to see the answer, and it is the reason the
- * vocabulary has to stay small - a dimension with more than a handful of values
- * (a powiat, a person) must not go in a name. `home-map:region` is one goal for
- * all 380 powiaty on purpose.
+ * ## Properties carry the dimensions
  *
- * Properties are sent anyway, by `useAnalytics`, where they add something. They
- * cost nothing today and mean a later upgrade to Business starts producing
- * breakdowns without another pass over the call sites.
+ * The site is on a **Business** plan, so custom properties exist and can be
+ * filtered and grouped by. That is why there is one `search:pick` with a `kind`
+ * property rather than five goals with the kind spelled into the name, and one
+ * `tabela:filter` rather than one goal per control on the filter bar. Each goal
+ * declares the property keys it carries and `trackGoal` requires exactly those,
+ * so a property cannot be quietly renamed at one call site and left behind at
+ * another.
+ *
+ * Two things follow from properties being real stored data rather than
+ * something the API drops:
+ *
+ * - **No free text.** A search query is somebody's name and a note is somebody's
+ *   words; neither belongs in analytics. Properties here are closed sets, site
+ *   data (a party, a teryt, a filter name) or buckets. `resultBucket` exists
+ *   because the number of hits is interesting and the query is not.
+ * - **Bounded values where it costs nothing.** A property with a few dozen
+ *   values reads as a breakdown; one with ten thousand reads as a list.
+ *
+ * ## Interactive vs passive
+ *
+ * A custom event counts towards Plausible's bounce rate unless it is sent with
+ * `interactive: false` - the tracker puts it in the payload as `i`. So an event
+ * that fires because a page loaded, rather than because a reader did something,
+ * has to be declared `passive` here or it un-bounces every single visitor and
+ * the bounce rate becomes 0% and meaningless.
+ *
+ * Note what this means for `/eksploruj/tabela`, whose 76% entry bounce rate is
+ * the reason half of this file exists: once its interactions are counted, that
+ * number will fall, because a reader who filtered and left was always engaged
+ * and only looked like a bounce. The rate before and after this ships is not
+ * the same measurement, and the day it deploys is a discontinuity in the chart.
  */
 
 import type { NodeType } from "./model";
 
-/** The naming rule, such as it is: `<surface>:<what happened>`, kebab-case,
- * present tense, and the surface is where the reader was rather than which
- * component fired it. `home-explorer:tab-parties` survives the component being
- * renamed; `Explorer:tabChange` would not. */
-export type AnalyticsGoal = keyof typeof GOAL_DESCRIPTIONS;
-
-/** What each goal means, in the terms someone reading the dashboard needs.
+/** One goal: what it means, what it carries, and whether a reader did it.
  *
- * Write these for the person looking at a number six months from now who did
- * not write the code - "which of the two panels people actually open" is useful,
- * "fires on tab change" is not.
- */
-export const GOAL_DESCRIPTIONS = {
+ * `props` is the exact set of property keys the goal takes - not a minimum.
+ * Empty means the goal takes none. */
+type GoalSpec = {
+  description: string;
+  props: readonly string[];
+  /** True when the event fires from a page load rather than from something the
+   * reader did. Sent as `interactive: false`, so it does not touch the bounce
+   * rate. Defaults to false, i.e. the reader did it. */
+  passive?: true;
+};
+
+/** The naming rule: `<surface>:<what happened>`, kebab-case, and the surface is
+ * where the reader was rather than which component fired it.
+ * `home-explorer:tab` survives the component being renamed; `Explorer:tabChange`
+ * would not. */
+export const GOALS = {
   // --- The home page explorer -------------------------------------------
-  // These four exist to answer one question without splitting traffic: of the
+  // These exist to answer one question without splitting traffic: of the
   // people who land on `/` - 73% of all entrances - does anybody go to the
   // party treemap, and does either panel send them anywhere? The tab strip is
   // already there and already switchable, so the answer is observable as soon
   // as it is measured. Only then is an experiment on the *default* tab worth
   // the traffic it would cost.
-  "home-explorer:tab-map": "Reader switched the home explorer back to the map.",
-  "home-explorer:tab-parties":
-    "Reader opened the party treemap on the home page. The count of people who ever do this is the whole case for or against making it the default.",
-  "home-map:region":
-    "Reader clicked a powiat on the home map, which filters the list beside it. The map's only conversion.",
-  "home-parties:party":
-    "Reader clicked a party in the treemap, which opens the table filtered to it. The treemap's only conversion, and the one comparable to home-map:region.",
+  "home-explorer:tab": {
+    description:
+      "Reader switched the home explorer's panel. Break down by `tab` for how many people ever open the treemap - the whole case for or against making it the default.",
+    props: ["tab"],
+  },
+  "home-explorer:pick": {
+    description:
+      "Reader clicked through from one of the home explorer's panels into the data - a powiat on the map, a party in the treemap. One goal for both, so `panel` compares them directly: this is each panel's conversion rate.",
+    props: ["panel", "value"],
+  },
 
   // --- Search -----------------------------------------------------------
-  // OmniSearch is the first thing on a phone and the site has no idea what is
-  // typed into it, whether anything came back, or whether the reader took what
-  // it offered.
-  "search:performed": "A search query actually reached /api/search.",
-  "search:no-results":
-    "A search returned nothing. The gap between this and search:performed is the honest measure of whether the index covers what people look for.",
-  "search:pick-person": "Reader opened a person from the search results.",
-  "search:pick-place": "Reader opened an institution or company from search.",
-  "search:pick-region": "Reader opened a region from search.",
-  "search:pick-party":
-    "Reader picked a party from search, which opens the table filtered to it.",
-  "search:pick-list":
-    "Reader picked „Lista wszystkich osób”, the entry that is always first.",
-  "search:propose-person":
-    "Reader started adding a person the search could not find.",
-  "search:propose-place":
-    "Reader started adding an institution the search could not find.",
-  "search:propose-article":
-    "Reader started adding a source the search could not find.",
+  // OmniSearch is the first thing on a phone and the site has no idea whether
+  // anything came back or whether the reader took what it offered.
+  "search:performed": {
+    description:
+      "A search query reached /api/search. `results` buckets how many came back; `none` against the total is the share of searches the index cannot answer. The query itself is deliberately not recorded.",
+    props: ["results"],
+  },
+  "search:pick": {
+    description:
+      "Reader opened something from the search results. `kind` separates a real hit from „Lista wszystkich osób” and the party shortcuts - one is a reader with a name in mind, the other is a reader giving up on typing one.",
+    props: ["kind"],
+  },
+  "search:propose": {
+    description:
+      "Reader started adding something the search could not find. Whether they finished is a different question, and the revision queue already answers it.",
+    props: ["kind"],
+  },
 
   // --- The contribution funnel -----------------------------------------
   // The volunteer form is an outbound Google Forms link and has been the site's
   // main ask since it launched. Nobody has ever been able to say whether one
-  // person clicked it. `autoOutboundTracking` counts outbound clicks in
-  // aggregate, but on Growth the url is a property, so it cannot say *which*
-  // link - hence a named goal for the ones that matter.
-  "cta:volunteer-form":
-    "Reader clicked through to the volunteer Google Form. The site's primary conversion.",
-  "cta:pomoc": "Reader went to /pomoc from a call to action.",
-  "cta:donate":
-    "Reader clicked through to Patronite or Zrzutka. Both are outbound.",
-  "cta:community":
-    "Reader clicked through to Slack, Discord, Facebook or the GitHub issue tracker from /pomoc.",
-} as const satisfies Record<string, string>;
+  // person clicked it.
+  "cta:volunteer-form": {
+    description:
+      "Reader clicked through to the volunteer Google Form. The site's primary conversion.",
+    props: ["from"],
+  },
+  "cta:pomoc": {
+    description: "Reader went to /pomoc from a call to action.",
+    props: ["from"],
+  },
+  "cta:donate": {
+    description: "Reader clicked through to Patronite or Zrzutka.",
+    props: ["to"],
+  },
+  "cta:community": {
+    description:
+      "Reader clicked through to Slack, Discord, Facebook or the GitHub issue tracker.",
+    props: ["to"],
+  },
+
+  // --- /eksploruj/tabela -------------------------------------------------
+  // The #2 page, 2,068 visitors, and 76% of the people who enter on it bounce.
+  // Nothing could say why, and one detail makes that worse than it sounds: the
+  // tracker fires a pageview only when `location.pathname` changes, and every
+  // control on this page writes to the query string instead. A reader who spent
+  // five minutes filtering, sorting and paging produced exactly one pageview.
+  "tabela:open": {
+    description:
+      "Reader arrived at the table. `filtered` splits cold arrivals from arrivals with intent - from search, a party chip, the home map or a shared link - and `filters` says which ones they came with.",
+    props: ["filtered", "filters"],
+    // Fires on mount. Interactive, this would un-bounce every visitor to the
+    // page and take the number it exists to explain down to zero.
+    passive: true,
+  },
+  "tabela:filter": {
+    description:
+      "Reader changed one of the filters. Break down by `filter` for whether the bar earns the space it takes - note that visibility, voted and min-votes are only shown to a signed-in reader, so they measure the tagging workflow rather than the public.",
+    props: ["filter"],
+  },
+  "tabela:filter-cleared": {
+    description:
+      "Reader emptied every filter at once with „Wyczyść”. One event, not one per filter dropped.",
+    props: ["dropped"],
+  },
+  "tabela:sorted": {
+    description: "Reader reordered the table.",
+    props: ["by", "order"],
+  },
+  "tabela:paged": {
+    description:
+      "Reader went past the first page, or asked for more rows. On a table whose readers mostly bounce, getting to row 11 is the strongest engagement signal there is.",
+    props: ["kind", "to"],
+  },
+  "tabela:row-opened": {
+    description:
+      "Reader opened a person's drawer from a row. The table's conversion - everything else on the page is in service of this.",
+    props: [],
+  },
+  "tabela:no-results": {
+    description:
+      "A filter combination came back empty. The cheapest explanation for a reader who filters once and leaves.",
+    props: ["filters"],
+    // Passive because it also fires for an arrival whose incoming filter finds
+    // nobody, and being shown an empty table is not something the reader did.
+    passive: true,
+  },
+  "tabela:shared": {
+    description: "Reader copied a link to the filtered table.",
+    props: [],
+  },
+
+  // --- Experiments -------------------------------------------------------
+  "experiment:assigned": {
+    description:
+      "Records which arm a reader was put in, once per session per experiment. The arm also rides as a property on every other goal, so this exists to give each arm a denominator.",
+    props: ["experiment", "arm"],
+    // Fires on mount, before the reader has done anything.
+    passive: true,
+  },
+} as const satisfies Record<string, GoalSpec>;
+
+export type AnalyticsGoal = keyof typeof GOALS;
+
+/** The property keys `goal` carries. */
+export type GoalPropKeys<G extends AnalyticsGoal> =
+  (typeof GOALS)[G]["props"][number];
 
 /** Every goal name, for pasting into Plausible -> Settings -> Goals.
  *
  * Sorted, because the dashboard lists goals in creation order and comparing an
  * unsorted list against it by eye is how one gets missed. */
 export const ALL_GOALS: AnalyticsGoal[] = (
-  Object.keys(GOAL_DESCRIPTIONS) as AnalyticsGoal[]
+  Object.keys(GOALS) as AnalyticsGoal[]
 ).sort();
 
-/** Everything a search result can be, mapped onto the goal picking it converts.
+/** Whether `goal` fires from a page load rather than from a reader's action. */
+export function isPassiveGoal(goal: AnalyticsGoal): boolean {
+  return "passive" in GOALS[goal] && GOALS[goal].passive === true;
+}
+
+// --- search -------------------------------------------------------------
+
+/** What a search result can be, for `search:pick`'s `kind`.
  *
  * Wider than the node types the endpoint returns: „Lista wszystkich osób” and
  * the parties are entries OmniSearch builds itself and never asks the server
- * about, and they are worth telling apart from a hit - one is a reader with a
- * name in mind, the other is a reader giving up on typing one.
- *
- * A map rather than a built name, so a new kind is a type error here instead of
- * a goal Plausible silently drops on the floor. */
-export const SEARCH_PICK_GOALS = {
-  person: "search:pick-person",
-  place: "search:pick-place",
-  region: "search:pick-region",
-  party: "search:pick-party",
-  list: "search:pick-list",
-} as const satisfies Record<string, AnalyticsGoal>;
+ * about. */
+export const SEARCH_PICK_KINDS = [
+  "person",
+  "place",
+  "region",
+  "party",
+  "list",
+] as const;
+export type SearchPickKind = (typeof SEARCH_PICK_KINDS)[number];
 
-export type SearchPickKind = keyof typeof SEARCH_PICK_GOALS;
-
-/** How a hit from /api/search counts.
- *
- * Only these three: the endpoint filters on `type in ["person", "place",
- * "region"]` (`server/api/search.get.ts`), so an article or a topic reaching
- * the results would be a change to the search rather than a case to handle
- * here. The `NodeType` constraint is what keeps the keys honest if one of them
- * is ever renamed. */
+/** Only these three: /api/search filters on `type in ["person", "place",
+ * "region"]`, so an article or a topic reaching the results would be a change
+ * to the search rather than a case to handle here. The `NodeType` constraint is
+ * what keeps the keys honest if one of them is ever renamed. */
 const SEARCH_KINDS_BY_NODE_TYPE = {
   person: "person",
   place: "place",
   region: "region",
 } as const satisfies Partial<Record<NodeType, SearchPickKind>>;
 
-/** Which pick goal a search hit of `nodeType` converts.
+/** Which `kind` a search hit of `nodeType` is.
  *
  * A runtime lookup rather than an indexed type, because the type arrives over
  * the wire as a plain string - the endpoint returns whatever Firestore holds,
- * and a document with a `type` nobody expected should show up in the results
- * under some goal rather than crash the search box. "place" is the fallback for
- * the same reason the component uses it as its icon default. */
+ * and a document with an unexpected `type` should still show up under some kind
+ * rather than crash the search box. */
 export function searchPickKind(nodeType: string | undefined): SearchPickKind {
   return (
     (SEARCH_KINDS_BY_NODE_TYPE as Record<string, SearchPickKind>)[
@@ -147,11 +243,115 @@ export function searchPickKind(nodeType: string | undefined): SearchPickKind {
   );
 }
 
-/** The three things OmniSearch offers to create when it finds nothing. */
-export const SEARCH_PROPOSE_GOALS = {
-  person: "search:propose-person",
-  place: "search:propose-place",
-  article: "search:propose-article",
-} as const satisfies Record<string, AnalyticsGoal>;
+/** The things OmniSearch offers to create when it finds nothing. */
+export type SearchProposeKind = "person" | "place" | "article";
 
-export type SearchProposeKind = keyof typeof SEARCH_PROPOSE_GOALS;
+/** How many results a search returned, as something a dashboard can group by.
+ *
+ * Bucketed rather than exact: the interesting distinctions are "nothing",
+ * "a short list the reader can read" and "too many to choose from", and a
+ * property with one value per possible count is a list rather than a breakdown.
+ */
+export function resultBucket(count: number): string {
+  if (count === 0) return "none";
+  if (count <= 4) return "1-4";
+  if (count <= 20) return "5-20";
+  return "21+";
+}
+
+// --- /eksploruj/tabela filters -------------------------------------------
+
+/** The name each of the table's url parameters is reported under.
+ *
+ * Keyed by url parameter rather than by control, because that is where the page
+ * keeps its filter state: every control on the bar is a writable computed over
+ * `route.query`, so one watcher over these keys sees every filter, every chip's
+ * close button and every legacy spelling, and cannot drift when a control is
+ * added or moved.
+ *
+ * Two pairs map onto one name: `parties`/`party` and `krs`/`place` are the same
+ * filter under an older spelling that links minted before the rename still
+ * carry. Paging, sorting and row count are deliberately absent - they are the
+ * table's own state, not filters, and they have goals of their own.
+ */
+export const TABELA_FILTER_NAMES = {
+  party: "party",
+  parties: "party",
+  teryt: "region",
+  companyTeryt: "company-region",
+  place: "company",
+  krs: "company",
+  category: "category",
+  currentlyEmployed: "currently-employed",
+  minEmploymentDate: "employed-since",
+  visibility: "visibility",
+  hideVoted: "voted",
+  minVotes: "min-votes",
+} as const satisfies Record<string, string>;
+
+export type TabelaFilterKey = keyof typeof TABELA_FILTER_NAMES;
+
+const TABELA_FILTER_KEYS = Object.keys(
+  TABELA_FILTER_NAMES,
+) as TabelaFilterKey[];
+
+/** A url query as the router hands it over: a string, a list, or nothing. */
+type QueryValue = string | null | undefined | (string | null)[];
+export type TabelaQuery = Partial<Record<string, QueryValue>>;
+
+/** Whether `value` means the filter is on.
+ *
+ * An empty string and an empty array are both "off": `stringFilter` leaves a
+ * cleared text filter as `""` rather than removing the key, and a multi-select
+ * emptied down to nothing does the same. Counting those as filters would report
+ * every reader who cleared one chip as still filtering. */
+function isSet(value: QueryValue): boolean {
+  if (value == null) return false;
+  if (Array.isArray(value)) return value.some((entry) => !!entry);
+  return value !== "";
+}
+
+/** The filters carrying a value in `query`, by reported name and deduplicated.
+ *
+ * Used for the arrival split - a reader who lands with one of these came from
+ * search, a chip or a shared link, and wanted something specific. */
+export function activeTabelaFilters(query: TabelaQuery): string[] {
+  const names = new Set<string>();
+  for (const key of TABELA_FILTER_KEYS) {
+    if (isSet(query[key])) names.add(TABELA_FILTER_NAMES[key]);
+  }
+  return [...names].sort();
+}
+
+/** Comparable form of a query value, so `["pis"]` and `"pis"` are one filter.
+ *
+ * The router gives a single-valued parameter as a string and a repeated one as
+ * an array, and which of the two a filter arrives as depends on how the url was
+ * written rather than on what it means. */
+function normalise(value: QueryValue): string {
+  if (value == null) return "";
+  return (Array.isArray(value) ? value : [value])
+    .filter((entry): entry is string => !!entry)
+    .join(",");
+}
+
+/** The filters a move from `before` to `after` touched, deduplicated.
+ *
+ * Deduplicated because of the shared keys above: switching an employer from a
+ * `krs` link to a picked `place` changes two parameters and is one thing the
+ * reader did. Clearing counts as changing - dropping the one party chip is
+ * using the party filter - which is why „Wyczyść” is not routed through here;
+ * it would report eight filters used by somebody who used none.
+ */
+export function tabelaFiltersChanged(
+  before: TabelaQuery,
+  after: TabelaQuery,
+): string[] {
+  const names = new Set<string>();
+  for (const key of TABELA_FILTER_KEYS) {
+    if (normalise(before[key]) !== normalise(after[key])) {
+      names.add(TABELA_FILTER_NAMES[key]);
+    }
+  }
+  return [...names].sort();
+}

--- a/frontend/shared/analytics.ts
+++ b/frontend/shared/analytics.ts
@@ -1,0 +1,157 @@
+/** Every custom event the site is allowed to send to Plausible, in one place.
+ *
+ * Two reasons this is a closed vocabulary rather than string literals at the
+ * call sites.
+ *
+ * The first is that Plausible only *counts* an event it has been told about:
+ * an event whose name is not registered as a goal on the dashboard is accepted,
+ * stored and then invisible. So the set has to be enumerable to be set up at
+ * all - `ALL_GOALS` below is the list to paste into Settings -> Goals, and
+ * `analytics.test.ts` fails if a name is added here without a description, so
+ * the list stays the documentation of what each goal means.
+ *
+ * The second is that koryta.pl is on a Growth plan, where **custom properties
+ * do not exist**. On Business you would send `track("search", { props: { kind:
+ * "person" }})` and break the goal down by `kind` in the dashboard; on Growth
+ * that property is accepted by the API and then dropped. Any dimension worth
+ * having therefore has to be part of the goal *name*, which is why the names
+ * below read `search:pick-person` rather than `search:pick`. That trades a
+ * longer goal list for being able to see the answer, and it is the reason the
+ * vocabulary has to stay small - a dimension with more than a handful of values
+ * (a powiat, a person) must not go in a name. `home-map:region` is one goal for
+ * all 380 powiaty on purpose.
+ *
+ * Properties are sent anyway, by `useAnalytics`, where they add something. They
+ * cost nothing today and mean a later upgrade to Business starts producing
+ * breakdowns without another pass over the call sites.
+ */
+
+import type { NodeType } from "./model";
+
+/** The naming rule, such as it is: `<surface>:<what happened>`, kebab-case,
+ * present tense, and the surface is where the reader was rather than which
+ * component fired it. `home-explorer:tab-parties` survives the component being
+ * renamed; `Explorer:tabChange` would not. */
+export type AnalyticsGoal = keyof typeof GOAL_DESCRIPTIONS;
+
+/** What each goal means, in the terms someone reading the dashboard needs.
+ *
+ * Write these for the person looking at a number six months from now who did
+ * not write the code - "which of the two panels people actually open" is useful,
+ * "fires on tab change" is not.
+ */
+export const GOAL_DESCRIPTIONS = {
+  // --- The home page explorer -------------------------------------------
+  // These four exist to answer one question without splitting traffic: of the
+  // people who land on `/` - 73% of all entrances - does anybody go to the
+  // party treemap, and does either panel send them anywhere? The tab strip is
+  // already there and already switchable, so the answer is observable as soon
+  // as it is measured. Only then is an experiment on the *default* tab worth
+  // the traffic it would cost.
+  "home-explorer:tab-map": "Reader switched the home explorer back to the map.",
+  "home-explorer:tab-parties":
+    "Reader opened the party treemap on the home page. The count of people who ever do this is the whole case for or against making it the default.",
+  "home-map:region":
+    "Reader clicked a powiat on the home map, which filters the list beside it. The map's only conversion.",
+  "home-parties:party":
+    "Reader clicked a party in the treemap, which opens the table filtered to it. The treemap's only conversion, and the one comparable to home-map:region.",
+
+  // --- Search -----------------------------------------------------------
+  // OmniSearch is the first thing on a phone and the site has no idea what is
+  // typed into it, whether anything came back, or whether the reader took what
+  // it offered.
+  "search:performed": "A search query actually reached /api/search.",
+  "search:no-results":
+    "A search returned nothing. The gap between this and search:performed is the honest measure of whether the index covers what people look for.",
+  "search:pick-person": "Reader opened a person from the search results.",
+  "search:pick-place": "Reader opened an institution or company from search.",
+  "search:pick-region": "Reader opened a region from search.",
+  "search:pick-party":
+    "Reader picked a party from search, which opens the table filtered to it.",
+  "search:pick-list":
+    "Reader picked „Lista wszystkich osób”, the entry that is always first.",
+  "search:propose-person":
+    "Reader started adding a person the search could not find.",
+  "search:propose-place":
+    "Reader started adding an institution the search could not find.",
+  "search:propose-article":
+    "Reader started adding a source the search could not find.",
+
+  // --- The contribution funnel -----------------------------------------
+  // The volunteer form is an outbound Google Forms link and has been the site's
+  // main ask since it launched. Nobody has ever been able to say whether one
+  // person clicked it. `autoOutboundTracking` counts outbound clicks in
+  // aggregate, but on Growth the url is a property, so it cannot say *which*
+  // link - hence a named goal for the ones that matter.
+  "cta:volunteer-form":
+    "Reader clicked through to the volunteer Google Form. The site's primary conversion.",
+  "cta:pomoc": "Reader went to /pomoc from a call to action.",
+  "cta:donate":
+    "Reader clicked through to Patronite or Zrzutka. Both are outbound.",
+  "cta:community":
+    "Reader clicked through to Slack, Discord, Facebook or the GitHub issue tracker from /pomoc.",
+} as const satisfies Record<string, string>;
+
+/** Every goal name, for pasting into Plausible -> Settings -> Goals.
+ *
+ * Sorted, because the dashboard lists goals in creation order and comparing an
+ * unsorted list against it by eye is how one gets missed. */
+export const ALL_GOALS: AnalyticsGoal[] = (
+  Object.keys(GOAL_DESCRIPTIONS) as AnalyticsGoal[]
+).sort();
+
+/** Everything a search result can be, mapped onto the goal picking it converts.
+ *
+ * Wider than the node types the endpoint returns: „Lista wszystkich osób” and
+ * the parties are entries OmniSearch builds itself and never asks the server
+ * about, and they are worth telling apart from a hit - one is a reader with a
+ * name in mind, the other is a reader giving up on typing one.
+ *
+ * A map rather than a built name, so a new kind is a type error here instead of
+ * a goal Plausible silently drops on the floor. */
+export const SEARCH_PICK_GOALS = {
+  person: "search:pick-person",
+  place: "search:pick-place",
+  region: "search:pick-region",
+  party: "search:pick-party",
+  list: "search:pick-list",
+} as const satisfies Record<string, AnalyticsGoal>;
+
+export type SearchPickKind = keyof typeof SEARCH_PICK_GOALS;
+
+/** How a hit from /api/search counts.
+ *
+ * Only these three: the endpoint filters on `type in ["person", "place",
+ * "region"]` (`server/api/search.get.ts`), so an article or a topic reaching
+ * the results would be a change to the search rather than a case to handle
+ * here. The `NodeType` constraint is what keeps the keys honest if one of them
+ * is ever renamed. */
+const SEARCH_KINDS_BY_NODE_TYPE = {
+  person: "person",
+  place: "place",
+  region: "region",
+} as const satisfies Partial<Record<NodeType, SearchPickKind>>;
+
+/** Which pick goal a search hit of `nodeType` converts.
+ *
+ * A runtime lookup rather than an indexed type, because the type arrives over
+ * the wire as a plain string - the endpoint returns whatever Firestore holds,
+ * and a document with a `type` nobody expected should show up in the results
+ * under some goal rather than crash the search box. "place" is the fallback for
+ * the same reason the component uses it as its icon default. */
+export function searchPickKind(nodeType: string | undefined): SearchPickKind {
+  return (
+    (SEARCH_KINDS_BY_NODE_TYPE as Record<string, SearchPickKind>)[
+      nodeType ?? ""
+    ] ?? "place"
+  );
+}
+
+/** The three things OmniSearch offers to create when it finds nothing. */
+export const SEARCH_PROPOSE_GOALS = {
+  person: "search:propose-person",
+  place: "search:propose-place",
+  article: "search:propose-article",
+} as const satisfies Record<string, AnalyticsGoal>;
+
+export type SearchProposeKind = keyof typeof SEARCH_PROPOSE_GOALS;

--- a/frontend/shared/experiments.ts
+++ b/frontend/shared/experiments.ts
@@ -13,11 +13,25 @@
  * machinery does is exist. Turning it on is changing the weights, and the goals
  * are already registered so no data is lost to a forgotten dashboard step.
  *
- * Before spending traffic on the split, read `home-explorer:tab-parties`
- * (`shared/analytics.ts`). The tab strip is already switchable, so how many
- * people open the treemap at all is observable for free, at full sample size,
- * with no arm to divide by. An experiment is only worth running if that number
- * is ambiguous.
+ * Before spending traffic on the split, read `home-explorer:tab` broken down by
+ * `tab`, and `home-explorer:pick` broken down by `panel` (`shared/analytics.ts`).
+ * The tab strip is already switchable, so how many people open the treemap at
+ * all - and what each panel converts once opened - is observable for free, at
+ * full sample size, with no arm to divide by. An experiment is only worth
+ * running if those numbers are ambiguous.
+ *
+ * ## The arm is a property, not a goal
+ *
+ * On a Business plan the arm rides as a custom property on every event
+ * (`setGlobalProp` in `app/composables/analytics.ts`), so the dashboard can be
+ * filtered to one arm and *every* goal compared across them. That is a
+ * different and much better measurement than a goal per arm would have been:
+ * with a goal you can only count conversions, with a property you can ask what
+ * each arm's readers went on to do.
+ *
+ * One goal remains - `experiment:assigned` - and it is there to give each arm a
+ * denominator. It is passive, so being sorted into an arm does not by itself
+ * count as engagement.
  *
  * ## Stickiness is per session, on purpose
  *
@@ -109,27 +123,13 @@ export const EXPERIMENTS = {
 
 export type ExperimentId = keyof typeof EXPERIMENTS;
 
-/** The goal that records which arm a reader was assigned to.
+/** The property name an experiment's arm is reported under.
  *
- * On a Growth plan this marker is the *only* way to segment the other goals:
- * custom properties do not exist, but the dashboard can be filtered to visitors
- * who completed a given goal. So the reading is "filter to
- * `exp:home-default:parties`, then look at `home-parties:party`" - which is why
- * the arm has to be its own goal rather than a property on the others. */
-export function experimentGoal(experimentId: string, armId: string): string {
-  return `exp:${experimentId}:${armId}`;
+ * Keyed by experiment rather than a single `arm` property, so two experiments
+ * running at once do not overwrite each other on the same event. */
+export function armPropertyName(experimentId: string): string {
+  return `arm:${experimentId}`;
 }
-
-/** Every arm-marker goal, including the arms currently at zero weight.
- *
- * Zero-weight arms are included deliberately: registering a goal in Plausible
- * is a manual dashboard step, and the point of this list is that activating an
- * experiment never needs one. */
-export const EXPERIMENT_GOALS: string[] = Object.values(EXPERIMENTS)
-  .flatMap((experiment) =>
-    experiment.arms.map((arm) => experimentGoal(experiment.id, arm.id)),
-  )
-  .sort();
 
 /** A stable number in [0, 1) from an arbitrary string.
  *

--- a/frontend/shared/experiments.ts
+++ b/frontend/shared/experiments.ts
@@ -1,0 +1,176 @@
+/** A/B experiments: which arm a reader is in, and how that reaches Plausible.
+ *
+ * ## Why this is deliberately small
+ *
+ * koryta.pl saw 381 visitors in the last 21 days of the August export - about
+ * 18 a day outside a press spike, against a median of 16 over the whole 91-day
+ * window. Split three ways that is six readers per arm per day, and the traffic
+ * is spike-driven rather than steady: one Facebook post lands 700 people in an
+ * afternoon and whichever arm it happens to weight is the one that "wins".
+ *
+ * So the registry below ships **dormant** - `home-default` gives every reader
+ * the map, exactly what the site does today, and the only thing the experiment
+ * machinery does is exist. Turning it on is changing the weights, and the goals
+ * are already registered so no data is lost to a forgotten dashboard step.
+ *
+ * Before spending traffic on the split, read `home-explorer:tab-parties`
+ * (`shared/analytics.ts`). The tab strip is already switchable, so how many
+ * people open the treemap at all is observable for free, at full sample size,
+ * with no arm to divide by. An experiment is only worth running if that number
+ * is ambiguous.
+ *
+ * ## Stickiness is per session, on purpose
+ *
+ * The arm is held in `sessionStorage`, not a cookie. Two reasons, and the
+ * second is the real one:
+ *
+ * 1. Plausible is cookieless, and the site says so. Setting an identifier
+ *    cookie to run an experiment on top of it would be a bigger change to what
+ *    the site does with its readers than the experiment is worth.
+ * 2. Plausible's own notion of a visitor is a hash that rotates daily. Pinning
+ *    an arm for 90 days while the analytics re-identifies the same person every
+ *    morning does not buy a longer measurement - it just puts one reader's
+ *    later visits in a different bucket from their first, which is noise. A
+ *    session is the unit the numbers are actually reported in.
+ *
+ * ## The one thing to fix before activating
+ *
+ * `routeRules` caches `/` with `swr: 3600` (`nuxt.config.ts`), so the server
+ * renders the home page once an hour and hands the same html to everybody. The
+ * arm therefore cannot be decided server-side as things stand, and is resolved
+ * after hydration - which means a reader in a non-default arm sees the map for
+ * a frame before the tab switches. Control has no such swap, so the flash is an
+ * asymmetry between the arms and would bias the very comparison being run.
+ *
+ * Two ways out when the time comes, neither free:
+ *   - drop `swr` on `/`, and pay a full render per request on a container that
+ *     runs at `minInstances: 0`; or
+ *   - keep `swr` and vary the cache key on an arm header set by a server
+ *     middleware, which is one cache entry per arm and no flash, but puts the
+ *     assignment on the server where it has to agree with the client's.
+ * Deciding that is part of activating the experiment, not of shipping this.
+ */
+
+/** One arm of an experiment. `weight` is relative, not a percentage - the
+ * weights are summed and each arm gets its share, so `[1, 1, 1]` and
+ * `[10, 10, 10]` mean the same thing and a zero-weight arm is simply off. */
+export type ExperimentArm<Id extends string = string> = {
+  id: Id;
+  weight: number;
+  /** What this arm shows, for whoever reads the results later. */
+  description: string;
+};
+
+export type Experiment<Id extends string = string> = {
+  id: string;
+  /** The question the split is meant to answer, in one sentence. */
+  question: string;
+  arms: ExperimentArm<Id>[];
+};
+
+/** Which panel the home page opens on.
+ *
+ * All the weight is on `map`, which is what `HomeExplorer` has always defaulted
+ * to, so this changes nothing until somebody moves it. `gry` is declared with
+ * no weight and no implementation: the games hub lives on the `gry-games`
+ * branch, and naming the arm here is what keeps the eventual three-way split
+ * from being a redesign - see `useExperiment`, which falls back to the first
+ * arm for anything it does not recognise. */
+export const HOME_DEFAULT_EXPERIMENT = {
+  id: "home-default",
+  question:
+    "Which of the home explorer's panels should a first-time reader land on?",
+  arms: [
+    {
+      id: "map",
+      weight: 1,
+      description: "Mapa koryciarstwa, the panel the page opens on today.",
+    },
+    {
+      id: "parties",
+      weight: 0,
+      description: "Podział na partie, the treemap that is currently a tab.",
+    },
+    {
+      id: "gry",
+      weight: 0,
+      description:
+        "The /gry hub. Not built on main - the arm is declared so activating it is a weight change plus a panel, and the goal already exists in Plausible.",
+    },
+  ],
+} as const satisfies Experiment;
+
+export type HomeDefaultArm =
+  (typeof HOME_DEFAULT_EXPERIMENT)["arms"][number]["id"];
+
+export const EXPERIMENTS = {
+  "home-default": HOME_DEFAULT_EXPERIMENT,
+} as const;
+
+export type ExperimentId = keyof typeof EXPERIMENTS;
+
+/** The goal that records which arm a reader was assigned to.
+ *
+ * On a Growth plan this marker is the *only* way to segment the other goals:
+ * custom properties do not exist, but the dashboard can be filtered to visitors
+ * who completed a given goal. So the reading is "filter to
+ * `exp:home-default:parties`, then look at `home-parties:party`" - which is why
+ * the arm has to be its own goal rather than a property on the others. */
+export function experimentGoal(experimentId: string, armId: string): string {
+  return `exp:${experimentId}:${armId}`;
+}
+
+/** Every arm-marker goal, including the arms currently at zero weight.
+ *
+ * Zero-weight arms are included deliberately: registering a goal in Plausible
+ * is a manual dashboard step, and the point of this list is that activating an
+ * experiment never needs one. */
+export const EXPERIMENT_GOALS: string[] = Object.values(EXPERIMENTS)
+  .flatMap((experiment) =>
+    experiment.arms.map((arm) => experimentGoal(experiment.id, arm.id)),
+  )
+  .sort();
+
+/** A stable number in [0, 1) from an arbitrary string.
+ *
+ * FNV-1a. It is not a good hash and does not need to be - it needs to be the
+ * same in a test as in a browser, to have no dependency, and to spread a few
+ * thousand random session ids evenly across three buckets. Math.random() is
+ * what actually assigns; this only turns an id into a position so that the
+ * assignment is a pure function of it and can be asserted on. */
+export function hashToUnitInterval(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    // The FNV prime, by shift-add rather than multiplication: `hash * 16777619`
+    // overflows a double's exact-integer range and stops being reproducible.
+    hash +=
+      (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+  }
+  // >>> 0 reads the low 32 bits as unsigned; without it the sign bit makes half
+  // the inputs negative and every one of those lands in the first arm.
+  return (hash >>> 0) / 4294967296;
+}
+
+/** Which arm `sessionId` belongs to.
+ *
+ * Falls back to the first arm - never to nothing - so that a mistyped weight,
+ * an experiment whose arms all sit at zero, or an id that hashes to exactly 1
+ * shows the reader the control rather than an empty panel. */
+export function assignArm<Id extends string>(
+  experiment: Experiment<Id>,
+  sessionId: string,
+): Id {
+  const arms = experiment.arms;
+  const control = arms[0]!.id;
+
+  const total = arms.reduce((sum, arm) => sum + Math.max(0, arm.weight), 0);
+  if (total <= 0) return control;
+
+  let position = hashToUnitInterval(`${experiment.id}:${sessionId}`) * total;
+  for (const arm of arms) {
+    position -= Math.max(0, arm.weight);
+    if (position < 0) return arm.id;
+  }
+  return control;
+}

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,24 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "pomiar-tabeli-eksploruj",
+    title: "Wiemy, co ludzie robią w tabeli",
+    description:
+      "Tabela jest drugą najczęściej otwieraną stroną, ale trzech na " +
+      "czterech czytelników, którzy na niej zaczynają, wychodziło bez śladu " +
+      "- filtry, sortowanie i przewijanie stron zmieniają tylko adres, więc " +
+      "dla statystyk wyglądały jak nic. Teraz każde z nich się liczy. " +
+      "Wygląd i działanie strony bez zmian.",
+    steps: [
+      "Wejdź na /eksploruj/tabela, ustaw filtr partii, posortuj kolumnę i przejdź na drugą stronę wyników - wszystko ma działać jak dotąd.",
+      "Kliknij nazwisko: ma się otworzyć panel boczny osoby.",
+      "Kliknij „Wyczyść” - wszystkie filtry znikają naraz.",
+      "Skopiuj link z karty udostępniania i sprawdź, że otwiera tę samą przefiltrowaną tabelę.",
+    ],
+    link: "/eksploruj/tabela",
+    area: "public",
+  },
+  {
     id: "pomiar-uzycia-strony",
     title: "Wiemy wreszcie, w co ludzie na stronie klikają",
     description:

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,25 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "pomiar-uzycia-strony",
+    title: "Wiemy wreszcie, w co ludzie na stronie klikają",
+    description:
+      "Strona zbierała dotąd tylko odsłony - nie było widać ani czego " +
+      "szukacie w wyszukiwarce, ani czy ktokolwiek otwiera „Partie” na " +
+      "stronie głównej, ani czy formularz wolontariusza kliknęła choć jedna " +
+      "osoba. Teraz każde z tych zdarzeń trafia do Plausible pod własną " +
+      "nazwą. Nic się nie zmienia w tym, co widać: to ten sam interfejs, " +
+      "tylko policzony. Statystyki są zbiorcze i nadal bez ciasteczek.",
+    steps: [
+      "Na stronie głównej przełącz zakładkę z „Mapa” na „Partie” i z powrotem.",
+      "Wpisz coś w wyszukiwarkę i wybierz podpowiedź - albo wpisz nazwisko, którego nie ma, i sprawdź, czy proponuje dodanie osoby.",
+      "Kliknij kafelek na mapie, a potem kwadrat partii w drzewie na zakładce „Partie” - oba powinny prowadzić tam, gdzie prowadziły wcześniej.",
+      "Wejdź na /pomoc i kliknij dowolny link wychodzący (formularz, Patronite, Slack) - ma się otworzyć w nowej karcie tak jak dotąd.",
+    ],
+    link: "/",
+    area: "public",
+  },
+  {
     id: "szpitale-bez-ostrzezen-hydracji-po-zalogowaniu",
     title: "Strona szpitali nie zgłasza błędów hydracji po zalogowaniu",
     description:

--- a/frontend/tests/components/OmniSearch.test.ts
+++ b/frontend/tests/components/OmniSearch.test.ts
@@ -149,7 +149,7 @@ describe("OmniSearch", () => {
     await autocomplete.emit("update:modelValue", {
       title: "Place 1",
       path: "/entity/place/place1",
-      logEventKey: { content_id: "place1", content_type: "place" },
+      analyticsKind: "place",
     });
 
     await nextTick();

--- a/frontend/tests/components/home/Explorer.test.ts
+++ b/frontend/tests/components/home/Explorer.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mountSuspended, registerEndpoint } from "@nuxt/test-utils/runtime";
+import Explorer from "../../../app/components/home/Explorer.vue";
+import { HOME_DEFAULT_EXPERIMENT } from "../../../shared/experiments";
+
+/** Mocked at the composable rather than at the tracker, so the assertions are
+ * about which goal the explorer decided to fire. Whether the plausible plugin
+ * booted in the test environment is a different question, and not one this
+ * component can answer. */
+const trackGoal = vi.fn();
+const trackExperimentGoal = vi.fn();
+vi.mock("~/composables/analytics", () => ({
+  trackGoal: (...args: unknown[]) => trackGoal(...args),
+  trackExperimentGoal: (...args: unknown[]) => trackExperimentGoal(...args),
+}));
+
+registerEndpoint("/api/stats/progress", () => ({
+  total: 100,
+  approved: 40,
+  reviewed: 30,
+  toCheck: 30,
+}));
+
+const mount = () =>
+  mountSuspended(Explorer, {
+    global: {
+      stubs: {
+        // The map is an svg of 380 powiaty, the treemap needs apexcharts and
+        // the list needs firestore. None of them is what is under test here.
+        //
+        // Both names for the treemap: the template asks for the `Lazy` variant,
+        // and stubbing only that one leaves apexcharts to render into a
+        // detached happy-dom node and reject with "Element not found" - after
+        // the assertions have passed, so the suite stays green and the run
+        // exits 1.
+        ChartPolandMap: true,
+        ChartTreemapParty: true,
+        LazyChartTreemapParty: true,
+        CardPeopleList: true,
+      },
+    },
+  });
+
+/** Both breakpoints render a tab strip bound to the same value, so "the Partie
+ * tab" is two elements. Clicking either has to do the same thing - and firing
+ * twice for one reader is exactly the bug the controlled model-value guards
+ * against. */
+const tabs = (wrapper: Awaited<ReturnType<typeof mount>>, label: string) =>
+  wrapper.findAll(".v-tab").filter((tab) => tab.text() === label);
+
+beforeEach(() => {
+  trackGoal.mockClear();
+  trackExperimentGoal.mockClear();
+  sessionStorage.clear();
+});
+
+describe("HomeExplorer", () => {
+  it("opens on the map while the experiment is dormant", async () => {
+    const wrapper = await mount();
+
+    expect(wrapper.text()).toContain("Mapa koryciarstwa");
+    expect(wrapper.text()).not.toContain("Podział na partie");
+  });
+
+  it("records the arm once, not once per tab strip", async () => {
+    await mount();
+
+    expect(trackExperimentGoal).toHaveBeenCalledTimes(1);
+    expect(trackExperimentGoal.mock.calls[0]![0]).toBe(
+      `exp:${HOME_DEFAULT_EXPERIMENT.id}:map`,
+    );
+  });
+
+  it("counts a switch to the party treemap, and back", async () => {
+    const wrapper = await mount();
+
+    await tabs(wrapper, "Partie")[0]!.trigger("click");
+    expect(trackGoal).toHaveBeenCalledWith("home-explorer:tab-parties");
+    expect(wrapper.text()).toContain("Podział na partie");
+
+    trackGoal.mockClear();
+    await tabs(wrapper, "Mapa")[0]!.trigger("click");
+    expect(trackGoal).toHaveBeenCalledWith("home-explorer:tab-map");
+  });
+
+  it("does not count a click on the tab already open", async () => {
+    const wrapper = await mount();
+
+    await tabs(wrapper, "Mapa")[0]!.trigger("click");
+
+    expect(trackGoal).not.toHaveBeenCalled();
+  });
+
+  it("counts a powiat picked on the map", async () => {
+    const wrapper = await mount();
+    const map = wrapper.findComponent({ name: "ChartPolandMap" });
+
+    map.vm.$emit("click", { teryt: "1261", d: "", name: "Kraków" });
+    await wrapper.vm.$nextTick();
+
+    expect(trackGoal).toHaveBeenCalledWith("home-map:region", {
+      region: "1261",
+    });
+  });
+});

--- a/frontend/tests/components/home/Explorer.test.ts
+++ b/frontend/tests/components/home/Explorer.test.ts
@@ -8,10 +8,10 @@ import { HOME_DEFAULT_EXPERIMENT } from "../../../shared/experiments";
  * booted in the test environment is a different question, and not one this
  * component can answer. */
 const trackGoal = vi.fn();
-const trackExperimentGoal = vi.fn();
+const setGlobalProp = vi.fn();
 vi.mock("~/composables/analytics", () => ({
   trackGoal: (...args: unknown[]) => trackGoal(...args),
-  trackExperimentGoal: (...args: unknown[]) => trackExperimentGoal(...args),
+  setGlobalProp: (...args: unknown[]) => setGlobalProp(...args),
 }));
 
 registerEndpoint("/api/stats/progress", () => ({
@@ -50,7 +50,7 @@ const tabs = (wrapper: Awaited<ReturnType<typeof mount>>, label: string) =>
 
 beforeEach(() => {
   trackGoal.mockClear();
-  trackExperimentGoal.mockClear();
+  setGlobalProp.mockClear();
   sessionStorage.clear();
 });
 
@@ -65,26 +65,51 @@ describe("HomeExplorer", () => {
   it("records the arm once, not once per tab strip", async () => {
     await mount();
 
-    expect(trackExperimentGoal).toHaveBeenCalledTimes(1);
-    expect(trackExperimentGoal.mock.calls[0]![0]).toBe(
-      `exp:${HOME_DEFAULT_EXPERIMENT.id}:map`,
+    const assigned = trackGoal.mock.calls.filter(
+      (call) => call[0] === "experiment:assigned",
     );
+    expect(assigned).toHaveLength(1);
+    expect(assigned[0]![1]).toEqual({
+      experiment: HOME_DEFAULT_EXPERIMENT.id,
+      arm: "map",
+    });
+  });
+
+  it("puts the arm on every later event", async () => {
+    // The whole point of moving off a goal-per-arm: with the arm as a property
+    // the dashboard can be filtered to one arm and any metric compared, not
+    // just the conversions of one goal.
+    const wrapper = await mount();
+
+    expect(setGlobalProp).toHaveBeenCalledWith(
+      `arm:${HOME_DEFAULT_EXPERIMENT.id}`,
+      "map",
+    );
+    // Registered before the first goal is sent, so the denominator sits inside
+    // the same filter as the things it is a denominator for.
+    expect(setGlobalProp.mock.invocationCallOrder[0]!).toBeLessThan(
+      trackGoal.mock.invocationCallOrder[0]!,
+    );
+    expect(wrapper.text()).toContain("Mapa koryciarstwa");
   });
 
   it("counts a switch to the party treemap, and back", async () => {
     const wrapper = await mount();
 
     await tabs(wrapper, "Partie")[0]!.trigger("click");
-    expect(trackGoal).toHaveBeenCalledWith("home-explorer:tab-parties");
+    expect(trackGoal).toHaveBeenCalledWith("home-explorer:tab", {
+      tab: "parties",
+    });
     expect(wrapper.text()).toContain("Podział na partie");
 
     trackGoal.mockClear();
     await tabs(wrapper, "Mapa")[0]!.trigger("click");
-    expect(trackGoal).toHaveBeenCalledWith("home-explorer:tab-map");
+    expect(trackGoal).toHaveBeenCalledWith("home-explorer:tab", { tab: "map" });
   });
 
   it("does not count a click on the tab already open", async () => {
     const wrapper = await mount();
+    trackGoal.mockClear();
 
     await tabs(wrapper, "Mapa")[0]!.trigger("click");
 
@@ -98,8 +123,9 @@ describe("HomeExplorer", () => {
     map.vm.$emit("click", { teryt: "1261", d: "", name: "Kraków" });
     await wrapper.vm.$nextTick();
 
-    expect(trackGoal).toHaveBeenCalledWith("home-map:region", {
-      region: "1261",
+    expect(trackGoal).toHaveBeenCalledWith("home-explorer:pick", {
+      panel: "map",
+      value: "1261",
     });
   });
 });

--- a/frontend/tests/shared/analytics.test.ts
+++ b/frontend/tests/shared/analytics.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  ALL_GOALS,
+  GOAL_DESCRIPTIONS,
+  SEARCH_PICK_GOALS,
+  SEARCH_PROPOSE_GOALS,
+  searchPickKind,
+} from "../../shared/analytics";
+import { EXPERIMENT_GOALS } from "../../shared/experiments";
+
+/** A goal Plausible has not been told about is recorded and then invisible, so
+ * the checks here are about the list staying something one can paste into the
+ * dashboard: every name described, every name unique, and no name carrying a
+ * dimension with more values than a goal list can hold. */
+describe("the goal vocabulary", () => {
+  it("describes every goal", () => {
+    for (const goal of ALL_GOALS) {
+      expect(GOAL_DESCRIPTIONS[goal], goal).toBeTruthy();
+      // A description that only restates the name tells the person reading the
+      // dashboard in six months nothing they did not already have.
+      expect(GOAL_DESCRIPTIONS[goal].length, goal).toBeGreaterThan(20);
+    }
+  });
+
+  it("names every goal <surface>:<what happened>", () => {
+    for (const goal of ALL_GOALS) {
+      expect(goal, goal).toMatch(/^[a-z0-9-]+:[a-z0-9-]+$/);
+    }
+  });
+
+  it("stays small enough to register by hand", () => {
+    // Not a law of nature, but a tripwire: the moment this list is long enough
+    // to be tedious to set up, somebody has put a high-cardinality dimension in
+    // a name and the Growth-plan reasoning in shared/analytics.ts has been
+    // forgotten. Raise it deliberately, not to make a red test green.
+    expect(ALL_GOALS.length + EXPERIMENT_GOALS.length).toBeLessThan(40);
+  });
+
+  it("does not collide with an experiment marker", () => {
+    for (const goal of EXPERIMENT_GOALS) {
+      expect(ALL_GOALS).not.toContain(goal);
+    }
+  });
+
+  it("points every search goal at a registered name", () => {
+    for (const goal of [
+      ...Object.values(SEARCH_PICK_GOALS),
+      ...Object.values(SEARCH_PROPOSE_GOALS),
+    ]) {
+      expect(ALL_GOALS).toContain(goal);
+    }
+  });
+});
+
+describe("searchPickKind", () => {
+  it("maps the three types /api/search returns", () => {
+    expect(searchPickKind("person")).toBe("person");
+    expect(searchPickKind("place")).toBe("place");
+    expect(searchPickKind("region")).toBe("region");
+  });
+
+  it("files anything unexpected as a place rather than throwing", () => {
+    // The type arrives over the wire; a document with a stray one should still
+    // land under some goal instead of breaking the search box.
+    expect(searchPickKind("topic")).toBe("place");
+    expect(searchPickKind(undefined)).toBe("place");
+    expect(searchPickKind("")).toBe("place");
+  });
+});

--- a/frontend/tests/shared/analytics.test.ts
+++ b/frontend/tests/shared/analytics.test.ts
@@ -1,24 +1,28 @@
 import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   ALL_GOALS,
-  GOAL_DESCRIPTIONS,
-  SEARCH_PICK_GOALS,
-  SEARCH_PROPOSE_GOALS,
+  GOALS,
+  SEARCH_PICK_KINDS,
+  TABELA_FILTER_NAMES,
+  activeTabelaFilters,
+  isPassiveGoal,
+  resultBucket,
   searchPickKind,
+  tabelaFiltersChanged,
 } from "../../shared/analytics";
-import { EXPERIMENT_GOALS } from "../../shared/experiments";
 
 /** A goal Plausible has not been told about is recorded and then invisible, so
  * the checks here are about the list staying something one can paste into the
- * dashboard: every name described, every name unique, and no name carrying a
- * dimension with more values than a goal list can hold. */
+ * dashboard: every name described, every name well formed, and every property
+ * declared where the type checker can hold the call sites to it. */
 describe("the goal vocabulary", () => {
   it("describes every goal", () => {
     for (const goal of ALL_GOALS) {
-      expect(GOAL_DESCRIPTIONS[goal], goal).toBeTruthy();
       // A description that only restates the name tells the person reading the
       // dashboard in six months nothing they did not already have.
-      expect(GOAL_DESCRIPTIONS[goal].length, goal).toBeGreaterThan(20);
+      expect(GOALS[goal].description.length, goal).toBeGreaterThan(20);
     }
   });
 
@@ -28,27 +32,34 @@ describe("the goal vocabulary", () => {
     }
   });
 
+  it("names every property in a form Plausible can group by", () => {
+    for (const goal of ALL_GOALS) {
+      for (const prop of GOALS[goal].props) {
+        expect(prop, `${goal}.${prop}`).toMatch(/^[a-z][a-z0-9-]*$/);
+      }
+      // Plausible caps an event at 30 properties; anything near that is a log
+      // line rather than a dimension.
+      expect(GOALS[goal].props.length, goal).toBeLessThanOrEqual(4);
+    }
+  });
+
   it("stays small enough to register by hand", () => {
-    // Not a law of nature, but a tripwire: the moment this list is long enough
-    // to be tedious to set up, somebody has put a high-cardinality dimension in
-    // a name and the Growth-plan reasoning in shared/analytics.ts has been
-    // forgotten. Raise it deliberately, not to make a red test green.
-    expect(ALL_GOALS.length + EXPERIMENT_GOALS.length).toBeLessThan(40);
+    // Not a law of nature, but a tripwire: goals are created one at a time in
+    // the dashboard by hand, and the moment this list is tedious to set up,
+    // somebody has spelled a dimension into a name that belongs in a property.
+    expect(ALL_GOALS.length).toBeLessThan(30);
   });
 
-  it("does not collide with an experiment marker", () => {
-    for (const goal of EXPERIMENT_GOALS) {
-      expect(ALL_GOALS).not.toContain(goal);
-    }
-  });
-
-  it("points every search goal at a registered name", () => {
-    for (const goal of [
-      ...Object.values(SEARCH_PICK_GOALS),
-      ...Object.values(SEARCH_PROPOSE_GOALS),
-    ]) {
-      expect(ALL_GOALS).toContain(goal);
-    }
+  it("marks exactly the goals that fire without a reader doing anything", () => {
+    // The consequence of getting this wrong is quiet and total: an interactive
+    // event on mount un-bounces every visitor, and the bounce rate - which is
+    // the number `tabela:open` exists to explain - goes to zero.
+    const passive = ALL_GOALS.filter(isPassiveGoal).sort();
+    expect(passive).toEqual([
+      "experiment:assigned",
+      "tabela:no-results",
+      "tabela:open",
+    ]);
   });
 });
 
@@ -61,9 +72,165 @@ describe("searchPickKind", () => {
 
   it("files anything unexpected as a place rather than throwing", () => {
     // The type arrives over the wire; a document with a stray one should still
-    // land under some goal instead of breaking the search box.
+    // land under some kind instead of breaking the search box.
     expect(searchPickKind("topic")).toBe("place");
     expect(searchPickKind(undefined)).toBe("place");
     expect(searchPickKind("")).toBe("place");
+  });
+
+  it("only ever returns a kind the vocabulary knows", () => {
+    for (const type of ["person", "place", "region", "topic", "nonsense"]) {
+      expect(SEARCH_PICK_KINDS).toContain(searchPickKind(type));
+    }
+  });
+});
+
+describe("resultBucket", () => {
+  it("separates nothing from something", () => {
+    expect(resultBucket(0)).toBe("none");
+    expect(resultBucket(1)).toBe("1-4");
+  });
+
+  it("buckets rather than counts", () => {
+    // The query is not recorded, so this is the only thing that says whether a
+    // search worked - it has to read as a breakdown, not as a list.
+    const buckets = new Set(
+      Array.from({ length: 500 }, (_, i) => resultBucket(i)),
+    );
+    expect(buckets.size).toBeLessThanOrEqual(4);
+  });
+});
+
+describe("activeTabelaFilters", () => {
+  it("finds nothing in a bare or table-only query", () => {
+    expect(activeTabelaFilters({})).toEqual([]);
+    // Paging and sorting are the table's own state, not filters - a reader on
+    // page three of the unfiltered list arrived cold.
+    expect(
+      activeTabelaFilters({ page: "3", sortBy: "name", itemsPerPage: "50" }),
+    ).toEqual([]);
+  });
+
+  it("reads a filter however the router spelled it", () => {
+    expect(activeTabelaFilters({ party: "PiS" })).toEqual(["party"]);
+    expect(activeTabelaFilters({ party: ["PiS", "PO"] })).toEqual(["party"]);
+  });
+
+  it("treats an emptied filter as absent", () => {
+    // stringFilter leaves a cleared text filter as "", and a multi-select
+    // emptied down to nothing does the same. Counting those would report every
+    // reader who cleared a chip as still filtering.
+    expect(activeTabelaFilters({ teryt: "" })).toEqual([]);
+    expect(activeTabelaFilters({ party: [] })).toEqual([]);
+    expect(activeTabelaFilters({ party: [null] })).toEqual([]);
+  });
+
+  it("reports the spellings older links carry under the current name", () => {
+    expect(activeTabelaFilters({ parties: "PiS" })).toEqual(["party"]);
+    expect(activeTabelaFilters({ krs: "123" })).toEqual(["company"]);
+    // Both spellings of one filter are one filter.
+    expect(activeTabelaFilters({ krs: "123", place: "abc" })).toEqual([
+      "company",
+    ]);
+  });
+});
+
+describe("tabelaFiltersChanged", () => {
+  it("says nothing changed when nothing did", () => {
+    expect(tabelaFiltersChanged({ party: "PiS" }, { party: "PiS" })).toEqual(
+      [],
+    );
+    // A single value and a one-element list are the same filter; which one the
+    // router produces depends on how the url was written.
+    expect(tabelaFiltersChanged({ party: "PiS" }, { party: ["PiS"] })).toEqual(
+      [],
+    );
+  });
+
+  it("ignores paging and sorting", () => {
+    expect(
+      tabelaFiltersChanged({ page: "1" }, { page: "2", sortBy: "name" }),
+    ).toEqual([]);
+  });
+
+  it("counts setting, changing and clearing a filter", () => {
+    expect(tabelaFiltersChanged({}, { party: "PiS" })).toEqual(["party"]);
+    expect(tabelaFiltersChanged({ party: "PiS" }, { party: "PO" })).toEqual([
+      "party",
+    ]);
+    // Dropping the one chip is still using the party filter - which is why
+    // „Wyczyść” is reported by the page instead of through here.
+    expect(tabelaFiltersChanged({ party: "PiS" }, {})).toEqual(["party"]);
+  });
+
+  it("reports one filter when two parameters name it", () => {
+    // Picking an employer on a page reached by an old ?krs= link rewrites both
+    // parameters, and it is one thing the reader did.
+    expect(tabelaFiltersChanged({ krs: "123" }, { place: "abc" })).toEqual([
+      "company",
+    ]);
+  });
+
+  it("keeps the filters a property can tell apart separate", () => {
+    // On a Business plan there is no reason to group these: `filter` is a
+    // property, so eleven values cost exactly as much as three.
+    expect(
+      tabelaFiltersChanged(
+        {},
+        { currentlyEmployed: "selected", minEmploymentDate: "2023-01-01" },
+      ),
+    ).toEqual(["currently-employed", "employed-since"]);
+    expect(
+      tabelaFiltersChanged(
+        {},
+        { visibility: "private", hideVoted: "no_votes", minVotes: "3" },
+      ),
+    ).toEqual(["min-votes", "visibility", "voted"]);
+  });
+
+  it("reports each distinct filter of a multi-filter change", () => {
+    expect(tabelaFiltersChanged({}, { party: "PiS", teryt: "1261" })).toEqual([
+      "party",
+      "region",
+    ]);
+  });
+});
+
+describe("the tabela filter map", () => {
+  it("covers every filter the page clears", () => {
+    // The silent failure this catches: a filter is added to the bar, the reader
+    // uses it, and nothing is recorded because nobody remembered this map.
+    // `clearFilters` is the one list in the page that has to name every filter
+    // parameter, so it is the thing to compare against.
+    //
+    // From `process.cwd()` rather than `import.meta.url`: under the Nuxt test
+    // environment a module's url is served by vite over http, and
+    // `fileURLToPath` rejects it. Both candidates are tried because the suite
+    // is run from `frontend/` and occasionally from the repo root.
+    const candidates = [
+      resolve(process.cwd(), "app/pages/eksploruj/tabela.vue"),
+      resolve(process.cwd(), "frontend/app/pages/eksploruj/tabela.vue"),
+    ];
+    const found = candidates.find((candidate) => existsSync(candidate));
+    expect(found, `tabela.vue not found from ${process.cwd()}`).toBeTruthy();
+    const page = readFileSync(found!, "utf8");
+
+    const cleared = page
+      .split("const clearFilters = () => {")[1]!
+      .split("};")[0]!;
+    const keys = [...cleared.matchAll(/^\s{4}(\w+): undefined,$/gm)].map(
+      (match) => match[1]!,
+    );
+
+    // Sanity: if the shape of clearFilters changes enough that nothing parses,
+    // this test would pass by finding nothing to check.
+    expect(keys.length).toBeGreaterThan(8);
+
+    for (const key of keys) {
+      // `page` is the table's own state; clearFilters resets it along with the
+      // filters because a narrower list has fewer pages.
+      if (key === "page") continue;
+      expect(Object.keys(TABELA_FILTER_NAMES), key).toContain(key);
+    }
   });
 });

--- a/frontend/tests/shared/experiments.test.ts
+++ b/frontend/tests/shared/experiments.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   EXPERIMENTS,
-  EXPERIMENT_GOALS,
   HOME_DEFAULT_EXPERIMENT,
+  armPropertyName,
   assignArm,
-  experimentGoal,
   hashToUnitInterval,
   type Experiment,
 } from "../../shared/experiments";
@@ -118,13 +117,15 @@ describe("the registry", () => {
     }
   });
 
-  it("registers a marker goal for every arm, including dormant ones", () => {
-    for (const experiment of Object.values(EXPERIMENTS)) {
-      for (const arm of experiment.arms) {
-        expect(EXPERIMENT_GOALS).toContain(
-          experimentGoal(experiment.id, arm.id),
-        );
-      }
+  it("gives each experiment its own property name", () => {
+    // One `arm` property shared by every experiment would mean two running at
+    // once overwrite each other on the same event, and neither is readable.
+    const names = Object.values(EXPERIMENTS).map((experiment) =>
+      armPropertyName(experiment.id),
+    );
+    expect(new Set(names).size).toBe(names.length);
+    for (const name of names) {
+      expect(name).toMatch(/^arm:[a-z0-9-]+$/);
     }
   });
 

--- a/frontend/tests/shared/experiments.test.ts
+++ b/frontend/tests/shared/experiments.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  EXPERIMENTS,
+  EXPERIMENT_GOALS,
+  HOME_DEFAULT_EXPERIMENT,
+  assignArm,
+  experimentGoal,
+  hashToUnitInterval,
+  type Experiment,
+} from "../../shared/experiments";
+
+const evenSplit: Experiment<"a" | "b" | "c"> = {
+  id: "test",
+  question: "does the split split?",
+  arms: [
+    { id: "a", weight: 1, description: "a" },
+    { id: "b", weight: 1, description: "b" },
+    { id: "c", weight: 1, description: "c" },
+  ],
+};
+
+const ids = Array.from({ length: 6000 }, (_, i) => `session-${i}`);
+
+describe("hashToUnitInterval", () => {
+  it("stays inside [0, 1)", () => {
+    for (const id of ids) {
+      const value = hashToUnitInterval(id);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+
+  it("is stable for the same input", () => {
+    expect(hashToUnitInterval("session-1")).toBe(
+      hashToUnitInterval("session-1"),
+    );
+  });
+
+  it("spreads across the interval", () => {
+    // The failure this guards against is the sign bit: without `>>> 0` half of
+    // the inputs come out negative, every one of them lands in the first arm,
+    // and the experiment silently stops being an experiment.
+    const halves = ids.filter((id) => hashToUnitInterval(id) < 0.5).length;
+    expect(halves / ids.length).toBeGreaterThan(0.4);
+    expect(halves / ids.length).toBeLessThan(0.6);
+  });
+});
+
+describe("assignArm", () => {
+  it("is stable for the same session", () => {
+    for (const id of ids.slice(0, 50)) {
+      expect(assignArm(evenSplit, id)).toBe(assignArm(evenSplit, id));
+    }
+  });
+
+  it("honours the weights", () => {
+    const counts = { a: 0, b: 0, c: 0 };
+    for (const id of ids) counts[assignArm(evenSplit, id)]++;
+    for (const arm of ["a", "b", "c"] as const) {
+      expect(counts[arm] / ids.length, arm).toBeGreaterThan(0.28);
+      expect(counts[arm] / ids.length, arm).toBeLessThan(0.39);
+    }
+  });
+
+  it("never assigns a zero-weight arm", () => {
+    const oneLive: Experiment<"a" | "b"> = {
+      id: "test",
+      question: "",
+      arms: [
+        { id: "a", weight: 1, description: "a" },
+        { id: "b", weight: 0, description: "b" },
+      ],
+    };
+    for (const id of ids) expect(assignArm(oneLive, id)).toBe("a");
+  });
+
+  it("falls back to the control when every weight is zero", () => {
+    const dead: Experiment<"a" | "b"> = {
+      id: "test",
+      question: "",
+      arms: [
+        { id: "a", weight: 0, description: "a" },
+        { id: "b", weight: 0, description: "b" },
+      ],
+    };
+    expect(assignArm(dead, "session-1")).toBe("a");
+  });
+
+  it("assigns independently per experiment", () => {
+    // The session id is one value for the whole site, so two experiments would
+    // put the same readers in the same-numbered arm if the experiment id were
+    // not hashed in with it - which quietly turns two experiments into one.
+    const other: Experiment<"a" | "b" | "c"> = { ...evenSplit, id: "other" };
+    const differing = ids.filter(
+      (id) => assignArm(evenSplit, id) !== assignArm(other, id),
+    ).length;
+    expect(differing / ids.length).toBeGreaterThan(0.5);
+  });
+});
+
+describe("the registry", () => {
+  it("ships dormant", () => {
+    // The guard on accidentally deploying a live split. Activating an
+    // experiment means changing this test in the same commit, which is where
+    // the decision gets reviewed.
+    for (const experiment of Object.values(EXPERIMENTS)) {
+      const live = experiment.arms.filter((arm) => arm.weight > 0);
+      expect(
+        live.map((arm) => arm.id),
+        experiment.id,
+      ).toEqual([experiment.arms[0]!.id]);
+    }
+  });
+
+  it("keys each experiment by its own id", () => {
+    for (const [key, experiment] of Object.entries(EXPERIMENTS)) {
+      expect(experiment.id).toBe(key);
+    }
+  });
+
+  it("registers a marker goal for every arm, including dormant ones", () => {
+    for (const experiment of Object.values(EXPERIMENTS)) {
+      for (const arm of experiment.arms) {
+        expect(EXPERIMENT_GOALS).toContain(
+          experimentGoal(experiment.id, arm.id),
+        );
+      }
+    }
+  });
+
+  it("keeps the home arms the panels the explorer can render", () => {
+    // `gry` is declared for the games hub on another branch, so this is the
+    // reminder that HomeExplorer only implements two of the three.
+    expect(HOME_DEFAULT_EXPERIMENT.arms.map((arm) => arm.id)).toEqual([
+      "map",
+      "parties",
+      "gry",
+    ]);
+  });
+});


### PR DESCRIPTION
The site has only ever recorded pageviews. Nothing said what was typed into the search, whether it answered, or whether a single reader has clicked the volunteer form that has been the main ask since launch - it is an outbound Google Forms link and `autoOutboundTracking` was off, so the answer was literally unavailable.

shared/analytics.ts is the closed vocabulary of custom goals, with the descriptions doubling as the setup notes: a name Plausible has not been told about is recorded and then invisible, so the set has to be enumerable to be registered at all. It is also why dimensions are in the goal names rather than in properties - the account is on a Growth plan, where custom properties are accepted by the API and dropped. Properties are still sent where they say something, so a later upgrade needs no second pass over the call sites.

The home page gets four of them. 73% of all entrances land on `/`, and the explorer there already has a Mapa/Partie tab strip, so how many readers ever open the treemap - and whether either panel sends anyone into the data - is observable at full sample size without splitting traffic. That is the cheap half of "which panel should we open on", and it should be read before the expensive half.

shared/experiments.ts is the expensive half, and it ships dormant: every arm but the control is at zero weight, so the page does exactly what it did before. Registering it now means the marker goals exist before they are needed, and a `gry` arm is declared for the games hub on the other branch so the eventual three-way split is a weight change rather than a redesign. Two things are written down there rather than discovered later: the traffic is spike-driven at ~18 visitors a day outside a press spike, which is six per arm across three arms; and `routeRules` caches `/` with `swr`, so an arm cannot be chosen server-side until that cache either goes or learns to vary, and until then a non-control arm would paint control for a frame - an asymmetry between the arms in the exact comparison being run.

Also: the tracker's event endpoint now goes through our own origin. The script itself was already first-party - @nuxtjs/plausible bundles the tracker rather than loading a remote one - so the endpoint was the only thing left for a blocklist to match, on an audience that is 69% mobile and Polish. Every number the dashboard has shown so far is a floor.

OmniSearch's `logEventKey` is gone. It carried content_id/content_type for an analytics call that no longer existed, so every result was describing itself to nobody; the field it is replaced by is the one the pick goals read.