### PR TITLE
Count the feedback widget, count errors, and stop counting a dormant experiment

### DIFF
--- a/frontend/app/components/feedback/Dialog.vue
+++ b/frontend/app/components/feedback/Dialog.vue
@@ -118,6 +118,7 @@ import {
   submitFeedback,
 } from "~/composables/feedback";
 import { useAuthState } from "~/composables/auth";
+import { trackGoal } from "~/composables/analytics";
 import type { FeedbackContext, FeedbackKind } from "~~/shared/model";
 
 const open = defineModel<boolean>({ required: true });
@@ -177,6 +178,11 @@ const submit = async () => {
       },
       { attribute: signed.value },
     );
+
+    // After the call, so a report that never reached us is not counted as one
+    // that did. `kind` is the chip; the message is somebody's words and stays
+    // out of analytics entirely.
+    trackGoal("feedback:sent", { kind: kind.value });
 
     sent.value = true;
     message.value = "";

--- a/frontend/app/components/feedback/Launcher.vue
+++ b/frontend/app/components/feedback/Launcher.vue
@@ -11,7 +11,7 @@
       class="feedback-fab"
       :size="mdAndUp ? 'default' : 'small'"
       aria-label="Zgłoś błąd lub pomysł"
-      @click="open = true"
+      @click="openDialog"
     >
       <span v-if="mdAndUp">Zgłoś</span>
     </v-btn>
@@ -24,9 +24,18 @@
 import { mdiMessageAlertOutline } from "@mdi/js";
 import { ref } from "vue";
 import { useDisplay } from "vuetify";
+import { trackGoal } from "~/composables/analytics";
 
 const { mdAndUp } = useDisplay();
 const open = ref(false);
+
+/** Counted on the button rather than on the dialog's `open` model, which the
+ * close button and the auto-close after a send write to as well - one reader
+ * opening the form once would otherwise be three events. */
+function openDialog() {
+  trackGoal("feedback:opened");
+  open.value = true;
+}
 </script>
 
 <style scoped>

--- a/frontend/app/components/home/Explorer.vue
+++ b/frontend/app/components/home/Explorer.vue
@@ -103,8 +103,8 @@ const region = ref<Powiat | undefined>(undefined);
 
 /** Dormant: every reader is on the `map` arm until the weights in
  * `shared/experiments.ts` move, so this resolves to what the page already did.
- * What it does today is record the arm, which is what makes the split readable
- * on a Growth plan when it is switched on. */
+ * With every weight on `map` the assignment does not even run - see
+ * `isExperimentLive` - so today this is exactly what the page did before. */
 const arm = useExperimentArm(HOME_DEFAULT_EXPERIMENT);
 watch(arm, (value) => {
   if (isPanel(value)) tab.value = value;

--- a/frontend/app/composables/experiments.ts
+++ b/frontend/app/composables/experiments.ts
@@ -8,6 +8,7 @@
 import {
   armPropertyName,
   assignArm,
+  isExperimentLive,
   type Experiment,
 } from "~~/shared/experiments";
 import { setGlobalProp, trackGoal } from "~/composables/analytics";
@@ -90,6 +91,12 @@ export function useExperimentArm<Id extends string>(
   const arm = ref(control) as Ref<Id>;
 
   onMounted(() => {
+    // Nothing to record while the split is dormant: `assignArm` would return
+    // the control arm every time, and reporting that costs an event per
+    // session plus a constant property on everything the reader does next.
+    // The ref is already on control, so this returns the same panel.
+    if (!isExperimentLive(experiment)) return;
+
     const id = sessionId();
     if (!id) return;
 

--- a/frontend/app/error.vue
+++ b/frontend/app/error.vue
@@ -48,8 +48,9 @@
 
 <script lang="ts" setup>
 import { mdiAlertCircleOutline, mdiHome, mdiMapSearchOutline } from "@mdi/js";
-import { computed } from "vue";
+import { computed, onMounted } from "vue";
 import type { NuxtError } from "#app";
+import { trackGoal } from "~/composables/analytics";
 
 const props = defineProps<{ error: NuxtError }>();
 
@@ -77,6 +78,14 @@ const devMessage = computed(() =>
 useSeoMeta({
   title: title.value,
   robots: "noindex, nofollow",
+});
+
+// On mount rather than at setup, because this renders on the server too and
+// the tracker is client-only. The url the reader asked for is the event's own
+// url, so the goal needs no property for it - only the status, which is what
+// separates a link to a page that no longer exists from something we broke.
+onMounted(() => {
+  trackGoal("error:shown", { status: String(statusCode.value ?? "unknown") });
 });
 
 // clearError tears down the error state before navigating; a plain

--- a/frontend/shared/analytics.ts
+++ b/frontend/shared/analytics.ts
@@ -174,6 +174,39 @@ export const GOALS = {
     props: [],
   },
 
+  // --- Feedback ----------------------------------------------------------
+  // The launcher sits in the default layout, so it is on every page, and what
+  // it collects is the site's own correction loop - somebody works through the
+  // queue daily. Nothing counted it, which left two very different situations
+  // looking identical from the dashboard: a widget nobody can find, and a
+  // widget everybody finds and nobody has anything to say to.
+  "feedback:opened": {
+    description:
+      "Reader opened the „Zgłoś” dialog. Against `feedback:sent` this is the form's completion rate; against the page's visitors it is whether the button is findable at all - it is an icon with no label below 960px. The page it was opened from is the event's own url.",
+    props: [],
+  },
+  "feedback:sent": {
+    description:
+      "Reader submitted a report. `kind` is the chip they picked, so the split between a broken page, wrong data and an idea is readable without opening the queue - and a spike in one kind after a deploy names what broke.",
+    props: ["kind"],
+  },
+
+  // --- Errors ------------------------------------------------------------
+  // A 404 here is rarely a typo: entity urls end in a Firestore document id
+  // and are minted by us, shared, and linked from elsewhere. When the seo
+  // module was lowercasing canonicals, every person page advertised a url that
+  // rendered „Nie ma takiej strony” - visible in Search Console eventually,
+  // and invisible to the analytics the whole time.
+  "error:shown": {
+    description:
+      "The error page rendered. Filter the dashboard to this goal and read the page list: a url that 404s repeatedly is a link somebody is actually following - a stale canonical, a shared address, a page that moved. `status` separates a missing page from a broken one.",
+    props: ["status"],
+    // Fires because a page rendered. Nobody navigates to an error on purpose,
+    // and counting it as engagement would mean the worst outcome on the site
+    // improves the bounce rate.
+    passive: true,
+  },
+
   // --- Experiments -------------------------------------------------------
   "experiment:assigned": {
     description:

--- a/frontend/shared/experiments.ts
+++ b/frontend/shared/experiments.ts
@@ -123,6 +123,21 @@ export const EXPERIMENTS = {
 
 export type ExperimentId = keyof typeof EXPERIMENTS;
 
+/** Whether `experiment` actually splits anybody.
+ *
+ * One weighted arm is not an experiment: every reader is handed the same thing,
+ * so an assignment answers no question and is not free. It costs an
+ * `experiment:assigned` event per session - on `/`, which is 73% of the site's
+ * entrances - and pins the arm as a property on every event after it, a column
+ * with one value forever. Both are billed, and a spike day is 700 of them.
+ *
+ * The registry ships dormant by design (above), so this is the state it is in
+ * today and the one it returns to between splits; the machinery stays wired
+ * either way, and moving a weight is still all it takes to start one. */
+export function isExperimentLive(experiment: Experiment): boolean {
+  return experiment.arms.filter((arm) => arm.weight > 0).length >= 2;
+}
+
 /** The property name an experiment's arm is reported under.
  *
  * Keyed by experiment rather than a single `arm` property, so two experiments

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,21 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "licznik-zgloszen-i-bledow",
+    title: "Liczymy kliknięcia w „Zgłoś” i trafienia na nieistniejącą stronę",
+    description:
+      "Nie było wiadomo ani czy ktokolwiek znajduje przycisk „Zgłoś” w rogu " +
+      "ekranu, ani jak często czytelnik trafia na „Nie ma takiej strony” - a " +
+      "adresy stron osób bywały psute przez nas i nikt tego nie widział. Oba " +
+      "zdarzenia są teraz liczone zbiorczo, bez ciasteczek i bez treści " +
+      "zgłoszenia. Nic się nie zmienia w tym, co widać.",
+    steps: [
+      "Kliknij „Zgłoś” w prawym dolnym rogu i wyślij zgłoszenie - dialog działa jak dotąd.",
+      "Wejdź na adres, którego nie ma (np. /nie-ma-takiej-strony) - strona błędu wygląda tak samo.",
+    ],
+    area: "public",
+  },
+  {
     id: "fakt-do-notatki",
     title: "Wydobyty fakt można przenieść do własnej notatki",
     description:

--- a/frontend/tests/shared/analytics.test.ts
+++ b/frontend/tests/shared/analytics.test.ts
@@ -56,6 +56,7 @@ describe("the goal vocabulary", () => {
     // the number `tabela:open` exists to explain - goes to zero.
     const passive = ALL_GOALS.filter(isPassiveGoal).sort();
     expect(passive).toEqual([
+      "error:shown",
       "experiment:assigned",
       "tabela:no-results",
       "tabela:open",

--- a/frontend/tests/shared/experiments.test.ts
+++ b/frontend/tests/shared/experiments.test.ts
@@ -5,6 +5,7 @@ import {
   armPropertyName,
   assignArm,
   hashToUnitInterval,
+  isExperimentLive,
   type Experiment,
 } from "../../shared/experiments";
 
@@ -94,6 +95,43 @@ describe("assignArm", () => {
       (id) => assignArm(evenSplit, id) !== assignArm(other, id),
     ).length;
     expect(differing / ids.length).toBeGreaterThan(0.5);
+  });
+});
+
+describe("isExperimentLive", () => {
+  it("calls one weighted arm dormant", () => {
+    // The whole point of the guard: a split with a single arm is what the
+    // registry ships, and assigning readers to it costs an event each and a
+    // constant property on everything they do afterwards.
+    expect(isExperimentLive(HOME_DEFAULT_EXPERIMENT)).toBe(false);
+  });
+
+  it("calls two weighted arms live", () => {
+    expect(
+      isExperimentLive({
+        id: "two",
+        question: "?",
+        arms: [
+          { id: "a", weight: 1, description: "a" },
+          { id: "b", weight: 1, description: "b" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores arms that are declared but off", () => {
+    // `gry` is declared with no weight, and a declaration is not a split.
+    expect(
+      isExperimentLive({
+        id: "declared",
+        question: "?",
+        arms: [
+          { id: "a", weight: 1, description: "a" },
+          { id: "b", weight: 0, description: "b" },
+          { id: "c", weight: 0, description: "c" },
+        ],
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
…experiment

The instrumentation added last week covers the home explorer, search, the call-to-action links and /eksploruj/tabela. Three things it left out, and one it pays for and cannot read:

- The „Zgłoś” launcher is in the default layout, on every page, and is the site's own correction loop, but nothing counted whether it is ever found. `feedback:opened` and `feedback:sent` make the form's completion rate readable, and `kind` splits a broken page from wrong data from an idea.
- The error page was invisible. Entity urls end in a Firestore document id and are minted, shared and linked by us - when the seo module was lowercasing canonicals, every person page advertised a url that 404s, and the analytics had no way to say so. `error:shown` carries the status; the url is the event's own.
- Every experiment is dormant, all the weight on one arm, and the assignment still ran: an `experiment:assigned` per session on `/` - 73% of entrances - and `arm:home-default=map` riding on every event after it as a column with one value. `isExperimentLive` skips both until a second arm has weight.

Nothing here changes what a reader sees.