### PR TITLE
Ask before loading more of the home feed

### DIFF
--- a/frontend/app/components/home/EventFeed.vue
+++ b/frontend/app/components/home/EventFeed.vue
@@ -4,18 +4,19 @@
     subtitle="Ostatnie stanowiska i okrągłe staże, od najświeższego. Kliknij kafelek, żeby zobaczyć stronę tej osoby."
   />
 
-  <!-- `mode` is not a constant: the feed loads a couple of pages on its own and
-       then asks. An unbounded intersect feed makes the page infinite, and
-       everything under it - the footer, which is where the contact address and
-       the source links live - is pushed further away every time the reader
-       scrolls towards it, so it can never be reached at all. -->
+  <!-- Always a button, never an intersect sentinel. An auto-loading feed makes
+       the page infinite, and everything under it - the footer, which is where
+       the contact address and the source links live - is pushed further away
+       every time the reader scrolls towards it, so it can never be reached at
+       all. Asking from the first page is also the cheaper default: a reader who
+       scrolls past the first screen on their way somewhere else costs nothing. -->
   <v-infinite-scroll
     v-if="items.length > 0"
     class="event-feed"
     data-testid="home-event-feed"
     empty-text="To już wszystko, co wiemy."
     load-more-text="Pokaż więcej"
-    :mode="mode"
+    mode="manual"
     @load="loadMore"
   >
     <div class="event-feed__grid">
@@ -212,12 +213,6 @@ const items = computed(() =>
 
 type LoadOptions = { done: (status: "ok" | "empty" | "error") => void };
 
-/** How many pages the feed fetches by itself before it starts asking.
- *
- * Two, so that scrolling past the first screen still feels like a feed, and the
- * page still ends. */
-const AUTO_PAGES = 2;
-
 /** Requests one click is allowed to make before it gives up and returns.
  *
  * The endpoint stops scanning at a fixed budget and answers short rather than
@@ -227,24 +222,14 @@ const AUTO_PAGES = 2;
  * animation frame. */
 const MAX_REQUESTS_PER_LOAD = 3;
 
-const autoLoaded = ref(0);
-
-/** Automatic while the count is under the budget, a button after it. Reading
- * it every render is what lets it change: Vuetify checks `mode` when it decides
- * whether to draw the sentinel and again before it chains the next load. */
-const mode = computed(() =>
-  autoLoaded.value < AUTO_PAGES ? "intersect" : "manual",
-);
-
-/** The next page of employments, once the reader has scrolled far enough to
- * want one.
+/** The next page of employments, once the reader has asked for one.
  *
  * Only the employments page. The milestones came whole and are already placed;
  * scrolling reaches further back in time, and there is nothing behind the
  * window they were computed over.
  *
  * Plain `$fetch` rather than `authFetch`, which is a `useFetch` and so cannot
- * be called for a page somebody asked for by scrolling. Nothing is lost by it:
+ * be called for a page somebody asked for with a click. Nothing is lost by it:
  * the endpoint answers with published employments whoever asks, and `latest`
  * would only skip the response cache.
  */
@@ -253,8 +238,6 @@ async function loadMore({ done }: LoadOptions) {
     done("empty");
     return;
   }
-
-  autoLoaded.value += 1;
 
   try {
     // A page can come back empty and still carry a cursor - the endpoint stops

--- a/frontend/shared/qa.ts
+++ b/frontend/shared/qa.ts
@@ -48,6 +48,21 @@ export const qaAreaConfig: Record<QaArea, { title: string; color: string }> = {
  * before the list could be read at all. */
 export const QA_ITEMS: QaItem[] = [
   {
+    id: "pokaz-wiecej-od-pierwszej-strony",
+    title: "Feed na stronie głównej dokłada wpisy dopiero po kliknięciu",
+    description:
+      "„Co nowego” dociągał dwie kolejne strony samo z siebie, zanim pokazał " +
+      "przycisk. Teraz „Pokaż więcej” jest od razu i nic nie ładuje się " +
+      "automatycznie.",
+    steps: [
+      "Wejdź na stronę główną i przewiń do końca sekcji „Co nowego”.",
+      "Pod kaflami zobacz przycisk „Pokaż więcej” - lista nie rośnie sama.",
+      "Kliknij go: dokładają się kolejne kafle, a przycisk zostaje.",
+    ],
+    link: "/",
+    area: "public",
+  },
+  {
     id: "brakujaca-strona-zwraca-404",
     title: "Nieistniejąca strona zwraca 404",
     description:

--- a/frontend/tests/components/home/EventFeed.test.ts
+++ b/frontend/tests/components/home/EventFeed.test.ts
@@ -213,27 +213,25 @@ describe("HomeEventFeed", () => {
     expect(asked).toEqual([null, "c1", "c2", "c3"]);
   });
 
-  it("stops loading by itself after two pages, and offers a button instead", async () => {
+  it("never loads a page by itself - it is a button from the first one", async () => {
     // Otherwise the page has no bottom: every scroll towards the footer adds
     // another screen of cards above it, so the footer is never reached.
     pages.first = { employments: [employment("a")], nextCursor: "c1" };
     pages.c1 = { employments: [employment("b")], nextCursor: "c2" };
     pages.c2 = { employments: [employment("c")], nextCursor: "c3" };
-    pages.c3 = { employments: [employment("d")], nextCursor: "c4" };
 
     const wrapper = await mountFeed();
     const scroll = wrapper.findComponent({ name: "VInfiniteScroll" });
-    expect(scroll.props("mode")).toBe("intersect");
-
-    await scrollToEnd(wrapper);
-    expect(scroll.props("mode")).toBe("intersect");
-
-    await scrollToEnd(wrapper);
     expect(scroll.props("mode")).toBe("manual");
 
-    // Still loads on request - it is a button now, not a stop.
+    // A button, not a stop: it still loads, and it stays a button after.
     expect(await scrollToEnd(wrapper)).toBe("ok");
-    expect(wrapper.text()).toContain("Osoba d");
+    expect(wrapper.text()).toContain("Osoba b");
+    expect(scroll.props("mode")).toBe("manual");
+
+    expect(await scrollToEnd(wrapper)).toBe("ok");
+    expect(wrapper.text()).toContain("Osoba c");
+    expect(scroll.props("mode")).toBe("manual");
   });
 
   it("says so when there is nothing to show at all", async () => {

--- a/frontend/tests/e2e/home_event_feed.spec.ts
+++ b/frontend/tests/e2e/home_event_feed.spec.ts
@@ -111,16 +111,14 @@ test.afterAll(async () => {
   await batch.commit();
 });
 
-/** Scrolls until `testId` is in the document, which is what the sentinel at
- * the end of the feed reacts to.
+/** Clicks „Pokaż więcej” until `testId` is in the document.
  *
- * The last card already rendered is what gets scrolled to rather than a blind
- * wheel from wherever the mouse happens to be: the sentinel sits directly
- * below it, so this puts it in view whatever the feed's height has grown to.
- *
- * The feed only loads two pages by itself and then puts a button there, so that
- * the page has a bottom and the footer can be reached. Past that, scrolling is
- * not enough and this has to click.
+ * The feed never loads a page by itself - it is a button from the first one, so
+ * that the page has a bottom and the footer can be reached - so scrolling alone
+ * never gets there. The scroll is still here to bring the button into view: the
+ * last card already rendered is what gets scrolled to rather than a blind wheel
+ * from wherever the mouse happens to be, since the button sits directly below
+ * it whatever the feed's height has grown to.
  */
 async function loadUntil(page: Page, testId: string) {
   const loadMore = page.getByRole("button", {


### PR DESCRIPTION
The feed loaded two further pages on its own before it put a button there. Now "Pokaż więcej" is the only way past the first page: mode is manual from the first render, so nothing loads without a click.