### PR TITLE
Give every bar chart the same, tighter column

### DIFF
--- a/frontend/app/components/stats/ActivityTimeline.vue
+++ b/frontend/app/components/stats/ActivityTimeline.vue
@@ -86,20 +86,25 @@ const props = defineProps<{
 /** Past this many columns a value on every cap is noise rather than a label. */
 const DIRECT_LABEL_LIMIT = 14;
 
-/** How much of a day's slot the column fills, and how wide it may ever get.
+/** How much of a day's slot the column fills.
  *
- * Both are wider than `barPlotOptions` gives a bar by default (60% of the slot,
- * 24px), and deliberately. The shared numbers are the mark spec for a chart of a
- * handful of named categories, where a thin mark with air around it reads as one
- * thing per band. Here the bands are consecutive days: the axis is a stretch of
- * time and the columns are supposed to read as a series across it, which at 30
- * days and full width they stopped doing - a 24px cap against a 37px slot puts a
- * third of the width between neighbours, and the eye reads scattered pins rather
- * than a shape. 90% leaves the 2px surface gap that separates them and nothing
- * more; the cap is what keeps a 7-day window, where a slot is 157px, from
- * drawing slabs. */
+ * Wider than the 85% `barPlotOptions` gives a bar, and deliberately. The shared
+ * number is the mark spec for a chart of a handful of named categories, where a
+ * little air around each mark reads as one thing per band. Here the bands are
+ * consecutive days: the axis is a stretch of time and the columns are supposed
+ * to read as a series across it, which at 30 days and full width they stopped
+ * doing - the eye read scattered pins rather than a shape. 90% leaves the 2px
+ * surface gap that separates them and nothing more.
+ *
+ * The price is the 7-day window, where a full-width slot is ~157px and the
+ * columns are drawn as slabs. A `maxBarThickness: 48` was written here against
+ * exactly that, and never did anything: it is Chart.js's option, not one
+ * ApexCharts reads, and this library has no absolute cap at all. Capping it for
+ * real means a px `columnWidth` (ApexCharts takes one when the string has no
+ * `%`), which then has to come back to a percentage below `sm` or seven 48px
+ * columns overlap on a phone. Left as it is: the slabs are legible, and the
+ * range this chart is opened on is 30 days. */
 const COLUMN_WIDTH = "90%";
-const MAX_COLUMN_PX = 48;
 
 /** The surface-coloured line between two stacked segments of one day.
  *
@@ -142,7 +147,6 @@ const options = computed(() => {
       bar: {
         ...barPlotOptions().plotOptions.bar,
         columnWidth: COLUMN_WIDTH,
-        maxBarThickness: MAX_COLUMN_PX,
         // The running total on the cap, but only while the columns are far
         // enough apart for it to be read.
         dataLabels: {

--- a/frontend/app/components/stats/PublicationCandidates.vue
+++ b/frontend/app/components/stats/PublicationCandidates.vue
@@ -144,7 +144,6 @@ const options = computed(() => {
     plotOptions: {
       bar: {
         ...barPlotOptions().plotOptions.bar,
-        columnWidth: "62%",
         // Five columns, so the running total fits on every cap.
         dataLabels: {
           total: {

--- a/frontend/app/components/stats/VoteDistribution.vue
+++ b/frontend/app/components/stats/VoteDistribution.vue
@@ -104,7 +104,6 @@ const options = computed(() => {
       bar: {
         ...barPlotOptions().plotOptions.bar,
         distributed: true,
-        columnWidth: "72%",
         // Above the cap, not buried in the fill: the value has to stay legible
         // on a short bar and on a tall one alike.
         dataLabels: { position: "top" },

--- a/frontend/app/utils/chartTheme.ts
+++ b/frontend/app/utils/chartTheme.ts
@@ -122,8 +122,26 @@ export function baseChartOptions() {
   };
 }
 
-/** Bar geometry the method fixes: capped thickness, a 4px rounded data end, and
- * a 2px gap in the surface colour doing the separating instead of a border. */
+/** How much of its slot a column fills - the whole of the thickness rule, since
+ * a percentage is the only handle ApexCharts gives.
+ *
+ * There was a `maxBarThickness: 24` next to it for a while, the cap the method
+ * asks for. ApexCharts has no such option - it is Chart.js's - so it was never
+ * read and the percentage was doing the work by itself, at 60%: two fifths of
+ * every slot painted as air, which on the five-bucket and ten-step charts of
+ * /eksploruj/statystyki put more gap between neighbours than a separation needs.
+ * 85% leaves the 2px surface gap that separates them and a little more.
+ *
+ * Nothing caps a bar drawn this way, so the container does it instead: every
+ * page carrying one of these is 1200px wide at most (the layout's default -
+ * `fullWidth` pages have no bar chart), which across two columns is a plot of
+ * about 465px, so five categories are ~79px of bar. Fewer categories than that,
+ * or a full-width page, and the columns are slabs - either wants its own
+ * narrower percentage. */
+const COLUMN_FILL = "85%";
+
+/** Bar geometry the method fixes: a 4px rounded data end, and a 2px gap in the
+ * surface colour doing the separating instead of a border. */
 export function barPlotOptions(options: { horizontal?: boolean } = {}) {
   return {
     plotOptions: {
@@ -132,8 +150,7 @@ export function barPlotOptions(options: { horizontal?: boolean } = {}) {
         borderRadius: 4,
         borderRadiusApplication: "end" as const,
         borderRadiusWhenStacked: "last" as const,
-        columnWidth: "60%",
-        maxBarThickness: 24,
+        columnWidth: COLUMN_FILL,
       },
     },
     stroke: { show: true, width: 2, colors: [ink.surface] },

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,21 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "statystyki-szersze-slupki-ocen",
+    title: "Szersze słupki na wykresach ocen",
+    description:
+      "Wykresy „Oddane oceny” i „Rozkład ocen” na dole /eksploruj/statystyki " +
+      "zostawiały między słupkami prawie tyle pustego miejsca, co same " +
+      "słupki. Mają teraz taki odstęp jak wykres aktywności nad nimi - " +
+      "wartość jest wspólna dla wszystkich wykresów słupkowych.",
+    steps: [
+      "Wejdź na /eksploruj/statystyki i zjedź na sam dół - na obu wykresach słupki mają niemal stykać się bokami.",
+      "Zwęź okno do szerokości telefonu i sprawdź, że liczby nad słupkami nadal się mieszczą.",
+    ],
+    link: "/eksploruj/statystyki",
+    area: "public",
+  },
+  {
     id: "fakt-do-notatki",
     title: "Wydobyty fakt można przenieść do własnej notatki",
     description:


### PR DESCRIPTION
The gap between the columns of „Rozkład ocen: Dobre znalezisko" was about two thirds of a column wide, which is what „Co się działo w bazie" looked like before it went to 90% - the same complaint, a screen further down.

`barPlotOptions` said it capped a bar at 24px. It does not: `maxBarThickness` is Chart.js's option and ApexCharts reads nothing of the sort, so the cap was decoration and `columnWidth` was setting the geometry by itself - 60% shared, and 62% and 72% where the two vote charts narrowed it further. Five buckets in the ~465px plot a half-width card gives on a 1200px page is a 58px column with 35px of white either side of it.

So: one shared 85%, the dead option deleted from the theme and from the timeline's `MAX_COLUMN_PX`, and both overrides dropped. Nothing caps a column now because nothing ever did; what does it is the page, which is 1200px at most, and the comment says so - along with what a chart of fewer than five categories would need instead.

The timeline keeps its 90%. Thirty columns read as a shape rather than as scattered pins only that tight, and it is the same 5% either way at five.